### PR TITLE
Add compliant attribute update REST API

### DIFF
--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTResourceService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTResourceService.java
@@ -28,19 +28,6 @@
 
 package it.geosolutions.geostore.services.rest;
 
-import it.geosolutions.geostore.core.model.Resource;
-import it.geosolutions.geostore.core.model.enums.DataType;
-import it.geosolutions.geostore.services.dto.search.SearchFilter;
-import it.geosolutions.geostore.services.exception.InternalErrorServiceEx;
-import it.geosolutions.geostore.services.rest.exception.BadRequestWebEx;
-import it.geosolutions.geostore.services.rest.exception.InternalErrorWebEx;
-import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
-import it.geosolutions.geostore.services.rest.model.RESTResource;
-import it.geosolutions.geostore.services.rest.model.ResourceList;
-import it.geosolutions.geostore.services.rest.model.SecurityRuleList;
-import it.geosolutions.geostore.services.rest.model.ShortAttributeList;
-import it.geosolutions.geostore.services.rest.model.ShortResourceList;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -57,6 +44,20 @@ import javax.ws.rs.core.SecurityContext;
 
 import org.apache.cxf.jaxrs.ext.multipart.Multipart;
 import org.springframework.security.access.annotation.Secured;
+
+import it.geosolutions.geostore.core.model.Resource;
+import it.geosolutions.geostore.core.model.enums.DataType;
+import it.geosolutions.geostore.services.dto.search.SearchFilter;
+import it.geosolutions.geostore.services.exception.InternalErrorServiceEx;
+import it.geosolutions.geostore.services.rest.exception.BadRequestWebEx;
+import it.geosolutions.geostore.services.rest.exception.InternalErrorWebEx;
+import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
+import it.geosolutions.geostore.services.rest.model.RESTAttribute;
+import it.geosolutions.geostore.services.rest.model.RESTResource;
+import it.geosolutions.geostore.services.rest.model.ResourceList;
+import it.geosolutions.geostore.services.rest.model.SecurityRuleList;
+import it.geosolutions.geostore.services.rest.model.ShortAttributeList;
+import it.geosolutions.geostore.services.rest.model.ShortResourceList;
 
 /**
  * Interface RESTResourceService.
@@ -240,6 +241,26 @@ public interface RESTResourceService {
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     String getAttribute(@Context SecurityContext sc, @PathParam("id") long id,
             @PathParam("name") String name) throws NotFoundWebEx;
+
+    /**
+     * Updates the attribute using the PUT request body (JSON).
+     *
+     * @param id id of the resource
+     * @param content the attribute object
+     * @return long
+     * @throws NotFoundWebEx
+     * @throws InternalErrorWebEx
+     */
+    @PUT
+    @Path("/resource/{id}/attributes/")
+    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
+    long updateAttribute(
+        @Context SecurityContext sc,
+        @PathParam("id") long id,
+        RESTAttribute content
+	);
 
     /**
      * @param id

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/RESTAttribute.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/RESTAttribute.java
@@ -1,0 +1,20 @@
+package it.geosolutions.geostore.services.rest.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import it.geosolutions.geostore.services.dto.ShortAttribute;
+
+/**
+ * DTO for attribute object
+ * @author Lorenzo Natali, GeoSolutions s.a.s.
+ *
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RESTAttribute extends ShortAttribute {
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/modules/rest/impl/pom.xml
+++ b/src/modules/rest/impl/pom.xml
@@ -144,6 +144,14 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!--  Test dependencies  -->
+        <dependency>
+            <groupId>it.geosolutions.geostore</groupId>
+            <artifactId>geostore-services-impl</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     
     </dependencies>
 

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTResourceServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTResourceServiceImpl.java
@@ -52,6 +52,7 @@ import it.geosolutions.geostore.services.rest.exception.ConflictWebEx;
 import it.geosolutions.geostore.services.rest.exception.ForbiddenErrorWebEx;
 import it.geosolutions.geostore.services.rest.exception.InternalErrorWebEx;
 import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
+import it.geosolutions.geostore.services.rest.model.RESTAttribute;
 import it.geosolutions.geostore.services.rest.model.RESTCategory;
 import it.geosolutions.geostore.services.rest.model.RESTResource;
 import it.geosolutions.geostore.services.rest.model.ResourceList;
@@ -484,6 +485,15 @@ public class RESTResourceServiceImpl extends RESTServiceImpl implements RESTReso
      */
     public long updateAttribute(SecurityContext sc,  long id,String name, String value) {
 		return updateAttribute(sc, id, name, value, null);
+	}
+
+    @Override
+	public long updateAttribute(SecurityContext sc, long id, RESTAttribute content) {
+		if (content != null && content.getName() != null) {
+			// TODO: type
+			return updateAttribute(sc, id, content.getName(), content.getValue(), content.getType());
+		}
+		throw new BadRequestWebEx("missing attribute content or attribute name in request");
 	}
 
     /*

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/service/impl/RESTResourceServiceImplTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/service/impl/RESTResourceServiceImplTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (C) 2007 - 2016 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.rest.service.impl;
+
+import javax.ws.rs.core.SecurityContext;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import it.geosolutions.geostore.core.model.Attribute;
+import it.geosolutions.geostore.core.model.Resource;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.enums.DataType;
+import it.geosolutions.geostore.core.model.enums.Role;
+import it.geosolutions.geostore.services.ServiceTestBase;
+import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
+import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
+import it.geosolutions.geostore.services.rest.impl.RESTResourceServiceImpl;
+import it.geosolutions.geostore.services.rest.model.RESTAttribute;
+import it.geosolutions.geostore.services.rest.utils.MockSecurityContext;
+
+/**
+ * Class ResourceServiceImplTest.
+ *
+ * @author Tobia di Pisa (tobia.dipisa at geo-solutions.it)
+ *
+ */
+public class RESTResourceServiceImplTest extends ServiceTestBase {
+
+	RESTResourceServiceImpl restService;
+	long adminID;
+
+	 @Before
+    public void setUp() throws BadRequestServiceEx, NotFoundServiceEx {
+       restService = new RESTResourceServiceImpl();
+       restService.setResourceService(resourceService);
+    }
+
+    @Test
+    public void testUpdateResourceAttribute() throws Exception {
+        // create a semple resource
+        long resourceId = createResource("name1", "description1", "MAP");
+
+        // insert fake admin user for security context
+        long adminID = createUser("admin", Role.ADMIN, "admin");
+
+        // create security context for the request
+         SecurityContext sc = new MockSecurityContext(userService.get(adminID));
+
+        // prepare request content
+        RESTAttribute attribute = new RESTAttribute();
+        String NAME = "NAME";
+        String VALUE = "VALUE";
+        attribute.setName(NAME);
+        attribute.setValue(VALUE);
+
+        // attempt to update the attribute from rest service
+        restService.updateAttribute(sc, resourceId, attribute);
+
+        // retrieve the modified resource
+        Resource res = resourceService.get(resourceId);
+
+        // verify the attribute has been changed
+        Attribute a = res.getAttribute().get(0);
+        assertEquals(a.getName(), NAME);
+        assertEquals(a.getValue(), VALUE);
+        assertEquals(a.getType(), DataType.STRING);
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockSecurityContext.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockSecurityContext.java
@@ -1,0 +1,88 @@
+package it.geosolutions.geostore.services.rest.utils;
+
+import java.security.Principal;
+import java.util.Collection;
+
+import javax.ws.rs.core.SecurityContext;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import it.geosolutions.geostore.core.model.User;
+
+/**
+ * Mock class to simulate REST Services Requests
+ * @author Lorenzo Natali, GeoSolutions s.a.s.
+ *
+ */
+public class MockSecurityContext  implements SecurityContext{
+
+	User user;
+	Authentication principal;
+
+	public MockSecurityContext(User uu) {
+			this.user = uu;
+			principal = new Authentication() {
+
+				@Override
+				public String getName() {
+					return user.getName();
+				}
+
+				@Override
+				public Collection<GrantedAuthority> getAuthorities() {
+					// TODO Auto-generated method stub
+					return null;
+				}
+
+				@Override
+				public Object getCredentials() {
+					// TODO Auto-generated method stub
+					return null;
+				}
+
+				@Override
+				public Object getDetails() {
+					// TODO Auto-generated method stub
+					return null;
+				}
+
+				@Override
+				public Object getPrincipal() {
+					return  user;
+				}
+
+				@Override
+				public boolean isAuthenticated() {
+					// TODO Auto-generated method stub
+					return false;
+				}
+
+				@Override
+				public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+					// TODO Auto-generated method stub
+				}
+			};
+	}
+	@Override
+	public Principal getUserPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public boolean isUserInRole(String role) {
+		return role != null && role.equals(user.getRole());
+	}
+
+	@Override
+	public boolean isSecure() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public String getAuthenticationScheme() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -248,10 +248,20 @@
                 <version>${geostore-version}</version>
             </dependency>
             
-	    <dependency>
+            <dependency>
                 <groupId>it.geosolutions.geostore</groupId>
                 <artifactId>geostore-rest-auditing</artifactId>
                 <version>${geostore-version}</version>
+            </dependency>
+
+            <!-- TEST PACKAGE DEPENDENCY RESOULTION -->
+
+            <dependency>
+                <groupId>it.geosolutions.geostore</groupId>
+                <artifactId>geostore-services-impl</artifactId>
+                <version>${geostore-version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
             </dependency>
 
 		    <!-- =========================================================== -->


### PR DESCRIPTION
Added REST API PUT API compliant, with value in the body. 
This should avoid issue https://github.com/georchestra/mapstore2-georchestra/issues/101 together with a different request from MapStore, using the new entry. 
The request should be like this: 

`PUT "/resource/{resource-id}/attributes/"`
```json
{
	"restAttribute": {
		"name": "test",
		"value": "MyTest1"
	}
}
```