### PR TITLE
Sql creation scripts for the geofence integration

### DIFF
--- a/doc/sql/geofence-geostoreUsersIntegration_scripts/postgres/001_setup_geostore_geofence_db.sql
+++ b/doc/sql/geofence-geostoreUsersIntegration_scripts/postgres/001_setup_geostore_geofence_db.sql
@@ -1,0 +1,48 @@
+-- ---------------------------
+-- CREATE geostore SCHEMAs  
+-- ---------------------------
+
+CREATE user geostore LOGIN PASSWORD 'geostore' NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE;
+
+CREATE SCHEMA geostore;
+
+GRANT USAGE ON SCHEMA geostore TO geostore ;
+GRANT ALL ON SCHEMA geostore TO geostore ;
+
+CREATE user geostore_test LOGIN PASSWORD 'geostore_test' NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE;
+
+CREATE SCHEMA geostore_test;
+
+GRANT USAGE ON SCHEMA geostore_test TO geostore_test;
+GRANT ALL ON SCHEMA geostore_test TO geostore_test;
+
+-- ---------------------------
+-- CREATE geofence SCHEMAs 
+-- ---------------------------
+
+CREATE SCHEMA geofence;
+
+GRANT USAGE ON SCHEMA geofence TO geostore;
+GRANT ALL ON SCHEMA geofence TO geostore;
+
+GRANT SELECT ON public.spatial_ref_sys to geostore;
+GRANT SELECT,INSERT,DELETE ON public.geometry_columns to geostore;
+
+
+-- CREATE SCHEMA geofence_test
+
+CREATE SCHEMA geofence_test;
+
+GRANT USAGE ON SCHEMA geofence_test TO geostore_test;
+GRANT ALL ON SCHEMA geofence_test TO geostore_test;
+
+GRANT SELECT ON public.spatial_ref_sys to geostore_test;
+GRANT SELECT,INSERT,DELETE ON public.geometry_columns to geostore_test;
+
+
+-- -------------------------------------
+-- -------- Set SearchPaths ------------
+-- -------------------------------------
+
+alter user geostore set search_path to geostore, geofence, public;
+alter user geostore_test set search_path to geostore_test, geofence_test, public;

