### PR TITLE
Version 1.5.0 with Spring 3.2.4 and Maven 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>it.geosolutions</groupId>
     <artifactId>geostore</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -63,8 +63,8 @@
     <scm>
         <url>https://github.com/geosolutions-it/geostore</url>
         <connection>scm:git:git@github.com:geosolutions-it/geostore.git</connection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <ciManagement>
         <system>jenkins</system>    
@@ -90,12 +90,16 @@
         </site>
     </distributionManagement>
 
+    <prerequisites>
+      <maven>3.0</maven>
+    </prerequisites>
+    
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -129,7 +133,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>2.5.3</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                 </configuration>
@@ -138,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -151,7 +155,7 @@
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>4.3.0</version>
             </plugin>
 			
             <plugin>

--- a/src/core/model/pom.xml
+++ b/src/core/model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
   
     <artifactId>geostore-model</artifactId>

--- a/src/core/persistence/pom.xml
+++ b/src/core/persistence/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-persistence</artifactId>
@@ -45,8 +45,8 @@
             <groupId>it.geosolutions.geostore</groupId>
             <artifactId>geostore-security</artifactId>
         </dependency>
-        
-        
+
+    
         <!-- ================================================================-->
        	<!-- APACHE COMMONS -->
         <!-- ================================================================-->
@@ -72,7 +72,7 @@
         <!-- ================================================================-->
         <!-- 4J UTILS -->
         <!-- ================================================================-->
-        <dependency> 
+        <dependency>
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
         </dependency>
@@ -188,7 +188,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-	
+
   	<!-- CGLIB -->
         <dependency>
             <groupId>asm</groupId>

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
   
     <artifactId>geostore-core</artifactId>

--- a/src/core/security/pom.xml
+++ b/src/core/security/pom.xml
@@ -24,7 +24,7 @@
      <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-security</artifactId>
@@ -35,7 +35,7 @@
     
         <!-- ================================================================-->
        	<!-- APACHE COMMONS -->
-        <!-- ================================================================-->
+        <!-- ================================================================-->       
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
@@ -49,7 +49,7 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>commons-dbcp</groupId>
             <artifactId>commons-dbcp</artifactId>
@@ -63,7 +63,7 @@
         <!-- ================================================================-->
         <!-- 4J UTILS -->
         <!-- ================================================================-->
-        <dependency> 
+        <dependency>
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
         </dependency>

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/CustomAttributesLdapUserDetailsMapper.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/CustomAttributesLdapUserDetailsMapper.java
@@ -54,7 +54,7 @@ public class CustomAttributesLdapUserDetailsMapper extends LdapUserDetailsMapper
 
     @Override
     public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
