### PR TITLE
Fixes #115: LDAP groups synch on init and reload rest call

### DIFF
--- a/src/server/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTMiscService.java
+++ b/src/server/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTMiscService.java
@@ -79,4 +79,12 @@ public interface RESTMiscService {
             @PathParam("cname") String cname) throws NotFoundWebEx, ConflictWebEx, BadRequestWebEx,
             InternalErrorWebEx;
 
+
+    @GET
+    @Path("/reload/{service}")
+    @Secured({ "ROLE_ADMIN" })
+    void reload(@Context SecurityContext sc, @PathParam("service") String service) throws BadRequestWebEx;
+        
+   
 }
+

--- a/src/server/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/GroupsRolesService.java
+++ b/src/server/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/GroupsRolesService.java
@@ -1,0 +1,56 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2015 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security;
+
+import java.util.Set;
+
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * Service to extract groups and/or roles list from an external service.
+ * 
+ * @author mauro.bartolomeoli@geo-solutions.it
+ *
+ */
+public interface GroupsRolesService {
+    /**
+     * Get all groups from the external service.
+     * 
+     * @return
+     */
+    public Set<GrantedAuthority> getAllGroups();
+    
+    /**
+     * Get all roles from the external service.
+     * 
+     * (currently not used, it will be useful when roles will not be
+     * fixed, finally).
+     * @return
+     */
+    public Set<GrantedAuthority> getAllRoles();
+}

--- a/src/server/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/MockLdapAuthoritiesPopulator.java
+++ b/src/server/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/MockLdapAuthoritiesPopulator.java
@@ -1,18 +1,33 @@
 package it.geosolutions.geostore.rest.security;
 
+import it.geosolutions.geostore.services.rest.security.GroupsRolesService;
+
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
 
