### PR TITLE
Implement support to manage permissions for external authentication

### DIFF
--- a/doc/sql/002_create_schema_oracle.sql
+++ b/doc/sql/002_create_schema_oracle.sql
@@ -37,6 +37,8 @@
         group_id number(19,0),
         resource_id number(19,0),
         user_id number(19,0),
+        username varchar2(255 char),
+        groupname varchar2(255 char),
         primary key (id),
         unique (user_id, resource_id),
         unique (resource_id, group_id)
@@ -140,6 +142,10 @@
     create index idx_security_write on gs_security (canWrite);
 
     create index idx_security_read on gs_security (canRead);
+    
+    create index idx_security_username on gs_security (username);
+    
+    create index idx_security_groupname on gs_security (groupname);
 
     alter table gs_security 
         add constraint fk_security_user 

--- a/doc/sql/002_create_schema_postgres.sql
+++ b/doc/sql/002_create_schema_postgres.sql
@@ -52,6 +52,8 @@ psql -U geostore_test -d geostore -f 002_create_schema_postgres.sql
         group_id int8,
         resource_id int8,
         user_id int8,
+        username varchar(255),
+        groupname varchar(255),
         primary key (id),
         unique (user_id, resource_id),
         unique (resource_id, group_id)
@@ -155,6 +157,10 @@ psql -U geostore_test -d geostore -f 002_create_schema_postgres.sql
     create index idx_security_write on gs_security (canWrite);
 
     create index idx_security_read on gs_security (canRead);
