### PR TITLE
Fix #168. Created custom provider for pure text request body

### DIFF
--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/providers/StringTextProvider.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/providers/StringTextProvider.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it.geosolutions.geostore.services.providers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.apache.cxf.helpers.IOUtils;
+import org.apache.cxf.jaxrs.provider.AbstractConfigurableProvider;
+import org.apache.cxf.jaxrs.utils.HttpUtils;
+
+/**
+ * This is a porting of org.apache.cxf.jaxrs.provider.StringTextProvider, created in a recent version of cxf.
+ * It's used in geostore to read the raw request body in in rest service's StoredDataService to retrieve the correct encoding.
+ *  
+ * @author Lorenzo Natali, GeoSolutions S.a.s.
+ *
+ */
+public class StringTextProvider extends AbstractConfigurableProvider
+    implements MessageBodyReader<String>, MessageBodyWriter<String> {
+    private int bufferSize = 4096;
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mt) {
+        return String.class == type;
+    }
+
+    public String readFrom(Class<String> type, Type genType, Annotation[] anns, MediaType mt,
+                      MultivaluedMap<String, String> headers, InputStream is) throws IOException {
+    	
+        return IOUtils.toString(is, HttpUtils.getSetEncoding(mt, null, StandardCharsets.UTF_8.name()));
+    }
+
+    public long getSize(String t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mt) {
+        return -1;
+    }
+
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mt) {
+        return String.class == type;
+    }
+
+    public void writeTo(String obj, Class<?> type, Type genType, Annotation[] anns,
+                        MediaType mt, MultivaluedMap<String, Object> headers,
+                        OutputStream os) throws IOException {
+        String encoding = HttpUtils.getSetEncoding(mt, headers, StandardCharsets.UTF_8.name());
+        //REVISIT try to avoid instantiating the whole byte array
+        byte[] bytes = obj.getBytes(encoding);
+        if (bytes.length > bufferSize) {
+            int pos = 0;
+            while (pos < bytes.length) {
+                int bl = bytes.length - pos;
+                if (bl > bufferSize) {
+                    bl = bufferSize;
+                }
+                os.write(bytes, pos, bl);
+                pos += bl;
+            }
+        } else {
+            os.write(bytes);
+        }
+    }
+    public void setBufferSize(int bufferSize) {
+        this.bufferSize = bufferSize;
+    }
+}

--- a/src/modules/rest/api/src/test/java/it/geosolutions/geostore/services/providers/StringConversionTest.java
+++ b/src/modules/rest/api/src/test/java/it/geosolutions/geostore/services/providers/StringConversionTest.java
@@ -1,0 +1,57 @@
+/*  Copyright (C) 2007 - 2012 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ * 
+ *  GPLv3 + Classpath exception
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.services.providers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.ws.rs.core.MediaType;
+
+import org.jdom.JDOMException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+/**
+ * 
+ * @author Lorenzo Natali, GeoSolutions S.a.s.
+ */
+public class StringConversionTest extends TestCase {
+	final String TEST_STRING = "àòèòù";
+    public StringConversionTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Test
+    public void testStringConversion() throws JDOMException, IOException {
+        StringTextProvider provider = new StringTextProvider();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        provider.writeTo(TEST_STRING, null, null, null, MediaType.APPLICATION_JSON_TYPE, null, os);
+        assertEquals(TEST_STRING, os.toString());
+    }
+}

--- a/src/modules/rest/impl/src/main/resources/applicationContext.xml
+++ b/src/modules/rest/impl/src/main/resources/applicationContext.xml
@@ -79,8 +79,7 @@
 		</jaxrs:features>
 
 		<jaxrs:providers>
-			<ref bean="jaxbXmlProvider" />
-			<ref bean="jsonProvider" />
+			<bean class="it.geosolutions.geostore.services.providers.StringTextProvider" />
 			<bean class="it.geosolutions.geostore.services.rest.security.SecurityExceptionMapper"/>
 		</jaxrs:providers>
 	</jaxrs:server>

--- a/src/web/app/src/test/resources/applicationContext-test.xml
+++ b/src/web/app/src/test/resources/applicationContext-test.xml
@@ -73,8 +73,7 @@
 		</jaxrs:features>
 
 		<jaxrs:providers>
-			<ref bean="jaxbXmlProvider" />
-			<ref bean="jsonProvider" />
+			<bean class="it.geosolutions.geostore.services.providers.StringTextProvider" />
 			<bean class="it.geosolutions.geostore.services.rest.security.SecurityExceptionMapper"/>
 		</jaxrs:providers>
 


### PR DESCRIPTION
Fix #168.
This fixes issues due to wrong encoding of strings like `àèìòù when update the StoredData. 
Implementing a StringTextProvider that replaces default behiviour when a provider is not matched for string. 