-public class MockLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator {
+public class MockLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator, GroupsRolesService {
 
     @Override
     public Collection<GrantedAuthority> getGrantedAuthorities(DirContextOperations userData,
             String username) {
         return Collections.EMPTY_LIST;
     }
+
+    @Override
+    public Set<GrantedAuthority> getAllGroups() {
+        return Collections.EMPTY_SET;
+    }
+
+    @Override
+    public Set<GrantedAuthority> getAllRoles() {
+        return Collections.EMPTY_SET;
+    }
+    
+    
 
 }

--- a/src/server/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/UserLdapAuthenticationProviderTest.java
+++ b/src/server/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/UserLdapAuthenticationProviderTest.java
@@ -21,25 +21,43 @@ package it.geosolutions.geostore.rest.security;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
+import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
+import it.geosolutions.geostore.services.rest.security.UserLdapAuthenticationProvider;
+import it.geosolutions.geostore.services.rest.utils.MockedUserGroupService;
+import it.geosolutions.geostore.services.rest.utils.MockedUserService;
+
+import java.util.Collections;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-
-import it.geosolutions.geostore.core.model.User;
-import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
-import it.geosolutions.geostore.services.rest.security.UserLdapAuthenticationProvider;
-import it.geosolutions.geostore.services.rest.utils.MockedUserService;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.GrantedAuthorityImpl;
 
 public class UserLdapAuthenticationProviderTest {
+    private static final String TEST_GROUP = "testgroup";
+    
     private UserLdapAuthenticationProvider provider;
-    MockedUserService userService;
+    private MockedUserService userService;
+    private MockedUserGroupService userGroupService;
     
     @Before
     public void setUp() {
-        provider = new UserLdapAuthenticationProvider(new MockLdapAuthenticator(), new MockLdapAuthoritiesPopulator());
+        provider = new UserLdapAuthenticationProvider(new MockLdapAuthenticator(), new MockLdapAuthoritiesPopulator(){
+
+            @Override
+            public Set<GrantedAuthority> getAllGroups() {
+                return Collections.singleton((GrantedAuthority)new GrantedAuthorityImpl(TEST_GROUP));
+            }
+            
+        });
         userService = new MockedUserService();
+        userGroupService = new MockedUserGroupService();
         provider.setUserService(userService);
+        provider.setUserGroupService(userGroupService);
     }
     
     @Test
@@ -48,5 +66,14 @@ public class UserLdapAuthenticationProviderTest {
         User user = userService.get("user");
         assertNotNull(user);
         assertNull(user.getPassword());
+    }
+    
+    @Test
+    public void testSynchronizeGroups() throws BadRequestServiceEx {
+        assertNull(userGroupService.get(TEST_GROUP));
+        
+        provider.synchronizeGroups();
+        
+        assertNotNull(userGroupService.get(TEST_GROUP));
     }
 }

--- a/src/server/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserGroupService.java
+++ b/src/server/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserGroupService.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ * 
+ *  GPLv3 + Classpath exception
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.services.rest.utils;
+
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.services.UserGroupService;
+import it.geosolutions.geostore.services.dto.ShortResource;
+import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
+import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MockedUserGroupService implements UserGroupService {
+
+    private static Random RANDOM = new Random();
+
+    private Map<Long, UserGroup> GROUPS = new ConcurrentHashMap<Long, UserGroup>();
+    
+    @Override
+    public long insert(UserGroup userGroup) throws BadRequestServiceEx {
+        Long id = RANDOM.nextLong();
+        userGroup.setId(id);
+        
+        GROUPS.put(id, userGroup);
+        return id;
+    }
+
+    @Override
+    public boolean delete(long id) throws NotFoundServiceEx, BadRequestServiceEx {
+        return GROUPS.containsKey(new Long(id)) && GROUPS.remove(new Long(id)) != null;
+    }
+
+    @Override
+    public void assignUserGroup(long userId, long groupId) throws NotFoundServiceEx {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public void deassignUserGroup(long userId, long groupId) throws NotFoundServiceEx {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public List<UserGroup> getAll(Integer page, Integer entries) throws BadRequestServiceEx {
+        return new ArrayList<UserGroup>(GROUPS.values());
+    }
+
+    @Override
+    public UserGroup get(long id) throws BadRequestServiceEx {
+        return GROUPS.get(new Long(id));
+    }
+
+    @Override
+    public List<ShortResource> updateSecurityRules(Long groupId, List<Long> resourcesToSet,
+            boolean canRead, boolean canWrite) throws NotFoundServiceEx, BadRequestServiceEx {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean insertSpecialUsersGroups() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public UserGroup get(String name) {
+        for (UserGroup userGroup : GROUPS.values()) {
+            if (userGroup.getGroupName().equals(name)) {
+                return userGroup;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/server/web/app/src/main/java/it/geosolutions/geostore/init/LDAPInit.java
+++ b/src/server/web/app/src/main/java/it/geosolutions/geostore/init/LDAPInit.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ * 
+ *  GPLv3 + Classpath exception
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.init;
+
+import it.geosolutions.geostore.services.rest.security.UserLdapAuthenticationProvider;
+
+import org.springframework.beans.factory.InitializingBean;
+
+public class LDAPInit implements InitializingBean {
+    private UserLdapAuthenticationProvider authenticationProvider;
+    
+    public LDAPInit(UserLdapAuthenticationProvider authenticationProvider) {
+        super();
+        this.authenticationProvider = authenticationProvider;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        authenticationProvider.synchronizeGroups();
+    }
+
+}

--- a/src/server/web/app/src/main/resources/geostore-spring-security.xml
+++ b/src/server/web/app/src/main/resources/geostore-spring-security.xml
@@ -74,6 +74,12 @@
 		<constructor-arg value="ldap://${ldap.host}:${ldap.port}/${ldap.root}" />
 	</bean>
 
+    <!-- 
+     <bean id="ldapInitializer" class="it.geosolutions.geostore.init.LDAPInit" lazy-init="false">
+       <constructor-arg ref="geostoreLdapProvider" />
+     </bean>
+     -->
+
 	<bean id="geostoreLdapProvider"
 		class="it.geosolutions.geostore.services.rest.security.UserLdapAuthenticationProvider">
 		<constructor-arg>


### PR DESCRIPTION
Added a new LDAPInit initializer to be enabled when LDAP security is enabled.
The initializer synchronizes all groups from the LDAP repo upon GeoStore start. Only adding is supported (no update or delete)
A new rest call allows synchronization to occur also after GeoStore start (/misc/reload/ldap)