--- a/doc/sql/geofence-geostoreUsersIntegration_scripts/postgres/002_create_schema_geostore_postgres.sql
+++ b/doc/sql/geofence-geostoreUsersIntegration_scripts/postgres/002_create_schema_geostore_postgres.sql
@@ -1,0 +1,241 @@
+SET search_path TO geostore;
+
+    create table gs_attribute (
+        id int8 not null,
+        attribute_date timestamp,
+        name varchar(255) not null,
+        attribute_number float8,
+        attribute_text varchar(255),
+        attribute_type varchar(255) not null,
+        resource_id int8 not null,
+        primary key (id),
+        unique (name, resource_id)
+    );
+    ALTER TABLE gs_attribute
+          OWNER TO geostore;
+
+    create table gs_category (
+        id int8 not null,
+        name varchar(255) not null,
+        primary key (id),
+        unique (name)
+    );
+    ALTER TABLE gs_category
+          OWNER TO geostore;
+
+    create table gs_resource (
+        id int8 not null,
+        creation timestamp not null,
+        description varchar(255),
+        lastUpdate timestamp,
+        metadata varchar(30000),
+        name varchar(255) not null,
+        category_id int8 not null,
+        primary key (id),
+        unique (name)
+    );
+    ALTER TABLE gs_resource
+          OWNER TO geostore;
+
+    create table gs_security (
+        id int8 not null,
+        canRead bool not null,
+        canWrite bool not null,
+        group_id int8,
+        resource_id int8,
+        user_id int8,
+        primary key (id),
+        unique (user_id, resource_id),
+        unique (resource_id, group_id)
+    );
+    ALTER TABLE gs_security
+          OWNER TO geostore;
+
+    create table gs_stored_data (
+        id int8 not null,
+        stored_data varchar(500000) not null,
+        resource_id int8 not null,
+        primary key (id),
+        unique (resource_id)
+    );
+    ALTER TABLE gs_stored_data
+          OWNER TO geostore;
+
+    create table gs_user (
+        id int8 not null,
+        name varchar(20) not null,
+        user_password varchar(255),
+        user_role varchar(255) not null,
+        group_id int8,
+		enabled char(1) NOT NULL DEFAULT 'Y',
+        primary key (id),
+        unique (name)
+    );
+    ALTER TABLE gs_user
+          OWNER TO geostore;
+
+    create table gs_user_attribute (
+        id int8 not null,
+        name varchar(255) not null,
+        string varchar(255),
+        user_id int8 not null,
+        primary key (id),
+        unique (name, user_id)
+    );
+    ALTER TABLE gs_user_attribute
+          OWNER TO geostore;
+
+    create table gs_usergroup (
+        id int8 not null,
+        groupName varchar(20) not null,
+		description varchar(200),
+		enabled char(1) NOT NULL DEFAULT 'Y',
+        primary key (id),
+        unique (groupName)
+    );
+    ALTER TABLE gs_usergroup
+          OWNER TO geostore;
+	
+	create table gs_usergroup_members (
+		user_id int8 not null, 
+		group_id int8 not null, 
+		primary key (user_id, group_id)
+	);
+    ALTER TABLE gs_usergroup_members
+          OWNER TO geostore;
+	
+	alter table gs_usergroup_members 
+		add constraint FKFDE460DB62224F72 
+		foreign key (user_id) 
+		references gs_user;
+		
+    alter table gs_usergroup_members 
+		add constraint FKFDE460DB9EC981B7 
+		foreign key (group_id) 
+		references gs_usergroup;
+
+    create index idx_attribute_name on gs_attribute (name);
+
+    create index idx_attribute_resource on gs_attribute (resource_id);
+
+    create index idx_attribute_text on gs_attribute (attribute_text);
+
+    create index idx_attribute_type on gs_attribute (attribute_type);
+
+    create index idx_attribute_date on gs_attribute (attribute_date);
+
+    create index idx_attribute_number on gs_attribute (attribute_number);
+
+    alter table gs_attribute 
+        add constraint fk_attribute_resource 
+        foreign key (resource_id) 
+        references gs_resource;
+
+    create index idx_category_type on gs_category (name);
+
+    create index idx_resource_name on gs_resource (name);
+
+    create index idx_resource_description on gs_resource (description);
+
+    create index idx_resource_metadata on gs_resource (metadata);
+
+    create index idx_resource_update on gs_resource (lastUpdate);
+
+    create index idx_resource_creation on gs_resource (creation);
+
+    create index idx_resource_category on gs_resource (category_id);
+
+    alter table gs_resource 
+        add constraint fk_resource_category 
+        foreign key (category_id) 
+        references gs_category;
+
+    create index idx_security_resource on gs_security (resource_id);
+
+    create index idx_security_user on gs_security (user_id);
+
+    create index idx_security_group on gs_security (group_id);
+
+    create index idx_security_write on gs_security (canWrite);
+
+    create index idx_security_read on gs_security (canRead);
+
+    alter table gs_security 
+        add constraint fk_security_user 
+        foreign key (user_id) 
+        references gs_user;
+
+    alter table gs_security 
+        add constraint fk_security_group 
+        foreign key (group_id) 
+        references gs_usergroup;
+
+    alter table gs_security 
+        add constraint fk_security_resource 
+        foreign key (resource_id) 
+        references gs_resource;
+
+    alter table gs_stored_data 
+        add constraint fk_data_resource 
+        foreign key (resource_id) 
+        references gs_resource;
+
+    create index idx_user_group on gs_user (group_id);
+
+    create index idx_user_password on gs_user (user_password);
+
+    create index idx_user_name on gs_user (name);
+
+    create index idx_user_role on gs_user (user_role);
+
+    alter table gs_user 
+        add constraint fk_user_ugroup 
+        foreign key (group_id) 
+        references gs_usergroup;
+
+    create index idx_user_attribute_name on gs_user_attribute (name);
+
+    create index idx_user_attribute_text on gs_user_attribute (string);
+
+    create index idx_attribute_user on gs_user_attribute (user_id);
+
+    alter table gs_user_attribute 
+        add constraint fk_uattrib_user 
+        foreign key (user_id) 
+        references gs_user;
+
+    create index idx_usergroup_name on gs_usergroup (groupName);
+
+    create sequence hibernate_sequence;
+    ALTER TABLE hibernate_sequence
+          OWNER TO geostore;
+		  
+		  
+    CREATE OR REPLACE FUNCTION delete_gfrule_on_delete_gsuser() RETURNS TRIGGER AS $delete_gfrule$
+    BEGIN
+        --
+        --
+        IF (TG_OP = 'DELETE') THEN
+	    DELETE FROM geofence.gf_rule WHERE gsuser_id = OLD.id;
+            RETURN OLD;
+        END IF;
+        RETURN NULL; -- result is ignored since this is an AFTER trigger
+    END;
+	
+	$delete_gfrule$ LANGUAGE plpgsql;
+
+	CREATE TRIGGER delete_gfrule BEFORE DELETE ON gs_user
+			FOR EACH ROW EXECUTE PROCEDURE delete_gfrule_on_delete_gsuser();
+		  
+		  
+		  
+		  
+		  
+		  
+		  
+		  
+		  
+		  
+		  
+		  
+		  