+    
+    create index idx_security_username on gs_security (username);
+    
+    create index idx_security_groupname on gs_security (groupname);
 
     alter table gs_security 
         add constraint fk_security_user 

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/SecurityRule.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/SecurityRule.java
@@ -107,6 +107,14 @@ public class SecurityRule implements Serializable {
     @Column(nullable = false, updatable = true)
     @Index(name = "idx_security_write")
     private boolean canWrite;
+    
+    @Column(nullable = true, updatable = true)
+    @Index(name = "idx_security_username")
+    private String username;
+    
+    @Column(nullable = true, updatable = true)
+    @Index(name = "idx_security_groupname")
+    private String groupname;
 
     /**
      * @throws Exception
@@ -192,6 +200,38 @@ public class SecurityRule implements Serializable {
      */
     public void setGroup(UserGroup group) {
         this.group = group;
+    }
+
+    /**
+     * 
+     * @return the username (from external authentication)
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * 
+     * @param username the user name to set
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * 
+     * @return the group name (from external authentication)
+     */
+    public String getGroupname() {
+        return groupname;
+    }
+
+    /**
+     * 
+     * @param groupname the group name to set
+     */
+    public void setGroupname(String groupname) {
+        this.groupname = groupname;
     }
 
     /**

--- a/src/core/model/src/test/java/it/geosolutions/geostore/core/model/AttributeTest.java
+++ b/src/core/model/src/test/java/it/geosolutions/geostore/core/model/AttributeTest.java
@@ -79,24 +79,3 @@ public class AttributeTest {
         doTheTest(a0);
     }
 }
-
-class Marshaler<T> {
-
-    private final Class<T> _class;
-
-    public Marshaler(Class<T> _class) {
-        this._class = _class;
-    }
-
-    protected String marshal(T a) {
-        StringWriter sw = new StringWriter();
-        JAXB.marshal(a, sw);
-        return sw.toString();
-    }
-
-    protected T unmarshal(String s) {
-        StringReader sr = new StringReader(s);
-        return JAXB.unmarshal(sr, _class);
-    }
-
-}

--- a/src/core/model/src/test/java/it/geosolutions/geostore/core/model/Marshaler.java
+++ b/src/core/model/src/test/java/it/geosolutions/geostore/core/model/Marshaler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007 - 2011 GeoSolutions S.A.S.
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
  *  http://www.geo-solutions.it
  * 
  *  GPLv3 + Classpath exception
@@ -19,44 +19,27 @@
  */
 package it.geosolutions.geostore.core.model;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.StringReader;
 import java.io.StringWriter;
-
 import javax.xml.bind.JAXB;
 
-import org.junit.Test;
+class Marshaler<T> {
 
-/**
- * 
- * @author ETj (etj at geo-solutions.it)
- */
-public class CategoryTest {
+    private final Class<T> _class;
 
-    private final static Marshaler<Category> MARSHALER = new Marshaler<Category>(Category.class);
-
-    public CategoryTest() {
+    public Marshaler(Class<T> _class) {
+        this._class = _class;
     }
 
-    @Test
-    public void testMarshallingString() throws Exception {
-        Category c0 = new Category();
-        c0.setName("testatt");
-        c0.setId(1l);
-
-        doTheTest(c0);
+    protected String marshal(T a) {
+        StringWriter sw = new StringWriter();
+        JAXB.marshal(a, sw);
+        return sw.toString();
     }
 
-    private void doTheTest(Category a0) {
-        String s = MARSHALER.marshal(a0);
-        Category a1 = MARSHALER.unmarshal(s);
-
-        System.out.println(a0);
-        System.out.println(a1);
-        System.out.println(s);
-
-        assertTrue(a0.equals(a1));
+    protected T unmarshal(String s) {
+        StringReader sr = new StringReader(s);
+        return JAXB.unmarshal(sr, _class);
     }
+
 }
-

--- a/src/core/model/src/test/java/it/geosolutions/geostore/core/model/SecurityRuleTest.java
+++ b/src/core/model/src/test/java/it/geosolutions/geostore/core/model/SecurityRuleTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007 - 2011 GeoSolutions S.A.S.
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
  *  http://www.geo-solutions.it
  * 
  *  GPLv3 + Classpath exception
@@ -20,43 +20,31 @@
 package it.geosolutions.geostore.core.model;
 
 import static org.junit.Assert.assertTrue;
-
-import java.io.StringReader;
-import java.io.StringWriter;
-
-import javax.xml.bind.JAXB;
-
 import org.junit.Test;
 
-/**
- * 
- * @author ETj (etj at geo-solutions.it)
- */
-public class CategoryTest {
-
-    private final static Marshaler<Category> MARSHALER = new Marshaler<Category>(Category.class);
-
-    public CategoryTest() {
-    }
-
+public class SecurityRuleTest {
+    private final static Marshaler<SecurityRule> MARSHALER = new Marshaler<SecurityRule>(SecurityRule.class);
+    
     @Test
-    public void testMarshallingString() throws Exception {
-        Category c0 = new Category();
-        c0.setName("testatt");
-        c0.setId(1l);
-
-        doTheTest(c0);
+    public void testMarshallingUsername() throws Exception {
+        SecurityRule sr0 = new SecurityRule();
+        sr0.setUsername("testuser");
+        doTheTest(sr0);
+    }
+    
+    @Test
+    public void testMarshallingGroupname() throws Exception {
+        SecurityRule sr0 = new SecurityRule();
+        sr0.setGroupname("testgroup");
+        doTheTest(sr0);
     }
 
-    private void doTheTest(Category a0) {
+    private void doTheTest(SecurityRule a0) {
         String s = MARSHALER.marshal(a0);
-        Category a1 = MARSHALER.unmarshal(s);
-
-        System.out.println(a0);
-        System.out.println(a1);
-        System.out.println(s);
+        SecurityRule a1 = MARSHALER.unmarshal(s);
 
         assertTrue(a0.equals(a1));
     }
 }
+
 

--- a/src/core/model/src/test/java/it/geosolutions/geostore/core/model/UserGroupTest.java
+++ b/src/core/model/src/test/java/it/geosolutions/geostore/core/model/UserGroupTest.java
@@ -20,12 +20,6 @@
 package it.geosolutions.geostore.core.model;
 
 import static org.junit.Assert.assertTrue;
-
-import java.io.StringReader;
-import java.io.StringWriter;
-
-import javax.xml.bind.JAXB;
-
 import org.junit.Test;
 
 /**
@@ -34,7 +28,7 @@ import org.junit.Test;
  */
 public class UserGroupTest {
 
-    private final static GMarshaler<UserGroup> MARSHALER = new GMarshaler<UserGroup>(UserGroup.class);
+    private final static Marshaler<UserGroup> MARSHALER = new Marshaler<UserGroup>(UserGroup.class);
 
     public UserGroupTest() {
     }
@@ -57,24 +51,3 @@ public class UserGroupTest {
     }
 
 }	
-
-class GMarshaler<T> {
-
-    private final Class<T> _class;
-
-    public GMarshaler(Class<T> _class) {
-        this._class = _class;
-    }
-
-    protected String marshal(T a) {
-        StringWriter sw = new StringWriter();
-        JAXB.marshal(a, sw);
-        return sw.toString();
-    }
-
-    protected T unmarshal(String s) {
-        StringReader sr = new StringReader(s);
-        return JAXB.unmarshal(sr, _class);
-    }
-
-}

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ResourceDAO.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ResourceDAO.java
@@ -27,17 +27,11 @@
  */
 package it.geosolutions.geostore.core.dao;
 
+import java.util.List;
+import javax.persistence.NonUniqueResultException;
+import com.googlecode.genericdao.search.ISearch;
 import it.geosolutions.geostore.core.model.Attribute;
 import it.geosolutions.geostore.core.model.Resource;
-import it.geosolutions.geostore.core.model.SecurityRule;
-import it.geosolutions.geostore.core.model.User;
-
-import java.util.List;
-
-import javax.persistence.NonUniqueResultException;
-
-import com.googlecode.genericdao.search.ISearch;
-import com.googlecode.genericdao.search.Search;
 
 /**
  * Interface ResourceDAO. Public interface to define operations on Resource
@@ -47,34 +41,6 @@ import com.googlecode.genericdao.search.Search;
  */
 public interface ResourceDAO extends RestrictedGenericDAO<Resource>
 {
-
-    /**
-     * @param userName
-     * @param resourceId
-     * @return List<SecurityRule>
-     *
-     * @deprecated move to SecurityDAO
-     */
-    @Deprecated
-    public List<SecurityRule> findUserSecurityRule(String userName, long resourceId);
-
-    /**
-     *
-     * @param userName
-     * @param resourceId
-     * @return
-     * @deprecated move to SecurityDAO
-     */
-    @Deprecated
-    public List<SecurityRule> findGroupSecurityRule(List<String> groupNames, long resourceId);
-
-    /**
-     * @param resourceId
-     * @return List<SecurityRule>
-     * @deprecated move to SecurityDAO
-     */
-    @Deprecated
-    public List<SecurityRule> findSecurityRules(long resourceId);
 
     /**
      * @param resourceId
@@ -107,10 +73,4 @@ public interface ResourceDAO extends RestrictedGenericDAO<Resource>
      * @return a list of resource names
      */
     public List<String> findResourceNamesMatchingPattern(String pattern);
-
-    /**
-     * Add security filtering in order to filter out resources the user has not read access to
-     */
-    void addReadSecurityConstraints(Search searchCriteria, User user);
-
 }

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/SecurityDAO.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/SecurityDAO.java
@@ -19,7 +19,10 @@
  */
 package it.geosolutions.geostore.core.dao;
 
+import java.util.List;
+import com.googlecode.genericdao.search.Search;
 import it.geosolutions.geostore.core.model.SecurityRule;
+import it.geosolutions.geostore.core.model.User;
 
 /**
  * Interface SecurityDAO.
@@ -28,5 +31,29 @@ import it.geosolutions.geostore.core.model.SecurityRule;
  * 
  */
 public interface SecurityDAO extends RestrictedGenericDAO<SecurityRule> {
+    /**
+     * Add security filtering in order to filter out resources the user has not read access to
+     */
+    void addReadSecurityConstraints(Search searchCriteria, User user);
+    
+    /**
+     * @param userName
+     * @param resourceId
+     * @return List<SecurityRule>
+     */
+    public List<SecurityRule> findUserSecurityRule(String userName, long resourceId);
 
+    /**
+     *
+     * @param userName
+     * @param resourceId
+     * @return
+     */
+    public List<SecurityRule> findGroupSecurityRule(List<String> groupNames, long resourceId);
+
+    /**
+     * @param resourceId
+     * @return List<SecurityRule>
+     */
+    public List<SecurityRule> findSecurityRules(long resourceId);
 }

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/StoredDataDAO.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/StoredDataDAO.java
@@ -20,9 +20,6 @@
 
 package it.geosolutions.geostore.core.dao;
 
-import java.util.List;
-
-import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.StoredData;
 
 /**
@@ -31,20 +28,5 @@ import it.geosolutions.geostore.core.model.StoredData;
  * @author Emanuele Tajariol (etj at geo-solutions.it)
  */
 public interface StoredDataDAO extends RestrictedGenericDAO<StoredData> {
-
-    /**
-     * @param name
-     * @param resourceId
-     * @return List<SecurityRule>
-     */
-    List<SecurityRule> findUserSecurityRule(String name, long resourceId);
-    
-    /**
-     * 
-     * @param name
-     * @param resourceId
-     * @return
-     */
-    List<SecurityRule> findGroupSecurityRule(List<String> groupNames, long resourceId);
 
 }

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/ExternalSecurityDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/ExternalSecurityDAOImpl.java
@@ -1,0 +1,206 @@
+/*
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.core.dao.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import com.googlecode.genericdao.search.Filter;
+import com.googlecode.genericdao.search.ISearch;
+import com.googlecode.genericdao.search.Search;
+import it.geosolutions.geostore.core.model.SecurityRule;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.Role;
+
+/**
+ * Alternative implementation of SecurityDAO that uses names for users and groups instead of
+ * loading data from the database.
+ * To be activated as an alias when external authentication is enabled:
+ * 
+ *  <alias name="externalSecurityDAO" alias="securityDAO"/>
+ *  
+ * @author mauro.bartolomeoli@geo-solutions.it
+ *
+ */
+public class ExternalSecurityDAOImpl extends SecurityDAOImpl {
+
+    @Override
+    public void persist(SecurityRule... entities) {
+        SecurityRule[] entitiesWithNames = extractNames(entities);
+        super.persist(entitiesWithNames);
+        for (int i = 0; i < entitiesWithNames.length; i++) {
+            entities[i].setId(entitiesWithNames[i].getId());
+        }
+    }
+
+    @Override
+    public List<SecurityRule> findAll() {
+        return fillFromNames(super.findAll());
+    }
+
+    /**
+     * Returns a new list populating User object from username and UserGroup object from groupname so
+     * that using external users is transparent for higher levels.
+     * 
+     * @param rules input rules
+     * @return rules with populated user objects
+     */
+    private List<SecurityRule> fillFromNames(List<SecurityRule> rules) {
+        List<SecurityRule> filled = new ArrayList<SecurityRule>();
+        for (SecurityRule rule : rules) {
+            SecurityRule filledRule = new SecurityRule();
+            filledRule.setId(rule.getId());
+            filledRule.setResource(rule.getResource());
+            filledRule.setCanRead(rule.isCanRead());
+            filledRule.setCanWrite(rule.isCanWrite());
+            if (rule.getUsername() != null) {
+                filledRule.setUsername(rule.getUsername());
+                if (rule.getUser() == null) {
+                    User user = new User();
+                    user.setId(-1L);
+                    user.setEnabled(true);
+                    user.setName(rule.getUsername());
+                    filledRule.setUser(user);
+                }
+            }
+            if (rule.getGroupname() != null) {
+                filledRule.setGroupname(rule.getGroupname());
+                if (rule.getGroup() == null) {
+                    UserGroup group = new UserGroup();
+                    group.setId(-1L);
+                    group.setEnabled(true);
+                    group.setGroupName(rule.getGroupname());
+                    filledRule.setGroup(group);
+                }
+            }
+            filled.add(filledRule);
+        }
+        return filled;
+    }
+
+    /**
+     * Extracts username and groupname from DTO objets, so that security is persisted
+     * with the names instead of the object.
+     * 
+     * @param rules input rules
+     * @return
+     */
+    private SecurityRule[] extractNames(SecurityRule[] rules) {
+        List<SecurityRule> extracted = new ArrayList<SecurityRule>();
+        for (SecurityRule rule : rules) {
+            SecurityRule extractedRule = new SecurityRule();
+            extractedRule.setId(rule.getId());
+            extractedRule.setResource(rule.getResource());
+            extractedRule.setCanRead(rule.isCanRead());
+            extractedRule.setCanWrite(rule.isCanWrite());
+            if (rule.getUser() != null) {
+                extractedRule.setUsername(rule.getUser().getName());
+            } else {
+                extractedRule.setUsername(rule.getUsername());
+            }
+            if (rule.getGroup() != null) {
+                extractedRule.setGroupname(rule.getGroup().getGroupName());
+            } else {
+                extractedRule.setGroupname(rule.getGroupname());
+            }
+            extracted.add(extractedRule);
+        }
+        return extracted.toArray(new SecurityRule[] {});
+    }
+
+    @Override
+    public List<SecurityRule> search(ISearch search) {
+        return fillFromNames(super.search(search));
+    }
+    
+    /**
+     * Add security filtering in order to filter out resources the user has not read access to
+     */
+    @Override
+    public void addReadSecurityConstraints(Search searchCriteria, User user)
+    {
+        // no further constraints for admin user
+        if(user.getRole() == Role.ADMIN) {
+            return;
+        }
+
+        Filter userFiltering = Filter.equal("username", user.getName());
+
+        if(! user.getGroups().isEmpty()) {
+            List<String> groupsName = new ArrayList<>();
+            for (UserGroup group : user.getGroups()) {
+                groupsName.add(group.getGroupName());
+            }
+            
+            userFiltering = Filter.or( userFiltering, Filter.in("groupname", groupsName));
+        }
+
+        Filter securityFilter = Filter.some(
+                "security",
+                Filter.and(
+                        Filter.equal("canRead", true),
+                        userFiltering
+                        )
+                );
+
+        searchCriteria.addFilter(securityFilter);
+    }
+    /**
+     * @param userName
+     * @param resourceId
+     * @return List<SecurityRule>
+     */
+    @Override
+    public List<SecurityRule> findUserSecurityRule(String userName, long resourceId) {
+        Search searchCriteria = new Search(SecurityRule.class);
+
+        Filter securityFilter =
+                Filter.and(Filter.equal("resource.id", resourceId),
+                        Filter.equal("username", userName));
+        searchCriteria.addFilter(securityFilter);
+        // now rules are not properly filtered. 
+        // so no user rules have to be removed externally (see RESTServiceImpl > ResourceServiceImpl)
+        // TODO: apply same worakaround of findGroupSecurityRule or fix searchCriteria issue (when this unit is well tested).
+        return fillFromNames(super.search(searchCriteria));
+    }
+
+    
+    
+    @Override
+    public List<SecurityRule> findSecurityRules(long resourceId) {
+        return fillFromNames(super.findSecurityRules(resourceId));
+    }
+
+    /* (non-Javadoc)
+     * @see it.geosolutions.geostore.core.dao.ResourceDAO#findGroupSecurityRule(java.lang.String, long)
+     */
+    @Override
+    public List<SecurityRule> findGroupSecurityRule(List<String> groupNames, long resourceId) {
+        List<SecurityRule> rules = findSecurityRules(resourceId);
+        //WORKAROUND
+        List<SecurityRule> filteredRules = new ArrayList<SecurityRule>();
+        for(SecurityRule sr : rules){
+            if(sr.getGroupname() != null && groupNames.contains(sr.getGroupname())){
+                filteredRules.add(sr);
+            }
+        }
+        return fillFromNames(filteredRules);
+    }
+}

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/StoredDataDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/StoredDataDAOImpl.java
@@ -78,44 +78,4 @@ public class StoredDataDAOImpl extends BaseDAO<StoredData, Long> implements Stor
     public boolean removeById(Long id) {
         return super.removeById(id);
     }
-
-    @Override
-    public List<SecurityRule> findUserSecurityRule(String name, long resourceId) {
-        Search searchCriteria = new Search(StoredData.class);
-        searchCriteria.addField("resource.security");
-
-        Filter securityFilter = Filter.some(
-                "resource.security",
-                Filter.and(Filter.equal("resource.security.resource.id", resourceId),
-                        Filter.equal("resource.security.user.name", name)));
-        searchCriteria.addFilter(securityFilter);
-
-        return super.search(searchCriteria);
-    }
-
-    /* (non-Javadoc)
-     * @see it.geosolutions.geostore.core.dao.StoredDataDAO#findGroupSecurityRule(java.lang.String, long)
-     */
-    @Override
-    public List<SecurityRule> findGroupSecurityRule(List<String> userGroups, long resourceId) {
-        Search searchCriteria = new Search(StoredData.class);
-        
-         //get all the security rules
-          searchCriteria.addField("resource.security");
-          Filter securityFilter = Filter.some(
-                  "resource.security",Filter.equal("resource.security.resource.id", resourceId)
-          );
-          searchCriteria.addFilter(securityFilter);
-          
-        List<SecurityRule> rules = super.search(searchCriteria);
-        //WORKAROUND (See ResourceDAOImpl)
-        List<SecurityRule> filteredRules = new ArrayList<SecurityRule>();
-        for(SecurityRule sr : rules){
-            if(sr.getGroup() != null && userGroups.contains(sr.getGroup().getGroupName())){
-                filteredRules.add(sr);
-            }
-        }
-        return filteredRules;
-    }
-
 }

--- a/src/core/persistence/src/main/resources/applicationContext.xml
+++ b/src/core/persistence/src/main/resources/applicationContext.xml
@@ -71,4 +71,9 @@
 		<property name="userGroupDAO" ref="userGroupDAO"/>
 	</bean>
 	
+	<bean id="externalSecurityDAO" class="it.geosolutions.geostore.core.dao.impl.ExternalSecurityDAOImpl" >
+        <property name="searchProcessor" ref="geostoreSearchProcessor" />
+        <property name="userGroupDAO" ref="userGroupDAO"/>
+    </bean>
+	
 </beans>

--- a/src/core/persistence/src/main/resources/applicationContext.xml
+++ b/src/core/persistence/src/main/resources/applicationContext.xml
@@ -68,6 +68,7 @@
 	
 	<bean id="securityDAO" class="it.geosolutions.geostore.core.dao.impl.SecurityDAOImpl" >
 		<property name="searchProcessor" ref="geostoreSearchProcessor" />
+		<property name="userGroupDAO" ref="userGroupDAO"/>
 	</bean>
 	
 </beans>

--- a/src/core/persistence/src/main/resources/securityapplicationContext.xml
+++ b/src/core/persistence/src/main/resources/securityapplicationContext.xml
@@ -68,6 +68,12 @@
 	
 	<bean id="securityDAO" class="it.geosolutions.geostore.core.dao.impl.SecurityDAOImpl" >
 		<property name="searchProcessor" ref="geostoreSearchProcessor" />
+		<property name="userGroupDAO" ref="userGroupDAO"/>
 	</bean>
+	
+	<bean id="externalSecurityDAO" class="it.geosolutions.geostore.core.dao.impl.ExternalSecurityDAOImpl" >
+        <property name="searchProcessor" ref="geostoreSearchProcessor" />
+        <property name="userGroupDAO" ref="userGroupDAO"/>
+    </bean>
 	
 </beans>

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/BaseDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/BaseDAOTest.java
@@ -20,6 +20,11 @@
 
 package it.geosolutions.geostore.core.dao;
 
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import it.geosolutions.geostore.core.dao.impl.ExternalSecurityDAOImpl;
 import it.geosolutions.geostore.core.model.Attribute;
 import it.geosolutions.geostore.core.model.Category;
 import it.geosolutions.geostore.core.model.Resource;
@@ -27,16 +32,7 @@ import it.geosolutions.geostore.core.model.StoredData;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
 import it.geosolutions.geostore.core.model.UserGroup;
-
-import java.util.List;
-import java.util.Set;
-
 import junit.framework.TestCase;
-
-import org.apache.log4j.Logger;
-import org.hibernate.Hibernate;
-import org.junit.Test;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * Class BaseDAOTest
@@ -57,6 +53,8 @@ public abstract class BaseDAOTest extends TestCase {
     protected static CategoryDAO categoryDAO;
 
     protected static SecurityDAO securityDAO;
+    
+    protected static SecurityDAO externalSecurityDAO;
 
     protected static UserAttributeDAO userAttributeDAO;
 
@@ -81,6 +79,7 @@ public abstract class BaseDAOTest extends TestCase {
                 attributeDAO = (AttributeDAO) ctx.getBean("attributeDAO");
                 categoryDAO = (CategoryDAO) ctx.getBean("categoryDAO");
                 securityDAO = (SecurityDAO) ctx.getBean("securityDAO");
+                externalSecurityDAO = (SecurityDAO) ctx.getBean("externalSecurityDAO");
                 userAttributeDAO = (UserAttributeDAO) ctx.getBean("userAttributeDAO");
                 userDAO = (UserDAO) ctx.getBean("userDAO");
                 userGroupDAO = (UserGroupDAO) ctx.getBean("userGroupDAO");
@@ -103,6 +102,7 @@ public abstract class BaseDAOTest extends TestCase {
         assertNotNull(attributeDAO);
         assertNotNull(categoryDAO);
         assertNotNull(securityDAO);
+        assertNotNull(externalSecurityDAO);
         assertNotNull(userAttributeDAO);
         assertNotNull(userDAO);
         assertNotNull(userGroupDAO);

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ExternalSecurityDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ExternalSecurityDAOTest.java
@@ -1,0 +1,316 @@
+/*
+ *  Copyright (C) 2007 - 2011 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ * 
+ *  GPLv3 + Classpath exception
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.core.dao;
+
+import it.geosolutions.geostore.core.model.Category;
+import it.geosolutions.geostore.core.model.Resource;
+import it.geosolutions.geostore.core.model.SecurityRule;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.Role;
+import java.util.Date;
+
+import org.apache.log4j.Logger;
+import org.junit.Test;
+
+/**
+ * Class SecurityDAOTest.
+ * 
+ * @author Tobia di Pisa (tobia.dipisa at geo-solutions.it)
+ * 
+ */
+public class ExternalSecurityDAOTest extends BaseDAOTest {
+
+    final private static Logger LOGGER = Logger.getLogger(ExternalSecurityDAOTest.class);
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testPersistSecurity() throws Exception {
+
+        final String NAME = "NAME";
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Persisting Security");
+        }
+
+        long categoryId;
+        long resourceId;
+        long securityId;
+
+        //
+        // PRE-PERSIST
+        //
+        {
+            Category category = new Category();
+            category.setName("MAP");
+
+            categoryDAO.persist(category);
+            categoryId = category.getId();
+
+            assertEquals(1, categoryDAO.count(null));
+            assertEquals(1, categoryDAO.findAll().size());
+
+            Resource resource = new Resource();
+            resource.setName(NAME);
+            resource.setCreation(new Date());
+            resource.setCategory(category);
+
+            resourceDAO.persist(resource);
+            resourceId = resource.getId();
+
+            assertEquals(1, resourceDAO.count(null));
+            assertEquals(1, resourceDAO.findAll().size());
+
+            // SecurityRule security = new SecurityRule();
+            // security.setCanRead(true);
+            // security.setCanWrite(true);
+            // security.setCategory(category);
+            // security.setResource(resource);
+            //
+            // // ///////////////////////////////////////////////////////
+            // // The Exception should be trapped because only one
+            // // between resource and category can be specified
+            // // ///////////////////////////////////////////////////////
+            // try{
+            // securityDAO.persist(security);
+            // fail("Exception not trapped");
+            // } catch(Exception exc) {
+            // if(LOGGER.isDebugEnabled()){
+            // LOGGER.debug("OK: exception trapped", exc);
+            // }
+            // }
+        }
+
+        //
+        // PERSIST
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+
+            externalSecurityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, externalSecurityDAO.count(null));
+            assertEquals(1, externalSecurityDAO.findAll().size());
+        }
+
+        //
+        // UPDATE
+        //
+        {
+            SecurityRule loaded = externalSecurityDAO.find(securityId);
+            assertNotNull("Can't retrieve Security", loaded);
+
+            assertTrue(loaded.isCanWrite());
+
+            loaded.setCanWrite(false);
+            externalSecurityDAO.merge(loaded);
+
+            loaded = externalSecurityDAO.find(securityId);
+            assertNotNull("Can't retrieve Security", loaded);
+            assertFalse(loaded.isCanWrite());
+        }
+
+        //
+        // LOAD, REMOVE
+        //
+        {
+            externalSecurityDAO.removeById(securityId);
+            assertNull("Security not deleted", securityDAO.find(categoryId));
+        }
+
+    }
+    
+    @Test
+    public void testPersistSecurityUsingNames() throws Exception {
+
+        final String NAME = "NAME";
+        final String USERNAME= "USER";
+        final String GROUPNAME= "GROUP";
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Persisting Security");
+        }
+
+        long categoryId;
+        long resourceId;
+        long securityId;
+        long userId;
+        long groupId;
+
+        //
+        // PRE-PERSIST
+        //
+        {
+            Category category = new Category();
+            category.setName("MAP");
+
+            categoryDAO.persist(category);
+            categoryId = category.getId();
+
+            assertEquals(1, categoryDAO.count(null));
+            assertEquals(1, categoryDAO.findAll().size());
+            
+            User user = new User();
+            user.setName(USERNAME);
+            user.setRole(Role.USER);
+            userDAO.persist(user);
+            userId = user.getId();
+            assertEquals(1, userDAO.count(null));
+            assertEquals(1, userDAO.findAll().size());
+            
+            UserGroup group = new UserGroup();
+            group.setGroupName(GROUPNAME);
+            userGroupDAO.persist(group);
+            groupId = group.getId();
+            assertEquals(1, userGroupDAO.count(null));
+            assertEquals(1, userGroupDAO.findAll().size());
+
+            Resource resource = new Resource();
+            resource.setName(NAME);
+            resource.setCreation(new Date());
+            resource.setCategory(category);
+
+            resourceDAO.persist(resource);
+            resourceId = resource.getId();
+
+            assertEquals(1, resourceDAO.count(null));
+            assertEquals(1, resourceDAO.findAll().size());
+
+        }
+
+        //
+        // PERSIST WITH USERNAME
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+            security.setUsername("testuser");
+            externalSecurityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, externalSecurityDAO.count(null));
+            assertEquals(1, externalSecurityDAO.findAll().size());
+            SecurityRule rule = externalSecurityDAO.find(securityId);
+            assertNotNull(rule);
+            assertNotNull(rule.getUsername());
+            externalSecurityDAO.removeById(securityId);
+        }
+        
+        //
+        // PERSIST WITH USER
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+            User testUser = new User();
+            testUser.setId(userId);
+            testUser.setName(USERNAME);
+            security.setUser(testUser);
+            externalSecurityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, externalSecurityDAO.count(null));
+            assertEquals(1, externalSecurityDAO.findAll().size());
+            SecurityRule rule = externalSecurityDAO.find(securityId);
+            assertNotNull(rule);
+            assertNotNull(rule.getUsername());
+            externalSecurityDAO.removeById(securityId);
+        }
+        
+        //
+        // PERSIST WITH GROUPNAME
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+            security.setGroupname("testgroup");
+            externalSecurityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, externalSecurityDAO.count(null));
+            assertEquals(1, externalSecurityDAO.findAll().size());
+            SecurityRule rule = externalSecurityDAO.find(securityId);
+            assertNotNull(rule);
+            assertNotNull(rule.getGroupname());
+            externalSecurityDAO.removeById(securityId);
+        }
+        
+        //
+        // PERSIST WITH GROUP
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+            UserGroup testGroup = new UserGroup();
+            testGroup.setId(groupId);
+            testGroup.setGroupName(GROUPNAME);
+            security.setGroup(testGroup);
+            externalSecurityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, externalSecurityDAO.count(null));
+            assertEquals(1, externalSecurityDAO.findAll().size());
+            SecurityRule rule = externalSecurityDAO.find(securityId);
+            assertNotNull(rule);
+            assertNotNull(rule.getGroupname());
+        }
+
+        //
+        // UPDATE
+        //
+        {
+            SecurityRule loaded = externalSecurityDAO.find(securityId);
+            assertNotNull("Can't retrieve Security", loaded);
+
+            assertTrue(loaded.isCanWrite());
+
+            loaded.setCanWrite(false);
+            externalSecurityDAO.merge(loaded);
+
+            loaded = externalSecurityDAO.find(securityId);
+            assertNotNull("Can't retrieve Security", loaded);
+            assertFalse(loaded.isCanWrite());
+        }
+
+        //
+        // LOAD, REMOVE
+        //
+        {
+            externalSecurityDAO.removeById(securityId);
+            assertNull("Security not deleted", externalSecurityDAO.find(categoryId));
+        }
+
+    }
+
+}

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ExternalSecurityDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ExternalSecurityDAOTest.java
@@ -79,25 +79,6 @@ public class ExternalSecurityDAOTest extends BaseDAOTest {
 
             assertEquals(1, resourceDAO.count(null));
             assertEquals(1, resourceDAO.findAll().size());
-
-            // SecurityRule security = new SecurityRule();
-            // security.setCanRead(true);
-            // security.setCanWrite(true);
-            // security.setCategory(category);
-            // security.setResource(resource);
-            //
-            // // ///////////////////////////////////////////////////////
-            // // The Exception should be trapped because only one
-            // // between resource and category can be specified
-            // // ///////////////////////////////////////////////////////
-            // try{
-            // securityDAO.persist(security);
-            // fail("Exception not trapped");
-            // } catch(Exception exc) {
-            // if(LOGGER.isDebugEnabled()){
-            // LOGGER.debug("OK: exception trapped", exc);
-            // }
-            // }
         }
 
         //

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/SecurityDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/SecurityDAOTest.java
@@ -22,7 +22,9 @@ package it.geosolutions.geostore.core.dao;
 import it.geosolutions.geostore.core.model.Category;
 import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.core.model.SecurityRule;
