### PR TITLE
#195: Initial implementation of read-only LDAP User and UserGroup DAOs

### DIFF
--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/User.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/User.java
@@ -287,6 +287,7 @@ public class User implements Serializable {
      * 
      * @return
      */
+    @XmlTransient
     public boolean isTrusted() {
         return trusted;
     }

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/UserGroup.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/UserGroup.java
@@ -29,8 +29,8 @@
 package it.geosolutions.geostore.core.model;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -42,7 +42,6 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
-
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Index;
@@ -85,6 +84,22 @@ public class UserGroup implements Serializable {
     @Column(nullable = false,updatable =true)
     private boolean enabled=true;
     
+    private transient List<User> users = new ArrayList<User>();
+    
+    @XmlTransient
+    public List<User> getUsers() {
+        return users;
+    }
+
+    /**
+     * Users belonging to this UserGroup.
+     * 
+     * @param users
+     */
+    public void setUsers(List<User> users) {
+        this.users = users;
+    }
+
     /**
      * 
      * @return the enabled flag

--- a/src/core/model/src/test/java/it/geosolutions/geostore/core/model/UserTest.java
+++ b/src/core/model/src/test/java/it/geosolutions/geostore/core/model/UserTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007 - 2011 GeoSolutions S.A.S.
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
  *  http://www.geo-solutions.it
  * 
  *  GPLv3 + Classpath exception
@@ -19,42 +19,31 @@
  */
 package it.geosolutions.geostore.core.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import java.util.Arrays;
 import org.junit.Test;
 
-/**
- * 
- * @author ETj (etj at geo-solutions.it)
- */
-public class UserGroupTest {
+public class UserTest {
+    private final static Marshaler<User> MARSHALER = new Marshaler<User>(User.class);
 
-    private final static Marshaler<UserGroup> MARSHALER = new Marshaler<UserGroup>(UserGroup.class);
-
-    public UserGroupTest() {
+    public UserTest() {
     }
 
     @Test
     public void testMarshallingString() throws Exception {
-    	UserGroup g0 = new UserGroup();
-    	g0.setGroupName("group name");
-    	g0.setDescription("desciption");
-    	g0.setEnabled(true);
-    	
-    	User u0 = new User();
-    	u0.setName("user name");
-    	u0.setEnabled(true);
-    	g0.setUsers(Arrays.asList(u0));
-    	
-        doTheTest(g0);
+        User u0 = new User();
+        u0.setName("user name");
+        u0.setEnabled(true);
+        u0.setTrusted(true);
+        
+        doTheTest(u0);
     }
 
-    private void doTheTest(UserGroup g0) {
-        String s = MARSHALER.marshal(g0);
-        UserGroup ug = MARSHALER.unmarshal(s);
-        assertEquals(0, ug.getUsers().size());
-        assertTrue(g0.equals(ug));
-    }
+    private void doTheTest(User u0) {
+        String s = MARSHALER.marshal(u0);
+        User u = MARSHALER.unmarshal(s);
 
-}	
+        assertTrue(u0.equals(u));
+        assertFalse(u.isTrusted());
+    }
+}

--- a/src/core/persistence/pom.xml
+++ b/src/core/persistence/pom.xml
@@ -108,6 +108,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
         </dependency>
+        
+        <dependency>
+             <groupId>org.springframework.security</groupId>
+             <artifactId>spring-security-ldap</artifactId>
+       </dependency>
 
 		<!-- =========================================================== -->
 		<!--     SPRING SECURITY                                         -->

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/LdapBaseDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/LdapBaseDAOImpl.java
@@ -1,0 +1,326 @@
+/*
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package it.geosolutions.geostore.core.dao.ldap.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.naming.directory.DirContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.ldap.control.SortControlDirContextProcessor;
+import org.springframework.ldap.core.ContextSource;
+import org.springframework.ldap.core.DirContextProcessor;
+import org.springframework.ldap.core.LdapTemplate;
+import com.googlecode.genericdao.search.Filter;
+import com.googlecode.genericdao.search.ISearch;
+
+/**
+ * Class LdapBaseDAOImpl.
+ * Base class for LDAP (read-only) based DAOs.
+ * 
+ * @author Mauro Bartolomeoli (mauro.bartolomeoli at geo-solutions.it)
+ */
+public abstract class LdapBaseDAOImpl {
+    
+    public static final class NullDirContextProcessor implements DirContextProcessor {
+        public void postProcess(DirContext ctx) {
+            // Do nothing
+        }
+
+        public void preProcess(DirContext ctx) {
+            // Do nothing
+        }
+    }
+    
+    protected String searchBase = "";
+    protected String baseFilter = "cn=*";
+    protected  String nameAttribute = "cn";
+    protected  String descriptionAttribute = "description";
+    protected boolean sortEnabled = false;
+    
+    protected ContextSource contextSource;
+    protected LdapTemplate template;
+    
+    public LdapBaseDAOImpl(ContextSource contextSource) {
+        this.contextSource = contextSource;
+        template = new LdapTemplate(contextSource);
+    }
+    
+    public String getSearchBase() {
+        return searchBase;
+    }
+
+    /**
+     * LDAP root for all searches.
+     *  
+     * @param searchBase
+     */
+    public void setSearchBase(String searchBase) {
+        this.searchBase = searchBase;
+    }
+
+    public String getBaseFilter() {
+        return baseFilter;
+    }
+
+    /**
+     * Filter applied to all searches (eventually combined with a more specific filter).
+     * 
+     * @param filter
+     */
+    public void setBaseFilter(String filter) {
+        this.baseFilter = filter;
+    }
+
+    public String getNameAttribute() {
+        return nameAttribute;
+    }
+
+    /**
+     * Attribute to be mapped to the GeoStore object name.
+     * 
+     * @param nameAttribute
+     */
+    public void setNameAttribute(String nameAttribute) {
+        this.nameAttribute = nameAttribute;
+    }
+
+    public String getDescriptionAttribute() {
+        return descriptionAttribute;
+    }
+
+    /**
+     * Attribute to be mapped to the GeoStore object description.
+     * 
+     * @param nameAttribute
+     */
+    public void setDescriptionAttribute(String descriptionAttribute) {
+        this.descriptionAttribute = descriptionAttribute;
+    }
+    
+    /**
+     * Builds a proper processor for the given search.
+     * Implements sorting if enabled.
+     * 
+     * @param search
+     * @return
+     */
+    protected DirContextProcessor getProcessorForSearch(ISearch search) {
+        if (sortEnabled && search.getSorts() != null && search.getSorts().size() == 1) {
+            return new SortControlDirContextProcessor(nameAttribute);
+        }
+        return new NullDirContextProcessor();
+    }
+    
+    public boolean isSortEnabled() {
+        return sortEnabled;
+    }
+
+    /**
+     * Enables LDAP-side sorting (to be enabled if supported by the LDAP server).
+     * 
+     * @param sortEnabled
+     */
+    public void setSortEnabled(boolean sortEnabled) {
+        this.sortEnabled = sortEnabled;
+    }
+
+    /**
+     * Returns a combined filter (AND) from the given two.
+     * If any is empty, the other filter is returned.
+     * 
+     * @param baseFilter
+     * @param ldapFilter
+     * @return
+     */
+    protected String combineFilters(String baseFilter, String ldapFilter) {
+        if ("".equals(baseFilter)) {
+            return ldapFilter;
+        }
+        if ("".equals(ldapFilter)) {
+            return baseFilter;
+        }
+        return "(& ("+baseFilter+") ("+ldapFilter+"))";
+    }
+
+    /**
+     * Creates an LDAP filter for a GenericDAO search.
+     * 
+     * @param search
+     * @return
+     */
+    protected String getLdapFilter(ISearch search, Map<String, Object> propertyMapper) {
+        String currentFilter = "";
+        for (Filter filter : search.getFilters()) {
+            currentFilter = combineFilters(currentFilter, getLdapFilter(filter, propertyMapper));
+        }
+        if ("".equals(currentFilter)) {
+            return "(objectClass=*)";
+        }
+        return currentFilter;
+    }
+
+    
+    /**
+     * Creates an LDAP filter for a GenericDAO filter
+     * .
+     * @param filter
+     * @return
+     */
+    private String getLdapFilter(Filter filter, Map<String, Object> propertyMapper) {
+        String property = filter.getProperty();
+        Map<String, Object> mapper = propertyMapper;
+        if (propertyMapper.containsKey(property)) {
+            if (propertyMapper.get(property) instanceof String) {
+                property = (String)propertyMapper.get(property);
+            } else if (propertyMapper.get(property) instanceof Map) {
+                mapper = (Map)propertyMapper.get(property);
+            }
+        }
+        switch(filter.getOperator()) {
+            case Filter.OP_EQUAL:
+                return property + "=" + filter.getValue().toString();
+            case Filter.OP_SOME:
+                return getLdapFilter((Filter)filter.getValue(), mapper);
+            case Filter.OP_ILIKE:
+                return property + "=" + filter.getValue().toString().replaceAll("[%]", "*");
+            //TODO: implement all operators
+        }
+        return "";
+    }
+    
+    /**
+     * Returns true if the given search has one or more filters on a nested object.
+     * 
+     * @param search
+     * @return
+     */
+    protected boolean isNested(ISearch search) {
+        boolean found = false;
+        for (Filter filter : search.getFilters()) {
+            found = found || isNested(filter);
+        }
+        return found;
+    }
+    
+    /**
+    * Returns true if the given filter works on a nested object.
+    * 
+    * @param filter
+    * @return
+    */
+    private boolean isNested(Filter filter) {
+        if (filter.getOperator() == Filter.OP_SOME || filter.getOperator() == Filter.OP_ALL) {
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * If the given search has filters working on nested objects, 
+     * replaces them with the nested filter.
+     * @param search
+     * @return
+     */
+    protected ISearch getNestedSearch(ISearch search) {
+        List<Filter> newFilters = new ArrayList<>();
+        for (Filter filter : search.getFilters()) {
+            Filter nestedFilter = getNestedFilter(filter);
+            if (nestedFilter != null) {
+                newFilters.add(nestedFilter);
+            } else {
+                newFilters.add(filter);
+            }
+        }
+        search.getFilters().clear();
+        search.getFilters().addAll(newFilters);
+        return search;
+    }
+    
+    /**
+     * Returns the internal filter of a nested filter, null otherwise.
+     * 
+     * @param filter
+     * @return
+     */
+    private Filter getNestedFilter(Filter filter) {
+        if (filter.getOperator() == Filter.OP_SOME || filter.getOperator() == Filter.OP_ALL) {
+            return (Filter)filter.getValue();
+        }
+        return null;
+    }
+
+    /**
+     * Creates an SpEL expression for a GenericDAO search.
+     * 
+     * @param search
+     * @return
+     */
+    protected Expression getSearchExpression(ISearch search) {
+        String expression = "";
+        for (Filter filter: search.getFilters()) {
+            expression = combineExpressions(expression, getSearchExpression(filter));
+        }
+        if ("".equals(expression)) {
+            expression = "true";
+        }
+        ExpressionParser parser = new SpelExpressionParser();
+        return parser.parseExpression(expression);
+    }
+
+    /**
+     * Returns a combined expression (AND) from the given two.
+     * If any is empty, the other filter is returned.
+     * 
+     * @param expression
+     * @param searchExpression
+     * @return
+     */
+    protected String combineExpressions(String expression, String searchExpression) {
+        if ("".equals(expression)) {
+            return searchExpression;
+        }
+        if ("".equals(searchExpression)) {
+            return expression;
+        }
+        return "("+expression+") && ("+searchExpression+")";
+    }
+
+    /**
+     * Creates an SpEL expression for a GenericDAO filter.
+     *
+     * @param filter
+     * @return
+     */
+    private String getSearchExpression(Filter filter) {
+        switch(filter.getOperator()) {
+            case Filter.OP_EQUAL:
+                return filter.getProperty() + "=='" + filter.getValue().toString() +"'";
+            case Filter.OP_ILIKE:
+                return filter.getProperty() + " matches '^" + filter.getValue().toString().replace("*", ".*") +"$'";
+            //TODO: implement all operators
+        }
+        return "";
+    }
+
+}

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserDAOImpl.java
@@ -91,6 +91,7 @@ public class UserDAOImpl extends LdapBaseDAOImpl implements UserDAO {
      */
     @Override
     public void persist(User... entities) {
+        throw new UnsupportedOperationException();
      // NOT SUPPORTED
     }
 
@@ -174,8 +175,7 @@ public class UserDAOImpl extends LdapBaseDAOImpl implements UserDAO {
      */
     @Override
     public User merge(User entity) {
-        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
-        return entity;
+        throw new UnsupportedOperationException();
     }
 
     /*
@@ -185,8 +185,7 @@ public class UserDAOImpl extends LdapBaseDAOImpl implements UserDAO {
      */
     @Override
     public boolean remove(User entity) {
-        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
-        return true;
+        throw new UnsupportedOperationException();
     }
 
     /*
@@ -196,8 +195,7 @@ public class UserDAOImpl extends LdapBaseDAOImpl implements UserDAO {
      */
     @Override
     public boolean removeById(Long id) {
-        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
-        return true;
+        throw new UnsupportedOperationException();
     }
 
     /*
@@ -219,8 +217,7 @@ public class UserDAOImpl extends LdapBaseDAOImpl implements UserDAO {
      */
     @Override
     public User[] save(User... entities) {
-        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
-        return entities;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserDAOImpl.java
@@ -1,0 +1,260 @@
+/*
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.core.dao.ldap.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.naming.directory.SearchControls;
+import org.springframework.ldap.core.ContextSource;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.core.DirContextProcessor;
+import org.springframework.ldap.core.support.AbstractContextMapper;
+import com.googlecode.genericdao.search.ISearch;
+import it.geosolutions.geostore.core.dao.UserDAO;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserAttribute;
+import it.geosolutions.geostore.core.model.UserGroup;
+
+/**
+ * Class UserDAOImpl.
+ * LDAP (read-only) implementation of UserDAO.
+ * Allows fetching User from an LDAP repository.
+ * 
+ * @author Mauro Bartolomeoli (mauro.bartolomeoli at geo-solutions.it)
+ */
+public class UserDAOImpl extends LdapBaseDAOImpl implements UserDAO {
+    protected Map<String, String> attributesMapper = new HashMap<String, String>();
+    private Pattern memberPattern = Pattern.compile("^(.*)$");
+    
+    UserGroupDAOImpl userGroupDAO = null;
+    
+    public UserDAOImpl(ContextSource contextSource) {
+        super(contextSource);
+    }
+    
+    public void setUserGroupDAO(UserGroupDAOImpl userGroupDAO) {
+        if (this.userGroupDAO == null) {
+            this.userGroupDAO = userGroupDAO;
+            userGroupDAO.setUserDAO(this);
+        }
+    }
+    
+    /**
+     * Sets regular expression used to extract the member user name from a member LDAP attribute.
+     * The LDAP attribute can contain a DN, so this is useful to extract the real member name from it.
+     * 
+     * e.g. ^(uid=[^,]+.*)$ extracts the uid fragment of a DN
+     * @param memberPattern
+     */
+    public void setMemberPattern(String memberPattern) {
+        this.memberPattern = Pattern.compile(memberPattern);
+    }
+
+    public Map<String, String> getAttributesMapper() {
+        return attributesMapper;
+    }
+
+    /**
+     * Mapping of LDAP attribute names to geostore attribute names.
+     * 
+     * @param attributesMapper
+     */
+    public void setAttributesMapper(Map<String, String> attributesMapper) {
+        this.attributesMapper = attributesMapper;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#persist(T[])
+     */
+    @Override
+    public void persist(User... entities) {
+     // NOT SUPPORTED
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#findAll()
+     */
+    @Override
+    public List<User> findAll() {
+        return ldapSearch(baseFilter, new NullDirContextProcessor());
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#search(com.trg.search.ISearch)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<User> search(ISearch search) {
+        if (isNested(search)) {
+            List<User> users = new ArrayList<User>();
+            for(UserGroup group :  userGroupDAO.search(getNestedSearch(search))) {
+                users.addAll(group.getUsers());
+            }
+            return users;
+        } else {
+            return ldapSearch(combineFilters(baseFilter, getLdapFilter(search, getPropertyMapper())), getProcessorForSearch(search));
+        }
+    }
+
+    /**
+     * Maps user properties to LDAP properties.
+     * @return
+     */
+    private Map<String, Object> getPropertyMapper() {
+        Map<String, Object> mapper = new HashMap<>();
+        mapper.put("name", nameAttribute);
+        for(String ldap : attributesMapper.keySet()) {
+            mapper.put(attributesMapper.get(ldap), ldap);
+        }
+        // sub-mapper for groups properties
+        if (userGroupDAO != null) {
+            mapper.put("groups", userGroupDAO.getPropertyMapper());
+        }
+        return mapper;
+    }
+
+    protected List<User> ldapSearch(String filter, DirContextProcessor processor) {
+        SearchControls controls = new SearchControls();
+        controls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        return template.search(searchBase, filter, controls, new AbstractContextMapper() {
+            int counter = 1;
+            @Override
+            protected User doMapFromContext(DirContextOperations ctx) {
+                User user = new User();
+                user.setId((long)counter++); // TODO: optionally map an attribute to the id
+                user.setEnabled(true);
+                user.setName(ctx.getStringAttribute(nameAttribute));
+                List<UserAttribute> attributes = new ArrayList<UserAttribute>();
+                for (String ldapAttr : attributesMapper.keySet()) {
+                    String value = ctx.getStringAttribute(ldapAttr);
+                    String userAttr = attributesMapper.get(ldapAttr);
+                    UserAttribute attr = new UserAttribute();
+                    attr.setName(userAttr);
+                    attr.setValue(value);
+                    attributes.add(attr);
+                }
+                user.setAttribute(attributes);
+                return user;
+            }
+            
+        }, processor);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#merge(java.lang.Object)
+     */
+    @Override
+    public User merge(User entity) {
+        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
+        return entity;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#remove(java.lang.Object)
+     */
+    @Override
+    public boolean remove(User entity) {
+        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
+        return true;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#removeById(java.io.Serializable)
+     */
+    @Override
+    public boolean removeById(Long id) {
+        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
+        return true;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#find(java.io.Serializable)
+     */
+    @Override
+    public User find(Long id) {
+        // Not supported yet, we can eventually map an LDAP attribute and use it as an ID
+        // If needed in any use case
+        return null;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#save(T[])
+     */
+    @Override
+    public User[] save(User... entities) {
+        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
+        return entities;
+    }
+
+    @Override
+    public int count(ISearch search) {
+        // TODO: optimize
+        return search(search).size();
+    }
+
+    /**
+     * Create a User object from a group member name.
+     * 
+     * @param member
+     * @return
+     */
+    public User createMemberUser(String member) {
+        User user = new User();
+        user.setEnabled(true);
+        user.setId(-1L);
+        user.setName(getMemberName(member));
+        return user;
+    }
+
+    /**
+     * Extracts a User name from a member name, using the memberPattern regexp.
+     * 
+     * @param member
+     * @return
+     */
+    private String getMemberName(String member) {
+        Matcher m = memberPattern.matcher(member);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return member;
+    }
+
+}

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
@@ -1,0 +1,257 @@
+/*
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.core.dao.ldap.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.naming.directory.SearchControls;
+import org.springframework.expression.Expression;
+import org.springframework.ldap.core.ContextSource;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.core.DirContextProcessor;
+import org.springframework.ldap.core.support.AbstractContextMapper;
+import com.googlecode.genericdao.search.ISearch;
+import it.geosolutions.geostore.core.dao.UserGroupDAO;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.GroupReservedNames;
+
+/**
+ * Class UserGroupDAOImpl.
+ * LDAP (read-only) implementation of UserGroupDAO.
+ * Allows fetching UserGroup from an LDAP repository.
+ * 
+ * @author Mauro Bartolomeoli (mauro.bartolomeoli at geo-solutions.it)
+ */
+public class UserGroupDAOImpl  extends LdapBaseDAOImpl implements UserGroupDAO {
+    
+
+    private boolean addEveryOneGroup = false;
+    private String memberAttribute = "member";
+    private UserDAOImpl userDAO = null;
+    
+    public UserGroupDAOImpl(ContextSource contextSource) {
+        super(contextSource);
+    }
+    
+    public String getMemberAttribute() {
+        return memberAttribute;
+    }
+
+    /**
+     * LDAP Attribute containing the list of members of a group.
+     * A multi-valued attribute. Each value should identify a user, either through its DN or simple name.
+     * 
+     * @param memberAttribute
+     */
+    public void setMemberAttribute(String memberAttribute) {
+        this.memberAttribute = memberAttribute;
+    }
+
+
+
+    public void setUserDAO(UserDAOImpl userDAO) {
+        if (this.userDAO == null) {
+            this.userDAO = userDAO;
+            userDAO.setUserGroupDAO(this);
+        }
+    }
+
+    public boolean isAddEveryOneGroup() {
+        return addEveryOneGroup;
+    }
+
+    /**
+     * Add everyOne group to search results.
+     * 
+     * @param addEveryOneGroup
+     */
+    public void setAddEveryOneGroup(boolean addEveryOneGroup) {
+        this.addEveryOneGroup = addEveryOneGroup;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#persist(T[])
+     */
+    @Override
+    public void persist(UserGroup... entities) {
+        // NOT SUPPORTED
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#findAll()
+     */
+    @Override
+    public List<UserGroup> findAll() {
+        return addEveryOne(
+            ldapSearch(baseFilter, new NullDirContextProcessor()),
+            null
+        );
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#find(java.io.Serializable)
+     */
+    @Override
+    public UserGroup find(Long id) {
+        // Not supported yet, we can eventually map an LDAP attribute and use it as an ID
+        // If needed in any use case
+        return null;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#search(com.trg.search.ISearch)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<UserGroup> search(ISearch search) {
+        return addEveryOne(
+            ldapSearch(combineFilters(baseFilter, getLdapFilter(search, getPropertyMapper())), getProcessorForSearch(search)),
+            search
+        );
+    }
+    
+    /**
+     * Maps group properties to LDAP properties.
+     * @return
+     */
+    public Map<String, Object> getPropertyMapper() {
+        Map<String, Object> mapper = new HashMap<>();
+        mapper.put("groupName", nameAttribute);
+        mapper.put("description", descriptionAttribute);
+        return mapper;
+    }
+
+    protected List<UserGroup> ldapSearch(String filter, DirContextProcessor processor) {
+        SearchControls controls = new SearchControls();
+        controls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        return template.search(searchBase, filter, controls, new AbstractContextMapper() {
+            int counter = 1;
+            @Override
+            protected UserGroup doMapFromContext(DirContextOperations ctx) {
+                UserGroup group = new UserGroup();
+                group.setId((long)counter++); // TODO: optionally map an attribute to the id
+                group.setEnabled(true);
+                group.setGroupName(ctx.getStringAttribute(nameAttribute));
+                group.setDescription(ctx.getStringAttribute(descriptionAttribute));
+                // if we bind users to groups through member attribute on groups, we fill the users list here
+                if (!"".equals(memberAttribute) && userDAO != null && ctx.getStringAttributes(memberAttribute) != null) {
+                    for(String member : ctx.getStringAttributes(memberAttribute)) {
+                        group.getUsers().add(userDAO.createMemberUser(member));
+                    }
+                }
+                return group;
+            }
+            
+        }, processor);
+    }
+
+    /**
+     * Add the everyOne group to the LDAP returned list.
+     * 
+     * @param groups
+     * @param filters
+     * @return
+     */
+    private List<UserGroup> addEveryOne(List<UserGroup> groups, ISearch search) {
+        UserGroup everyoneGroup = new UserGroup();
+        everyoneGroup.setGroupName(GroupReservedNames.EVERYONE.groupName());
+        everyoneGroup.setId((long)(groups.size() + 1));
+        everyoneGroup.setEnabled(true);
+        if (search == null || matchFilters(everyoneGroup, search)) {
+            boolean everyoneFound = false;
+            for (UserGroup group : groups) {
+                if (group.getGroupName().equals(everyoneGroup.getGroupName())) {
+                    everyoneFound = true;
+                }
+            }
+            if (!everyoneFound && addEveryOneGroup) {
+                groups.add(everyoneGroup);
+            }
+        }
+        return groups;
+    }
+
+    /**
+     * Returns true if the group matches the given filters.
+     * 
+     * @param group
+     * @param filters
+     * @return
+     */
+    protected boolean matchFilters(UserGroup group, ISearch search) {
+        Expression matchExpression = getSearchExpression(search);
+        return matchExpression.getValue(group, Boolean.class);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#merge(java.lang.Object)
+     */
+    @Override
+    public UserGroup merge(UserGroup entity) {
+        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
+        return entity;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#remove(java.lang.Object)
+     */
+    @Override
+    public boolean remove(UserGroup entity) {
+        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
+        return true;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.trg.dao.jpa.GenericDAOImpl#removeById(java.io.Serializable)
+     */
+    @Override
+    public boolean removeById(Long id) {
+        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
+        return true;
+    }
+
+    @Override
+    public UserGroup[] save(UserGroup... entities) {
+        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
+        return entities;
+    }
+
+    @Override
+    public int count(ISearch search) {
+        // TODO: optimize
+        return search(search).size();
+    }
+
+}

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
@@ -117,7 +117,7 @@ public class UserGroupDAOImpl  extends LdapBaseDAOImpl implements UserGroupDAO {
      */
     @Override
     public UserGroup find(Long id) {
-        // Not supported yet, we can eventually map an LDAP attribute and use it as an ID
+        // Not supported yet, we can possibly map an LDAP attribute and use it as an ID
         // If needed in any use case
         return null;
     }

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
@@ -94,7 +94,7 @@ public class UserGroupDAOImpl  extends LdapBaseDAOImpl implements UserGroupDAO {
      */
     @Override
     public void persist(UserGroup... entities) {
-        // NOT SUPPORTED
+        throw new UnsupportedOperationException();
     }
 
     /*
@@ -216,8 +216,7 @@ public class UserGroupDAOImpl  extends LdapBaseDAOImpl implements UserGroupDAO {
      */
     @Override
     public UserGroup merge(UserGroup entity) {
-        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
-        return entity;
+        throw new UnsupportedOperationException();
     }
 
     /*
@@ -227,8 +226,7 @@ public class UserGroupDAOImpl  extends LdapBaseDAOImpl implements UserGroupDAO {
      */
     @Override
     public boolean remove(UserGroup entity) {
-        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
-        return true;
+        throw new UnsupportedOperationException();
     }
 
     /*
@@ -238,14 +236,12 @@ public class UserGroupDAOImpl  extends LdapBaseDAOImpl implements UserGroupDAO {
      */
     @Override
     public boolean removeById(Long id) {
-        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
-        return true;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public UserGroup[] save(UserGroup... entities) {
-        // DO NOTHING: PERSITENCE IS NOT SUPPORTED
-        return entities;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/UserDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/UserDAOTest.java
@@ -1,0 +1,217 @@
+/*
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ * 
+ *  GPLv3 + Classpath exception
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.core.dao.ldap;
+
+import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import org.junit.Test;
+import org.springframework.ldap.core.DirContextAdapter;
+import com.googlecode.genericdao.search.Filter;
+import com.googlecode.genericdao.search.Search;
+import it.geosolutions.geostore.core.dao.ldap.impl.UserDAOImpl;
+import it.geosolutions.geostore.core.dao.ldap.impl.UserGroupDAOImpl;
+import it.geosolutions.geostore.core.ldap.IterableNamingEnumeration;
+import it.geosolutions.geostore.core.ldap.MockContextSource;
+import it.geosolutions.geostore.core.ldap.MockDirContextOperations;
+import it.geosolutions.geostore.core.model.User;
+
+public class UserDAOTest {
+    
+    DirContext buildContextForUsers() {
+        return new DirContextAdapter() {
+            @Override
+            public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons)
+                    throws NamingException {
+                if ("ou=users".equals(name)) {
+                    if("cn=*".equals(filter)) {
+                        SearchResult sr1 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=username,ou=users";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "username";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        SearchResult sr2 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=username2,ou=users";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "username2";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Arrays.asList(sr1, sr2));
+                    } else if ("(& (cn=*) (cn=username))".equals(filter)) {
+                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=username,ou=users";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "username";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Collections.singletonList(sr));
+                    } 
+                }
+                return new IterableNamingEnumeration(Collections.EMPTY_LIST);
+            }
+        };
+    }
+    
+    DirContext buildContextForGroups(final String memberString) {
+        return new DirContextAdapter() {
+            @Override
+            public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons)
+                    throws NamingException {
+                if ("ou=groups".equals(name)) {
+                    if ("(& (cn=*) (cn=group))".equals(filter)) {
+                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group";
+                                }
+                                return "";
+                            }
+
+                            @Override
+                            public String[] getStringAttributes(String name) {
+                                if ("member".equals(name)) {
+                                    return new String[] {memberString == null ? "username" : memberString};
+                                }
+                                return new String[] {};
+                            }
+                            
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Collections.singletonList(sr));
+                    }
+                }
+                return new IterableNamingEnumeration(Collections.EMPTY_LIST);
+            }
+        };
+    }
+    
+    @Test
+    public void testFindAll() {
+        UserDAOImpl userDAO = new UserDAOImpl(new MockContextSource(buildContextForUsers()));
+        userDAO.setSearchBase("ou=users");
+        List<User> users = userDAO.findAll();
+        assertEquals(2, users.size());
+        User user = users.get(0);
+        assertEquals("username", user.getName());
+    }
+    
+    @Test
+    public void testSearchByname() {
+        UserDAOImpl userDAO = new UserDAOImpl(new MockContextSource(buildContextForUsers()));
+        userDAO.setSearchBase("ou=users");
+        Search search = new Search(User.class);
+        List<User> users = userDAO.search(search.addFilter(Filter.equal("name", "username")));
+        assertEquals(1, users.size());
+        User user = users.get(0);
+        assertEquals("username", user.getName());
+    }
+    
+    @Test
+    public void testAttributesMapper() {
+        UserDAOImpl userDAO = new UserDAOImpl(new MockContextSource(buildContextForUsers()));
+        Map<String, String> mapper = new HashMap<String, String>();
+        mapper.put("mail", "email");
+        userDAO.setAttributesMapper(mapper);
+        userDAO.setSearchBase("ou=users");
+        List<User> users = userDAO.findAll();
+        User user = users.get(0);
+        assertEquals("username", user.getName());
+        assertEquals(1, user.getAttribute().size());
+        assertEquals("email", user.getAttribute().get(0).getName());
+    }
+    
+    @Test
+    public void testSearchByGroup() {
+        UserGroupDAOImpl userGroupDAO = new UserGroupDAOImpl(new MockContextSource(buildContextForGroups(null)));
+        userGroupDAO.setSearchBase("ou=groups");
+        UserDAOImpl userDAO = new UserDAOImpl(new MockContextSource(buildContextForUsers()));
+        userDAO.setUserGroupDAO(userGroupDAO);
+        userDAO.setSearchBase("ou=users");
+        userGroupDAO.setUserDAO(userDAO);
+        Search search = new Search(User.class);
+        List<User> users = userDAO.search(search.addFilter(Filter.some("groups", Filter.equal("groupName", "group"))));
+        assertEquals(1, users.size());
+        User user = users.get(0);
+        assertEquals("username", user.getName());
+    }
+    
+    @Test
+    public void testMemberPattern() {
+        UserGroupDAOImpl userGroupDAO = new UserGroupDAOImpl(new MockContextSource(buildContextForGroups("uid=username,ou=users")));
+        userGroupDAO.setSearchBase("ou=groups");
+        UserDAOImpl userDAO = new UserDAOImpl(new MockContextSource(buildContextForUsers()));
+        userDAO.setUserGroupDAO(userGroupDAO);
+        userDAO.setSearchBase("ou=users");
+        userDAO.setMemberPattern("^uid=([^,]+).*$");
+        userGroupDAO.setUserDAO(userDAO);
+        Search search = new Search(User.class);
+        List<User> users = userDAO.search(search.addFilter(Filter.some("groups", Filter.equal("groupName", "group"))));
+        assertEquals(1, users.size());
+        User user = users.get(0);
+        assertEquals("username", user.getName());
+    }
+}

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/UserGroupDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/UserGroupDAOTest.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (C) 2019 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ * 
+ *  GPLv3 + Classpath exception
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.core.dao.ldap;
+
+import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import org.junit.Test;
+import org.springframework.ldap.core.DirContextAdapter;
+import com.googlecode.genericdao.search.Filter;
+import com.googlecode.genericdao.search.Search;
+import it.geosolutions.geostore.core.dao.ldap.impl.UserGroupDAOImpl;
+import it.geosolutions.geostore.core.ldap.IterableNamingEnumeration;
+import it.geosolutions.geostore.core.ldap.MockContextSource;
+import it.geosolutions.geostore.core.ldap.MockDirContextOperations;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserGroup;
+
+public class UserGroupDAOTest {
+    DirContext buildContextForGroups() {
+        return new DirContextAdapter() {
+            @Override
+            public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons)
+                    throws NamingException {
+                if ("ou=groups".equals(name)) {
+                    if ("cn=*".equals(filter)) {
+                        SearchResult sr1 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group";
+                                }
+                                return "";
+                            }
+
+                        }, new BasicAttributes());
+                        SearchResult sr2 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group2,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group2";
+                                }
+                                return "";
+                            }
+
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Arrays.asList(sr1, sr2));
+                    } else if ("(& (cn=*) (cn=group))".equals(filter)) {
+                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Collections.singletonList(sr));
+                    } 
+                }
+                return new IterableNamingEnumeration(Collections.EMPTY_LIST);
+            }
+        };
+    }
+    
+    @Test
+    public void testFindAll() {
+        UserGroupDAOImpl userGroupDAO = new UserGroupDAOImpl(new MockContextSource(buildContextForGroups()));
+        userGroupDAO.setSearchBase("ou=groups");
+        List<UserGroup> groups = userGroupDAO.findAll();
+        assertEquals(2, groups.size());
+        UserGroup group = groups.get(0);
+        assertEquals("group", group.getGroupName());
+    }
+    
+    @Test
+    public void testSearchByname() {
+        UserGroupDAOImpl userGroupDAO = new UserGroupDAOImpl(new MockContextSource(buildContextForGroups()));
+        userGroupDAO.setSearchBase("ou=groups");
+        Search search = new Search(User.class);
+        List<UserGroup> groups = userGroupDAO.search(search.addFilter(Filter.equal("groupName", "group")));
+        assertEquals(1, groups.size());
+        UserGroup group = groups.get(0);
+        assertEquals("group", group.getGroupName());
+    }
+    
+    @Test
+    public void testAddEveryOne() {
+        UserGroupDAOImpl userGroupDAO = new UserGroupDAOImpl(new MockContextSource(buildContextForGroups()));
+        userGroupDAO.setSearchBase("ou=groups");
+        userGroupDAO.setAddEveryOneGroup(true);
+        List<UserGroup> groups = userGroupDAO.findAll();
+        assertEquals(3, groups.size());
+        UserGroup group = groups.get(2);
+        assertEquals("everyone", group.getGroupName());
+    }
+}

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/ldap/IterableNamingEnumeration.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/ldap/IterableNamingEnumeration.java
@@ -1,4 +1,4 @@
-package it.geosolutions.geostore.rest.security;
+package it.geosolutions.geostore.core.ldap;
 
 import java.util.Iterator;
 
@@ -8,7 +8,7 @@ import javax.naming.NamingException;
 public class IterableNamingEnumeration<T> implements NamingEnumeration<T> {
     private final Iterator<T> iterator;
 
-    IterableNamingEnumeration(Iterable<T> iterable) {
+    public IterableNamingEnumeration(Iterable<T> iterable) {
         this.iterator = iterable.iterator();
     }
 

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/ldap/MockContextSource.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/ldap/MockContextSource.java
@@ -1,10 +1,8 @@
-package it.geosolutions.geostore.rest.security;
+package it.geosolutions.geostore.core.ldap;
 
 import javax.naming.directory.DirContext;
-
 import org.springframework.ldap.NamingException;
 import org.springframework.ldap.core.ContextSource;
-import org.springframework.ldap.core.DirContextAdapter;
 
 public class MockContextSource implements ContextSource {
 

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/ldap/MockDirContextOperations.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/ldap/MockDirContextOperations.java
@@ -1,4 +1,4 @@
-package it.geosolutions.geostore.core.security.ldap;
+package it.geosolutions.geostore.core.ldap;
 
 import java.util.HashMap;
 import java.util.Hashtable;

--- a/src/core/security/src/test/java/it/geosolutions/geostore/core/security/ldap/CustomAttributesLdapUserDetailsMapperTest.java
+++ b/src/core/security/src/test/java/it/geosolutions/geostore/core/security/ldap/CustomAttributesLdapUserDetailsMapperTest.java
@@ -29,6 +29,7 @@ package it.geosolutions.geostore.core.security.ldap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import it.geosolutions.geostore.core.ldap.MockDirContextOperations;
 import it.geosolutions.geostore.core.security.UserDetailsWithAttributes;
 import it.geosolutions.geostore.core.security.ldap.CustomAttributesLdapUserDetailsMapper;
 

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
@@ -30,6 +30,7 @@ package it.geosolutions.geostore.services;
 
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
+import it.geosolutions.geostore.core.model.UserGroup;
 import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
 import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
 
@@ -127,6 +128,6 @@ public interface UserService {
      * @return
      */
     public Collection<User>  getByAttribute(UserAttribute attribute);
-    public Collection<User>  getByGroup(long groupId);
+    public Collection<User>  getByGroup(UserGroup group);
 
 }

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
@@ -440,10 +440,16 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Collection<User> getByGroup(long groupId) {
+    public Collection<User> getByGroup(UserGroup group) {
 
         Search searchByGroup = new Search(User.class);
-        searchByGroup.addFilterSome("groups", Filter.equal("id", groupId));
+        // preferred search is by group name, revert back to id based search for compatibility
+        // if name is not present
+        if (group.getGroupName() != null) {
+            searchByGroup.addFilterSome("groups", Filter.equal("groupName", group.getGroupName()));
+        } else {
+            searchByGroup.addFilterSome("groups", Filter.equal("id", group.getId()));
+        }
         return userDAO.search(searchByGroup);
     }
 }

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ServiceTestBase.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ServiceTestBase.java
@@ -327,6 +327,16 @@ public class ServiceTestBase extends TestCase {
         return userService.insert(user);
     }
     
+    protected long createUser(String name, Role role, String password, long groupId) throws Exception {
+        User user = new User();
+        user.setName(name);
+        user.setRole(role);
+        user.setNewPassword(password);
+        long id = userService.insert(user);
+        userGroupService.assignUserGroup(id, groupId);
+        return id;
+    }
+    
     /**
      * @param name
      * @param role

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
@@ -20,16 +20,16 @@
 package it.geosolutions.geostore.services;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.UUID;
-
-import it.geosolutions.geostore.core.model.User;
-import it.geosolutions.geostore.core.model.UserAttribute;
-import it.geosolutions.geostore.core.model.enums.Role;
-import it.geosolutions.geostore.core.security.password.PwEncoder;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserAttribute;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.Role;
+import it.geosolutions.geostore.core.security.password.PwEncoder;
 
 /**
  * Class UserServiceImplTest.
@@ -117,6 +117,24 @@ public class UserServiceImplTest extends ServiceTestBase {
         assertEquals(1, userService.getByAttribute(attribute).size());
     }
 
+    @Test
+    public void testGetByGroupId() throws Exception {
+        long groupId = createGroup("testgroup");
+        createUser("test", Role.USER, "tesPW", groupId);
+        UserGroup group = new UserGroup();
+        group.setId(groupId);
+        Collection<User> users = userService.getByGroup(group);
+        assertEquals(1, users.size());
+    }
     
+    @Test
+    public void testGetByGroupName() throws Exception {
+        long groupId = createGroup("testgroup");
+        createUser("test", Role.USER, "tesPW", groupId);
+        UserGroup group = new UserGroup();
+        group.setGroupName("testgroup");
+        Collection<User> users = userService.getByGroup(group);
+        assertEquals(1, users.size());
+    }
 
 }

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/UserGroupList.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/UserGroupList.java
@@ -37,6 +37,7 @@ public class UserGroupList implements Iterable<RESTUserGroup> {
     private List<RESTUserGroup> list;
 
     public UserGroupList() {
+        this.list = new ArrayList<RESTUserGroup>();
     }
 
     /**

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTUserGroupServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTUserGroupServiceImpl.java
@@ -113,7 +113,7 @@ public class RESTUserGroupServiceImpl implements RESTUserGroupService {
             throws NotFoundWebEx {
         try {
             UserGroup g = userGroupService.get(id);
-            Collection<User> users = userService.getByGroup(id);
+            Collection<User> users = userService.getByGroup(g);
 
             return new RESTUserGroup(g.getId(), g.getGroupName(), new HashSet<>(users), g.getDescription());
         } catch (BadRequestServiceEx e) {
@@ -158,7 +158,7 @@ public class RESTUserGroupServiceImpl implements RESTUserGroupService {
             List<RESTUserGroup> ugl = new ArrayList<>(returnList.size());
             for(UserGroup ug : returnList){
                 if(all || GroupReservedNames.isAllowedName(ug.getGroupName())){
-                    Collection<User> users = userService.getByGroup(ug.getId());
+                    Collection<User> users = userService.getByGroup(ug);
                     RESTUserGroup rug = new RESTUserGroup(ug.getId(), ug.getGroupName(), new HashSet<>(users), ug.getDescription());
                     ugl.add(rug);
                 }
@@ -209,7 +209,7 @@ public class RESTUserGroupServiceImpl implements RESTUserGroupService {
             throws NotFoundWebEx {
         UserGroup ug = userGroupService.get(name);
         if (ug != null) {
-            Collection<User> users = userService.getByGroup(ug.getId());
+            Collection<User> users = userService.getByGroup(ug);
             return new RESTUserGroup(ug.getId(), ug.getGroupName(), new HashSet(users), ug.getDescription());
         }
         return null;

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/GeoStoreLdapAuthoritiesPopulatorTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/GeoStoreLdapAuthoritiesPopulatorTest.java
@@ -19,7 +19,8 @@ import javax.naming.directory.SearchResult;
 import org.junit.Test;
 import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.security.core.GrantedAuthority;
-
+import it.geosolutions.geostore.core.ldap.IterableNamingEnumeration;
+import it.geosolutions.geostore.core.ldap.MockContextSource;
 import it.geosolutions.geostore.services.rest.security.GeoStoreLdapAuthoritiesPopulator;
 
 public class GeoStoreLdapAuthoritiesPopulatorTest {

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/MockLdapAuthenticator.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/MockLdapAuthenticator.java
@@ -1,10 +1,9 @@
 package it.geosolutions.geostore.rest.security;
 
-import it.geosolutions.geostore.core.security.ldap.MockDirContextOperations;
-
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.ldap.authentication.LdapAuthenticator;
+import it.geosolutions.geostore.core.ldap.MockDirContextOperations;
 
 public class MockLdapAuthenticator implements LdapAuthenticator {
 

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserService.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserService.java
@@ -169,13 +169,13 @@ public class MockedUserService implements UserService {
     }
 
     @Override
-    public Collection<User> getByGroup(long groupId) {
+    public Collection<User> getByGroup(UserGroup ug) {
         List<User> ret = new LinkedList<>();
         for (User user : USERS.values()) {
             Set<UserGroup> groups = user.getGroups();
             if(groups != null) {
                 for (UserGroup group : groups) {
-                    if(group.getId() == groupId) {
+                    if(group.getId() == ug.getId() || group.getGroupName().equals(ug.getGroupName())) {
                         ret.add(user);
                         break;
                     }

--- a/src/web/app/src/main/resources/geostore-spring-security.xml
+++ b/src/web/app/src/main/resources/geostore-spring-security.xml
@@ -151,4 +151,25 @@
 		</constructor-arg>
 	</bean>
 
+    <bean id="ldapUserDAO" class="it.geosolutions.geostore.core.dao.ldap.impl.UserDAOImpl">
+        <constructor-arg ref="contextSource"/>
+        <property name="searchBase" value="ou=users"/>
+        <property name="memberPattern" value="^uid=([^,]+).*$"/>
+        <property name="attributesMapper">
+            <map>
+                <entry key="mail" value="email"/>
+                <entry key="givenName" value="fullname"/>
+                <entry key="description" value="description"/>
+            </map>
+        </property>
+    </bean>
+    <bean id="ldapUserGroupDAO" class="it.geosolutions.geostore.core.dao.ldap.impl.UserGroupDAOImpl">
+        <constructor-arg ref="contextSource"/>
+        <property name="searchBase" value="ou=roles"/>
+        <property name="addEveryOneGroup" value="true"/>
+    </bean>
+    <!-- Enable LDAP readonly User and UserGroup fetching -->
+    <!--alias name="ldapUserGroupDAO" alias="userGroupDAO"/>
+    <alias name="ldapUserDAO" alias="userDAO"/-->
+    
 </beans>


### PR DESCRIPTION
Enabling these DAOs (see example in xml) users and groups are fetched from LDAP instead of the internal database.
Current support is limited to API calls required by MapStore permissions handling.