--- a/doc/sql/geofence-geostoreUsersIntegration_scripts/postgres/003_create_schema_geofence_postgres.sql
+++ b/doc/sql/geofence-geostoreUsersIntegration_scripts/postgres/003_create_schema_geofence_postgres.sql
@@ -1,0 +1,199 @@
+set search_path to geofence;
+
+-- CLEAN-UP
+--drop table gf_gfuser cascade;
+--drop table gf_rule_limits;
+--drop table gf_layer_styles;
+--drop table gf_layer_custom_props ;
+--drop table gf_layer_attributes;
+--drop table gf_layer_details;
+--drop table gf_rule cascade;
+--drop table gf_gsuser cascade;
+--drop table gf_gsinstance cascade;
+--drop table gf_user_usergroups;
+--drop table gf_usergroup cascade;
+
+-- drop view geofence.gf_gsuser;
+-- drop view geofence.gf_user_usergroups;
+-- drop view geofence.gf_usergroup;
+
+--drop sequence hibernate_sequence;
+
+-- TABLE CREATION
+    create table gf_gfuser (
+        id int8 not null,
+        dateCreation timestamp,
+        emailAddress varchar(255),
+        enabled bool not null,
+        extId varchar(255) unique,
+        fullName varchar(255),
+        name varchar(255) not null unique,
+        password varchar(255),
+        primary key (id)
+    );
+
+    create table gf_gsinstance (
+        id int8 not null,
+        baseURL varchar(255) not null,
+        dateCreation timestamp,
+        description varchar(255),
+        name varchar(255) not null,
+        password varchar(255) not null,
+        username varchar(255) not null,
+        primary key (id)
+    );
+
+    create table gf_layer_attributes (
+        details_id int8 not null,
+        access_type varchar(255),
+        data_type varchar(255),
+        name varchar(255) not null,
+        primary key (details_id, name),
+        unique (details_id, name)
+    );
+
+    create table gf_layer_custom_props (
+        details_id int8 not null,
+        propvalue varchar(255),
+        propkey varchar(255),
+        primary key (details_id, propkey)
+    );
+
+    create table gf_layer_details (
+        id int8 not null,
+        area public.geometry,
+        cqlFilterRead varchar(4000),
+        cqlFilterWrite varchar(4000),
+        defaultStyle varchar(255),
+        catalog_mode varchar(255),
+		type varchar(255),
+        rule_id int8 not null,
+        primary key (id),
+        unique (rule_id)
+    );
+
+    create table gf_layer_styles (
+        details_id int8 not null,
+        styleName varchar(255)
+    );
+
+    create table gf_rule (
+        id int8 not null,
+        grant_type varchar(255) not null,
+		ip_high bigint,
+		ip_low bigint,
+		ip_size integer,
+        layer varchar(255),
+        priority int8 not null,
+        request varchar(255),
+        service varchar(255),
+        workspace varchar(255),
+        gsuser_id int8,
+        instance_id int8,
+        userGroup_id int8,
+        primary key (id),
+        unique (gsuser_id, userGroup_id, instance_id, service, request, workspace, layer)
+    );
+
+    create table gf_rule_limits (
+        id int8 not null,
+        area public.geometry,
+		catalog_mode varchar(255),
+        rule_id int8 not null,
+        primary key (id),
+        unique (rule_id)
+    );
+
+	------- VIEW gf_gsuser -------
+	create or replace view geofence.gf_gsuser as
+		select gs_user.id, 
+				current_timestamp as datecreation, 
+				character varying(255)'' as emailaddress, 
+				character varying(255) '' as extid, 
+				character varying(255) '' as fullname, 
+				-- the password used here is: "This_is_an_AES_hardcoded_password" (note that it is also base64 encoded)
+				gs_user.name, character varying(255) 'SWsIywoxKmqlGSjVedSqrpYd4/HBBn0pV+NmEEtta1T/do0NQNH6PM4Auj8EpwvX' as password,
+				cast(gs_user.enabled as boolean), 
+				case 
+					when user_role='ADMIN' 
+						then true 
+						else false 
+					end 
+				as admin
+		from geostore.gs_user;
+   
+	------- VIEW gf_user_usergroups -------
+	create or replace view geofence.gf_user_usergroups as
+		select gs_usergroup_members.user_id, 
+				gs_usergroup_members.group_id
+		from geostore.gs_usergroup_members;
+   
+	------- VIEW gf_usergroup -------
+	create or replace view geofence.gf_usergroup as
+		select gs_usergroup.id, 
+				timestamp without time zone '0001-01-01 00:00:00' as datecreation, 
+				cast(gs_usergroup.enabled as boolean), 
+				character varying(255)'' as extid, 
+				gs_usergroup.groupname as name
+		from geostore.gs_usergroup;
+	
+	
+    alter table gf_layer_attributes
+        add constraint fk_attribute_layer
+        foreign key (details_id)
+        references gf_layer_details;
+
+    alter table gf_layer_custom_props
+        add constraint fk_custom_layer
+        foreign key (details_id)
+        references gf_layer_details;
+
+    alter table gf_layer_details
+        add constraint fk_details_rule
+        foreign key (rule_id)
+        references gf_rule;
+
+    alter table gf_layer_styles
+        add constraint fk_styles_layer
+        foreign key (details_id)
+        references gf_layer_details;
+
+    create index idx_rule_request on gf_rule (request);
+
+    create index idx_rule_layer on gf_rule (layer);
+
+    create index idx_rule_service on gf_rule (service);
+
+    create index idx_rule_workspace on gf_rule (workspace);
+
+    create index idx_rule_priority on gf_rule (priority);
+
+    alter table gf_rule
+        add constraint fk_rule_instance
+        foreign key (instance_id)
+        references gf_gsinstance;
+
+    alter table gf_rule_limits
+        add constraint fk_limits_rule
+        foreign key (rule_id)
+        references gf_rule;
+
+    create sequence hibernate_sequence;
+
+--GRANTS
+alter table gf_gfuser owner to geostore;
+alter table gf_rule_limits owner to geostore;
+alter table gf_layer_styles owner to geostore;
+alter table gf_layer_custom_props owner to geostore;
+alter table gf_layer_attributes owner to geostore;
+alter table gf_layer_details owner to geostore;
+alter table gf_rule owner to geostore;
+alter table gf_gsinstance owner to geostore;
+alter view gf_gsuser owner to geostore;
+alter view gf_user_usergroups owner to geostore;
+alter view geofence.gf_usergroup owner to geostore;
+
+alter sequence hibernate_sequence owner to geostore;
+
+--DEFAULTS
+insert into geofence.gf_gfuser(id, datecreation, emailaddress, enabled, extid, fullname, "name", "password") values (0, 'now', null, true, 0, 'admin', 'admin', '21232f297a57a5a743894ae4a801fc3');