-
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.Role;
 import java.util.Date;
 
 import org.apache.log4j.Logger;
@@ -112,6 +114,174 @@ public class SecurityDAOTest extends BaseDAOTest {
 
             assertEquals(1, securityDAO.count(null));
             assertEquals(1, securityDAO.findAll().size());
+        }
+
+        //
+        // UPDATE
+        //
+        {
+            SecurityRule loaded = securityDAO.find(securityId);
+            assertNotNull("Can't retrieve Security", loaded);
+
+            assertTrue(loaded.isCanWrite());
+
+            loaded.setCanWrite(false);
+            securityDAO.merge(loaded);
+
+            loaded = securityDAO.find(securityId);
+            assertNotNull("Can't retrieve Security", loaded);
+            assertFalse(loaded.isCanWrite());
+        }
+
+        //
+        // LOAD, REMOVE
+        //
+        {
+            securityDAO.removeById(securityId);
+            assertNull("Security not deleted", securityDAO.find(categoryId));
+        }
+
+    }
+    
+    @Test
+    public void testPersistSecurityUsingNames() throws Exception {
+
+        final String NAME = "NAME";
+        final String USERNAME= "USER";
+        final String GROUPNAME= "GROUP";
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Persisting Security");
+        }
+
+        long categoryId;
+        long resourceId;
+        long securityId;
+        long userId;
+        long groupId;
+
+        //
+        // PRE-PERSIST
+        //
+        {
+            Category category = new Category();
+            category.setName("MAP");
+
+            categoryDAO.persist(category);
+            categoryId = category.getId();
+
+            assertEquals(1, categoryDAO.count(null));
+            assertEquals(1, categoryDAO.findAll().size());
+            
+            User user = new User();
+            user.setName(USERNAME);
+            user.setRole(Role.USER);
+            userDAO.persist(user);
+            userId = user.getId();
+            assertEquals(1, userDAO.count(null));
+            assertEquals(1, userDAO.findAll().size());
+            
+            UserGroup group = new UserGroup();
+            group.setGroupName(GROUPNAME);
+            userGroupDAO.persist(group);
+            groupId = group.getId();
+            assertEquals(1, userGroupDAO.count(null));
+            assertEquals(1, userGroupDAO.findAll().size());
+
+            Resource resource = new Resource();
+            resource.setName(NAME);
+            resource.setCreation(new Date());
+            resource.setCategory(category);
+
+            resourceDAO.persist(resource);
+            resourceId = resource.getId();
+
+            assertEquals(1, resourceDAO.count(null));
+            assertEquals(1, resourceDAO.findAll().size());
+
+        }
+
+        //
+        // PERSIST WITH USERNAME
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+            security.setUsername("testuser");
+            securityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, securityDAO.count(null));
+            assertEquals(1, securityDAO.findAll().size());
+            SecurityRule rule = securityDAO.find(securityId);
+            assertNotNull(rule);
+            assertNotNull(rule.getUsername());
+            securityDAO.removeById(securityId);
+        }
+        
+        //
+        // PERSIST WITH USER
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+            User testUser = new User();
+            testUser.setId(userId);
+            security.setUser(testUser);
+            securityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, securityDAO.count(null));
+            assertEquals(1, securityDAO.findAll().size());
+            SecurityRule rule = securityDAO.find(securityId);
+            assertNotNull(rule);
+            assertNotNull(rule.getUser());
+            securityDAO.removeById(securityId);
+        }
+        
+        //
+        // PERSIST WITH GROUPNAME
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+            security.setGroupname("testgroup");
+            securityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, securityDAO.count(null));
+            assertEquals(1, securityDAO.findAll().size());
+            SecurityRule rule = securityDAO.find(securityId);
+            assertNotNull(rule);
+            assertNotNull(rule.getGroupname());
+            securityDAO.removeById(securityId);
+        }
+        
+        //
+        // PERSIST WITH GROUP
+        //
+        {
+            SecurityRule security = new SecurityRule();
+            security.setCanRead(true);
+            security.setCanWrite(true);
+            security.setResource(resourceDAO.find(resourceId));
+            UserGroup testGroup = new UserGroup();
+            testGroup.setId(groupId);
+            security.setGroup(testGroup);
+            securityDAO.persist(security);
+            securityId = security.getId();
+
+            assertEquals(1, securityDAO.count(null));
+            assertEquals(1, securityDAO.findAll().size());
+            SecurityRule rule = securityDAO.find(securityId);
+            assertNotNull(rule);
+            assertNotNull(rule.getGroup());
         }
 
         //

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
@@ -419,7 +419,7 @@ public class ResourceServiceImpl implements ResourceService
         searchCriteria.addFetch("security");
         searchCriteria.setDistinct(true);
 