-            Collection<GrantedAuthority> authorities) {
+            Collection<? extends GrantedAuthority> authorities) {
         LdapUserDetails details =  (LdapUserDetails)super.mapUserFromContext(ctx, username, authorities);
         LdapUserDetailsWithAttributes detailsWithAttributes = new LdapUserDetailsWithAttributes(details);
         for(String attributeName : attributeMappings.keySet()) {

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/LdapUserDetailsWithAttributes.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/LdapUserDetailsWithAttributes.java
@@ -47,7 +47,12 @@ import org.springframework.security.ldap.userdetails.LdapUserDetails;
  *
  */
 public class LdapUserDetailsWithAttributes implements LdapUserDetails, UserDetailsWithAttributes {
-    private LdapUserDetails delegate;
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = 8623656298800133551L;
+
+	private LdapUserDetails delegate;
     
     private Map<String, Object> attributes = new HashMap<String, Object>();
     
@@ -64,7 +69,7 @@ public class LdapUserDetailsWithAttributes implements LdapUserDetails, UserDetai
         return attributes.get(name);
     }
     
-    public Collection<GrantedAuthority> getAuthorities() {
+    public Collection<? extends GrantedAuthority> getAuthorities() {
         return delegate.getAuthorities();
     }
 

--- a/src/core/security/src/test/java/it/geosolutions/geostore/core/security/ldap/MockDirContextOperations.java
+++ b/src/core/security/src/test/java/it/geosolutions/geostore/core/security/ldap/MockDirContextOperations.java
@@ -484,4 +484,10 @@ public class MockDirContextOperations implements DirContextOperations{
         return null;
     }
 
+	@Override
+	public boolean attributeExists(String arg0) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
 }

--- a/src/core/services-api/pom.xml
+++ b/src/core/services-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-services-api</artifactId>

--- a/src/core/services-impl/pom.xml
+++ b/src/core/services-impl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-services-impl</artifactId>
@@ -61,17 +61,7 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
 
-        <!-- This dep is needed in core::dao, but seems not to be transitively imported-->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        			
         <!-- =========================================================== -->
         <!-- SPRING -->
 
@@ -100,11 +90,6 @@
         <!-- MISC -->
 
         <dependency>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
         </dependency>
@@ -117,7 +102,7 @@
             <artifactId>persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
+		
 
 
 		 HIBERNATE-GENERIC-DAO 
@@ -172,7 +157,7 @@
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
         </dependency>
-	
+
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
@@ -231,7 +216,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.4</version>
+                        <version>2.7</version>
                         <configuration>
                             <instrumentation>
                             </instrumentation>

--- a/src/modules/pom.xml
+++ b/src/modules/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-modules</artifactId>

--- a/src/modules/rest/api/pom.xml
+++ b/src/modules/rest/api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-api</artifactId>
@@ -92,18 +92,18 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-ldap</artifactId>
         </dependency>
-		
-			<dependency>
-				<groupId>org.slf4j</groupId>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-log4j12</artifactId>
-			</dependency>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
         <!-- =============================================================== -->
-		
-		<dependency>
+
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>jsr250-api</artifactId>
         </dependency>
@@ -114,7 +114,13 @@
             <type>jar</type>
             <version>1.1.1</version>
         </dependency>
-
+        
+        <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom</artifactId>
+            <version>1.1.3</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/modules/rest/auditing/pom.xml
+++ b/src/modules/rest/auditing/pom.xml
@@ -23,11 +23,15 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
     <artifactId>geostore-rest-auditing</artifactId>
     <name>GeoStore - Modules - REST auditing</name>
     <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-core</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-core</artifactId>

--- a/src/modules/rest/client/pom.xml
+++ b/src/modules/rest/client/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-client</artifactId>
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
+                <version>2.20</version>
             </plugin>
         </plugins>
     </build>

--- a/src/modules/rest/extjs/pom.xml
+++ b/src/modules/rest/extjs/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-extjs</artifactId>
@@ -55,31 +55,16 @@
         <!-- ================================================================-->
         <!-- Core lib -->
         <!-- ================================================================-->
+        
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring-version}</version>
+        </dependency>
 
         <!-- ================================================================-->
         <!--  Misc support libs -->
         <!-- ================================================================-->
-
-        <!--dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>jsr250-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-		
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-        </dependency-->
         
         <dependency>
             <groupId>net.sf.json-lib</groupId>
@@ -141,7 +126,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
+                <version>2.20</version>
             </plugin>
         </plugins>
     </build>

--- a/src/modules/rest/impl/pom.xml
+++ b/src/modules/rest/impl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-impl</artifactId>
@@ -99,7 +99,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
@@ -131,7 +131,7 @@
             <version>2.4</version>
             <classifier>jdk15</classifier>
         </dependency>
-		
+    
         <dependency>
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserLdapAuthenticationProvider.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserLdapAuthenticationProvider.java
@@ -28,7 +28,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.security.ldap.authentication.LdapAuthenticator;
@@ -99,7 +99,7 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
         LdapUserDetails ldapUser = null;
         if (authentication.isAuthenticated()) {
 
-            Collection<GrantedAuthority> authorities = null;
+            Collection<? extends GrantedAuthority> authorities = null;
 
             ldapUser = (LdapUserDetails) authentication.getPrincipal();
 
@@ -189,7 +189,7 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
      */
     protected Authentication prepareAuthentication(String pw, User user, Role role) {
         List<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
-        grantedAuthorities.add(new GrantedAuthorityImpl("ROLE_" + role));
+        grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_" + role));
         Authentication a = new UsernamePasswordAuthenticationToken(user, pw, grantedAuthorities);
         // a.setAuthenticated(true);
         return a;
@@ -203,7 +203,7 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
      * @throws BadRequestServiceEx
      */
     protected Role extractUserRoleAndGroups(Role userRole,
-            Collection<GrantedAuthority> authorities, Set<UserGroup> groups)
+            Collection<? extends GrantedAuthority> authorities, Set<UserGroup> groups)
             throws BadRequestServiceEx {
         Role role = (userRole != null ? userRole : Role.USER);
         for (GrantedAuthority a : authorities) {

--- a/src/modules/rest/pom.xml
+++ b/src/modules/rest/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-modules</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-root</artifactId>

--- a/src/modules/rest/test/pom.xml
+++ b/src/modules/rest/test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-test</artifactId>
@@ -54,9 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                </configuration>
+                <version>3.0.0</version>
             </plugin>
 
             <!-- Run the application using "mvn jetty:run" -->

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>it.geosolutions</groupId>
         <artifactId>geostore</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <groupId>it.geosolutions.geostore</groupId>
@@ -40,22 +40,17 @@
     </modules>
 
     <properties>
-        <geostore-version>1.4.2-SNAPSHOT</geostore-version>
+        <geostore-version>1.5.0-SNAPSHOT</geostore-version>
         <main-prefix>geostore</main-prefix>
 
         <cxf-version>2.3.2</cxf-version>
         <activemq-version>5.3.0.4-fuse</activemq-version>
 
         <jersey-version>2.5.1</jersey-version>
-        <!--
-        spring-security-core 3.0.4 requires spring-core 3.x, otherwise we'd normally use 2.5.6, which
-        is what the rest of the app uses
-        -->
-        <spring-version>3.0.5.RELEASE</spring-version>
 
-        <!-- 2.5.6.SEC01 is the version used by smix-->
-        <!-- 2.5.5       is the version used by memberService-->
-        <spring-security-version>3.0.5.RELEASE</spring-security-version>
+        <spring-version>3.2.4.RELEASE</spring-version>
+
+        <spring-security-version>3.1.4.RELEASE</spring-security-version>
         <spring-security-crypto-version>3.1.3.RELEASE</spring-security-crypto-version>
         <camel-version>1.6.1.2-fuse</camel-version>
 
@@ -865,7 +860,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -884,7 +879,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.2</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                 </configuration>
@@ -893,9 +888,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- Use 2.4.2 because 2.4.3 has bug with system properties
-				     see http://jira.codehaus.org/browse/SUREFIRE-121 -->
-                <version>2.4.2</version>
+                <version>2.20</version>
             </plugin>
             
         </plugins>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-web</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-webapp</artifactId>
@@ -130,7 +130,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.1</version>
+                        <version>1.8</version>
                         <executions>
                             <execution>
                                 <phase>process-classes</phase>
@@ -164,7 +164,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.1</version>
+                        <version>1.8</version>
                         <executions>
                             <execution>
                                 <phase>process-classes</phase>
@@ -191,7 +191,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.1</version>
+                        <version>1.8</version>
                         <executions>
                             <execution>
                                 <phase>process-classes</phase>
@@ -256,7 +256,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.0</version>
                 <configuration>
                     <packagingExcludes>WEB-INF/lib/apacheds-all*.jar</packagingExcludes>
                 </configuration>

--- a/src/web/app/src/test/resources/geostore-spring-security-test.xml
+++ b/src/web/app/src/test/resources/geostore-spring-security-test.xml
@@ -62,7 +62,7 @@
 	<!-- Simple namespace-based configuration -->
 
 	<!-- Starts an internal LDAP server -->
-	<security:ldap-server ldif="classpath*:users.ldif" port="33389" root="dc=geosolutions,dc=it"/>
+	<security:ldap-server ldif="users.ldif" port="33389" root="dc=geosolutions,dc=it"/>
 
 	<security:authentication-manager>
 		<security:ldap-authentication-provider

--- a/src/web/pom.xml
+++ b/src/web/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
   
     <artifactId>geostore-web</artifactId>


### PR DESCRIPTION
Spring Security 3.1.4
Updated maven plugins

Version bump to 1.5 because the generated jars will not be compatible with previous versions.
Database and API are not changed, so GeoStore 1.5 can replace GeoStore 1.4