--- a/doc/sql/geofence-geostoreUsersIntegration_scripts/readme.markdown
+++ b/doc/sql/geofence-geostoreUsersIntegration_scripts/readme.markdown
@@ -1,0 +1,17 @@
+GeoFence geoStore integration
+=================================
+
+This folder contains the DDL scripts to create a common database shared between **GeoFence** and **GeoStore** that allow **GeoFence** to use the *Users and Groups* stored on **GeoStore** that could also be shared with **GeoServer**.
+These scripts require an empty postgres database spatially enabled.
+The script will create all the tables and views in 2 schemas called `geostore` and `geofence` plus it will create other 2 empty schemas called `geostore_test` and `geofence_test` for testing pourposes.
+All the schemas and all the objects will be owned by the script-created user called `geostore`
+
+Instructions
+==================================================
+
+* Create a new database, the admin can freely choose the db-name
+* Enable the postgres geospatial extensions, postGIS: run the query `CREATE EXTENSION postgis;` (Please note that the CREATE EXTENSION statement is available only with postgres version >= 2.0)
+* Run the DDL scripts you can find in this directory in the order indicated by the files suffixes (001, 002, 003) Please note that the db **should be empty** because if the user, schemas or tables that the scripts try to create are already/partially present the script will fail.
+* Install on two different tomcat instances GeoStore and Geofence and configure both to use the created database: configure properly the schema names: *geofence* must work on **geofence** schema and *geostore* on **geostore** schema
+* Run the applications, the startup order is not important.
+* Enjoy!


### PR DESCRIPTION

This pull request move the DDL scripts for the database creation from the geosolutions/geofence repository to geosolutions/geostore repository.


Regarding the matter of the schema trigger [see the postgres doc about the parameter name](http://www.postgresql.org/docs/9.1/static/sql-createtrigger.html), the schema of the trigger is inherithed by the table where the trigger work on.