-        resourceDAO.addReadSecurityConstraints(searchCriteria, authUser);
+        securityDAO.addReadSecurityConstraints(searchCriteria, authUser);
 
         if(LOGGER.isTraceEnabled()) {
             LOGGER.trace("Get Resource List: " + searchCriteria);
@@ -457,7 +457,7 @@ public class ResourceServiceImpl implements ResourceService
         searchCriteria.addFetch("security");
         searchCriteria.setDistinct(true);
 
-        resourceDAO.addReadSecurityConstraints(searchCriteria, authUser);
+        securityDAO.addReadSecurityConstraints(searchCriteria, authUser);
 
         List<Resource> found = resourceDAO.search(searchCriteria);
 
@@ -758,7 +758,7 @@ public class ResourceServiceImpl implements ResourceService
         searchCriteria.addFetch("security");
         searchCriteria.setDistinct(true);
 
-        resourceDAO.addReadSecurityConstraints(searchCriteria, authUser);
+        securityDAO.addReadSecurityConstraints(searchCriteria, authUser);
 
         List<Resource> resources = this.resourceDAO.search(searchCriteria);
         resources = this.configResourceList(resources, includeAttributes, includeData, authUser);
@@ -825,7 +825,7 @@ public class ResourceServiceImpl implements ResourceService
         searchCriteria.addFetch("security");
         searchCriteria.setDistinct(true);
 
-        resourceDAO.addReadSecurityConstraints(searchCriteria, authUser);
+        securityDAO.addReadSecurityConstraints(searchCriteria, authUser);
         
         List<Resource> resources = this.resourceDAO.search(searchCriteria);
 
@@ -854,7 +854,7 @@ public class ResourceServiceImpl implements ResourceService
         searchCriteria.setDistinct(true);
         searchCriteria.addFetch("data");
 
-        resourceDAO.addReadSecurityConstraints(searchCriteria, authUser);
+        securityDAO.addReadSecurityConstraints(searchCriteria, authUser);
 
         List<Resource> resources = this.resourceDAO.search(searchCriteria);
 
@@ -868,7 +868,7 @@ public class ResourceServiceImpl implements ResourceService
     @Override
     public List<SecurityRule> getUserSecurityRule(String userName, long resourceId)
     {
-        return resourceDAO.findUserSecurityRule(userName, resourceId);
+        return securityDAO.findUserSecurityRule(userName, resourceId);
     }
 
     /* (non-Javadoc)
@@ -877,14 +877,14 @@ public class ResourceServiceImpl implements ResourceService
     @Override
     public List<SecurityRule> getGroupSecurityRule(List<String> groupNames, long resourceId)
     {
-        return resourceDAO.findGroupSecurityRule(groupNames, resourceId);
+        return securityDAO.findGroupSecurityRule(groupNames, resourceId);
     }
 
     @Override
     public List<SecurityRule> getSecurityRules(long id)
             throws BadRequestServiceEx, InternalErrorServiceEx
     {
-        return resourceDAO.findSecurityRules(id);
+        return securityDAO.findSecurityRules(id);
     }
 
     @Override
@@ -906,14 +906,6 @@ public class ResourceServiceImpl implements ResourceService
             // insert new rules
             for (SecurityRule rule : rules) {
                 rule.setResource(resource);
-                //Retrieve from db the entity usergroup, if the securityrule is related to a group
-                if (rule.getGroup() != null) {
-                    UserGroup ug = userGroupDAO.find(rule.getGroup().getId());
-                    if (ug == null) {
-                        throw new InternalErrorServiceEx("The usergroup having the provided Id doesn't exist");
-                    }
-                    rule.setGroup(ug);
-                }
                 securityDAO.persist(rule);
             }
         } else {
@@ -933,7 +925,7 @@ public class ResourceServiceImpl implements ResourceService
     public long getCountByFilterAndUser(SearchFilter filter, User user) throws BadRequestServiceEx, InternalErrorServiceEx
     {
         Search searchCriteria = SearchConverter.convert(filter);
-        resourceDAO.addReadSecurityConstraints(searchCriteria, user);
+        securityDAO.addReadSecurityConstraints(searchCriteria, user);
         return resourceDAO.count(searchCriteria);
     }
 
@@ -955,7 +947,7 @@ public class ResourceServiceImpl implements ResourceService
             searchCriteria.addFilterILike("name", nameLike);
         }
 
-        resourceDAO.addReadSecurityConstraints(searchCriteria, user);
+        securityDAO.addReadSecurityConstraints(searchCriteria, user);
 
         return resourceDAO.count(searchCriteria);
     }

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
@@ -906,6 +906,12 @@ public class ResourceServiceImpl implements ResourceService
             // insert new rules
             for (SecurityRule rule : rules) {
                 rule.setResource(resource);
+                if (rule.getGroup() != null) {
+                    UserGroup ug = userGroupDAO.find(rule.getGroup().getId());
+                    if (ug != null) {
+                        rule.setGroup(ug);
+                    }
+                }
                 securityDAO.persist(rule);
             }
         } else {

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/StoredDataServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/StoredDataServiceImpl.java
@@ -19,18 +19,17 @@
  */
 package it.geosolutions.geostore.services;
 
+import java.util.Date;
 import java.util.List;
-
+import org.apache.log4j.Logger;
 import it.geosolutions.geostore.core.dao.ResourceDAO;
+import it.geosolutions.geostore.core.dao.SecurityDAO;
 import it.geosolutions.geostore.core.dao.StoredDataDAO;
 import it.geosolutions.geostore.core.model.Attribute;
 import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.StoredData;
 import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
-
-import java.util.Date;
-import org.apache.log4j.Logger;
 
 /**
  * Class StoredDataServiceImpl.
@@ -45,6 +44,8 @@ public class StoredDataServiceImpl implements StoredDataService {
     private StoredDataDAO storedDataDAO;
 
     private ResourceDAO resourceDAO;
+    
+    private SecurityDAO securityDAO;
 
     /**
      * @param resourceDAO the resourceDAO to set
@@ -58,6 +59,10 @@ public class StoredDataServiceImpl implements StoredDataService {
      */
     public void setStoredDataDAO(StoredDataDAO storedDataDAO) {
         this.storedDataDAO = storedDataDAO;
+    }
+    
+    public void setSecurityDAO(SecurityDAO securityDAO) {
+        this.securityDAO = securityDAO;
     }
 
     @Override
@@ -132,7 +137,7 @@ public class StoredDataServiceImpl implements StoredDataService {
         for (StoredData data : found) {
             Resource resource = data.getResource();
             if (resource != null) {
-                List<SecurityRule> security = resourceDAO.findSecurityRules(resource.getId());
+                List<SecurityRule> security = securityDAO.findSecurityRules(resource.getId());
                 resource.setSecurity(security);
 
                 List<Attribute> attribute = resourceDAO.findAttributes(resource.getId());
@@ -149,7 +154,7 @@ public class StoredDataServiceImpl implements StoredDataService {
      */
     @Override
     public List<SecurityRule> getUserSecurityRule(String name, long storedDataId) {
-        return storedDataDAO.findUserSecurityRule(name, storedDataId);
+        return securityDAO.findUserSecurityRule(name, storedDataId);
     }
 
     /* (non-Javadoc)
@@ -157,7 +162,7 @@ public class StoredDataServiceImpl implements StoredDataService {
      */
     @Override
     public List<SecurityRule> getGroupSecurityRule(List<String> groupNames, long storedDataId) {
-        return storedDataDAO.findGroupSecurityRule(groupNames, storedDataId);
+        return securityDAO.findGroupSecurityRule(groupNames, storedDataId);
     }
 
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTServiceImpl.java
@@ -147,7 +147,7 @@ public abstract class RESTServiceImpl{
             if (userSecurityRules != null && userSecurityRules.size() > 0){
             	for(SecurityRule sr : userSecurityRules){
             		// the getUserSecurityRules returns all rules instead of user rules. So the user name check is necessary until problem with DAO is solved
-	                if (sr.isCanWrite() && sr.getUser() != null && sr.getUser().getName() == authUser.getName()){
+	                if (sr.isCanWrite() && sr.getUser() != null && sr.getUser().getName().equals(authUser.getName())){
 	                    return true;
 	                }
             	}
@@ -192,7 +192,7 @@ public abstract class RESTServiceImpl{
             if (userSecurityRules != null && userSecurityRules.size() > 0){
             	// the getUserSecurityRules returns all rules instead of user rules. So the user name check is necessary until problem with DAO is solved
                 for(SecurityRule sr : userSecurityRules){
-	                if (sr.isCanRead() && sr.getUser() != null && sr.getUser().getName() == authUser.getName()){
+	                if (sr.isCanRead() && sr.getUser() != null && sr.getUser().getName().equals(authUser.getName())){
 	                    return true;
 	                }
                 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/utils/Convert.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/utils/Convert.java
@@ -139,12 +139,14 @@ public class Convert {
 			if(rule.getUser() != null) {
 				User user = new User();
 				user.setId(rule.getUser().getId());
+				user.setName(rule.getUser().getName());
 				securityRule.setUser(user);
 			}
 			
 			if(rule.getGroup() != null) {
 				UserGroup group = new UserGroup();
 				group.setId(rule.getGroup().getId());
+				group.setGroupName(rule.getGroup().getGroupName());
 				securityRule.setGroup(group);
 			}
 			


### PR DESCRIPTION
 * changes to db security table to add explicit fields for username and groupname (to be used instead of ids when authentication is externalized)
 * centralized security stuff in SecurityDAO, so that we can plug a new implementation for external authentication
 * removed some dependencies from user / groups id where not needed
 * introduced ExternalSecurityDAO implementation