### PR TITLE
#219: improvements to the LDAP compatible DAOs to fully replace the standard ones in a MapStore standard security configuration

### DIFF
--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/enums/GroupReservedNames.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/enums/GroupReservedNames.java
@@ -19,6 +19,13 @@
  */
 package it.geosolutions.geostore.core.model.enums;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import it.geosolutions.geostore.core.model.UserGroup;
 
 /**
  * @author DamianoG
@@ -50,5 +57,21 @@ public enum GroupReservedNames {
             return false;
         }
         return true;
+    }
+    
+    /**
+     * Utility method to remove Reserved group (for example EVERYONE) from a group list
+     * 
+     * @param groups
+     * @return
+     */
+    public static Set<UserGroup> checkReservedGroups(Collection<UserGroup> groups) {
+        Set<UserGroup> result = new HashSet<UserGroup>();
+        for(UserGroup ug : groups){
+            if(GroupReservedNames.isAllowedName(ug.getGroupName())){
+            	result.add(ug);
+            }
+        }
+        return result;
     }
 }

--- a/src/core/model/src/test/java/it/geosolutions/geostore/core/model/GroupReservedNamesTest.java
+++ b/src/core/model/src/test/java/it/geosolutions/geostore/core/model/GroupReservedNamesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 - 2011 GeoSolutions S.A.S. http://www.geo-solutions.it
+ * 
+ * GPLv3 + Classpath exception
+ * 
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.core.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import it.geosolutions.geostore.core.model.enums.GroupReservedNames;
+import static org.junit.Assert.assertEquals;
+
+public class GroupReservedNamesTest {
+    @Test
+    public void testRemoveReserved() {
+        List<UserGroup> groups = new ArrayList<UserGroup>();
+        UserGroup everyOne = new UserGroup();
+        everyOne.setGroupName(GroupReservedNames.EVERYONE.groupName());
+        groups.add(everyOne);
+        UserGroup sample = new UserGroup();
+        sample.setGroupName("sample");
+        groups.add(sample);
+        
+        Set<UserGroup> result = GroupReservedNames.checkReservedGroups(groups);
+        
+        assertEquals(1, result.size());
+        assertEquals("sample", result.iterator().next().getGroupName());
+    }
+}

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserDAOImpl.java
@@ -232,7 +232,7 @@ public class UserDAOImpl extends LdapBaseDAOImpl implements UserDAO {
     }
     
     /**
-     * Returns truew if the given group is the adminRoleGroup group.
+     * Returns true if the given group is the adminRoleGroup group.
      * 
      * @param ug
      * @return

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
@@ -28,6 +28,8 @@ import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.DirContextProcessor;
 import org.springframework.ldap.core.support.AbstractContextMapper;
+
+import com.googlecode.genericdao.search.Filter;
 import com.googlecode.genericdao.search.ISearch;
 import it.geosolutions.geostore.core.dao.UserGroupDAO;
 import it.geosolutions.geostore.core.model.UserGroup;
@@ -130,8 +132,16 @@ public class UserGroupDAOImpl  extends LdapBaseDAOImpl implements UserGroupDAO {
     @SuppressWarnings("unchecked")
     @Override
     public List<UserGroup> search(ISearch search) {
+        String filter;
+        if (isNested(search)) {
+            // membership filter (member = <user>)
+            Filter nested = getNestedFilter(search.getFilters().get(0));
+            filter = memberAttribute + "=" + nested.getValue().toString();
+        } else {
+            filter = getLdapFilter(search, getPropertyMapper());
+        }
         return addEveryOne(
-            ldapSearch(combineFilters(baseFilter, getLdapFilter(search, getPropertyMapper())), getProcessorForSearch(search)),
+            ldapSearch(combineFilters(baseFilter, filter), getProcessorForSearch(search)),
             search
         );
     }

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/BaseDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/BaseDAOTest.java
@@ -1,0 +1,278 @@
+/*
+ *  Copyright (C) 2021 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ * 
+ *  GPLv3 + Classpath exception
+ * 
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.geosolutions.geostore.core.dao.ldap;
+
+import java.util.Arrays;
+import java.util.Collections;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import org.springframework.ldap.core.DirContextAdapter;
+import it.geosolutions.geostore.core.ldap.IterableNamingEnumeration;
+import it.geosolutions.geostore.core.ldap.MockDirContextOperations;
+
+public abstract class BaseDAOTest {
+    protected DirContext buildContextForUsers() {
+        return new DirContextAdapter() {
+            @Override
+            public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons)
+                    throws NamingException {
+                if ("ou=users".equals(name)) {
+                    if("cn=*".equals(filter)) {
+                        SearchResult sr1 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=username,ou=users";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "username";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        SearchResult sr2 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=username2,ou=users";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "username2";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Arrays.asList(sr1, sr2));
+                    } else if ("(& (cn=*) (cn=username))".equals(filter)) {
+                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=username,ou=users";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "username";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Collections.singletonList(sr));
+                    } else if ("(& (cn=*) (cn=username2))".equals(filter)) {
+                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=username2,ou=users";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "username2";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Collections.singletonList(sr));
+                    } 
+                }
+                return new IterableNamingEnumeration(Collections.EMPTY_LIST);
+            }
+        };
+    }
+    
+    protected DirContext buildContextForGroupsMembership(final String memberString) {
+        return new DirContextAdapter() {
+            @Override
+            public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons)
+                    throws NamingException {
+                if ("ou=groups".equals(name)) {
+                    if ("(& (cn=*) (cn=group))".equals(filter)) {
+                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group";
+                                }
+                                return "";
+                            }
+
+                            @Override
+                            public String[] getStringAttributes(String name) {
+                                if ("member".equals(name)) {
+                                    return new String[] {memberString == null ? "username" : memberString};
+                                }
+                                return new String[] {};
+                            }
+                            
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Collections.singletonList(sr));
+                    }
+                }
+                return new IterableNamingEnumeration(Collections.EMPTY_LIST);
+            }
+        };
+    }
+    
+    protected DirContext buildContextForGroups() {
+        return new DirContextAdapter() {
+            @Override
+            public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons)
+                    throws NamingException {
+                if ("ou=groups".equals(name)) {
+                    if ("cn=*".equals(filter)) {
+                        SearchResult sr1 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group";
+                                }
+                                return "";
+                            }
+
+                        }, new BasicAttributes());
+                        SearchResult sr2 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group2,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group2";
+                                }
+                                return "";
+                            }
+
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Arrays.asList(sr1, sr2));
+                    } else if ("(& (cn=*) (cn=group))".equals(filter)) {
+                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(Collections.singletonList(sr));
+                    } else if("(& (cn=*) (member=cn=username,ou=users))".contentEquals(filter)) {
+                        SearchResult sr1 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        SearchResult sr2 = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=admin,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "admin";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        return new IterableNamingEnumeration(
+                                Arrays.asList(new SearchResult[] {sr1, sr2}));
+                    } else if("(& (cn=*) (member=cn=username2,ou=users))".contentEquals(filter)) {
+                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
+
+                            @Override
+                            public String getNameInNamespace() {
+                                return "cn=group,ou=groups";
+                            }
+
+                            @Override
+                            public String getStringAttribute(String name) {
+                                if ("cn".equals(name)) {
+                                    return "group";
+                                }
+                                return "";
+                            }
+                            
+                        }, new BasicAttributes());
+                        
+                        return new IterableNamingEnumeration(
+                                Collections.singletonList(sr));
+                    }
+                }
+                return new IterableNamingEnumeration(Collections.EMPTY_LIST);
+            }
+        };
+    }
+    
+}

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/UserGroupDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/UserGroupDAOTest.java
@@ -40,71 +40,8 @@ import it.geosolutions.geostore.core.ldap.MockDirContextOperations;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserGroup;
 
-public class UserGroupDAOTest {
-    DirContext buildContextForGroups() {
-        return new DirContextAdapter() {
-            @Override
-            public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons)
-                    throws NamingException {
-                if ("ou=groups".equals(name)) {
-                    if ("cn=*".equals(filter)) {
-                        SearchResult sr1 = new SearchResult("cn=*", null, new MockDirContextOperations() {
-
-                            @Override
-                            public String getNameInNamespace() {
-                                return "cn=group,ou=groups";
-                            }
-
-                            @Override
-                            public String getStringAttribute(String name) {
-                                if ("cn".equals(name)) {
-                                    return "group";
-                                }
-                                return "";
-                            }
-
-                        }, new BasicAttributes());
-                        SearchResult sr2 = new SearchResult("cn=*", null, new MockDirContextOperations() {
-
-                            @Override
-                            public String getNameInNamespace() {
-                                return "cn=group2,ou=groups";
-                            }
-
-                            @Override
-                            public String getStringAttribute(String name) {
-                                if ("cn".equals(name)) {
-                                    return "group2";
-                                }
-                                return "";
-                            }
-
-                        }, new BasicAttributes());
-                        return new IterableNamingEnumeration(Arrays.asList(sr1, sr2));
-                    } else if ("(& (cn=*) (cn=group))".equals(filter)) {
-                        SearchResult sr = new SearchResult("cn=*", null, new MockDirContextOperations() {
-
-                            @Override
-                            public String getNameInNamespace() {
-                                return "cn=group,ou=groups";
-                            }
-
-                            @Override
-                            public String getStringAttribute(String name) {
-                                if ("cn".equals(name)) {
-                                    return "group";
-                                }
-                                return "";
-                            }
-                            
-                        }, new BasicAttributes());
-                        return new IterableNamingEnumeration(Collections.singletonList(sr));
-                    } 
-                }
-                return new IterableNamingEnumeration(Collections.EMPTY_LIST);
-            }
-        };
-    }
+public class UserGroupDAOTest extends BaseDAOTest {
+    
     
     @Test
     public void testFindAll() {

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
@@ -136,5 +136,50 @@ public class UserServiceImplTest extends ServiceTestBase {
         Collection<User> users = userService.getByGroup(group);
         assertEquals(1, users.size());
     }
+    
+    @Test
+    public void testUpdateByUserId() throws Exception {
+        final String NAME = "name1";
+
+        long userId = createUser(NAME, Role.USER, "testPW");
+
+        assertEquals(1, userService.getCount(null));
+        
+        User loaded = userService.get(userId);
+        assertNotNull(loaded);
+        assertEquals(NAME, loaded.getName());
+        assertTrue( PwEncoder.isPasswordValid(loaded.getPassword(),"testPW"));
+        assertEquals(Role.USER, loaded.getRole());
+
+        loaded.setNewPassword("testPW2");
+        userService.update(loaded);
+        
+        loaded = userService.get(userId);
+        assertNotNull(loaded);
+        assertTrue(PwEncoder.isPasswordValid(loaded.getPassword(),"testPW2"));
+    }
+    
+    @Test
+    public void testUpdateByUserName() throws Exception {
+        final String NAME = "name1";
+
+        long userId = createUser(NAME, Role.USER, "testPW");
+
+        assertEquals(1, userService.getCount(null));
+        
+        User loaded = userService.get(userId);
+        assertNotNull(loaded);
+        assertEquals(NAME, loaded.getName());
+        assertTrue( PwEncoder.isPasswordValid(loaded.getPassword(),"testPW"));
+        assertEquals(Role.USER, loaded.getRole());
+
+        loaded.setNewPassword("testPW2");
+        loaded.setId(-1L);
+        userService.update(loaded);
+        
+        loaded = userService.get(userId);
+        assertNotNull(loaded);
+        assertTrue(PwEncoder.isPasswordValid(loaded.getPassword(),"testPW2"));
+    }
 
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/SessionTokenAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/SessionTokenAuthenticationFilter.java
@@ -65,26 +65,25 @@ public class SessionTokenAuthenticationFilter extends TokenAuthenticationFilter 
     	if(ud != null) {
     	    User user = null;
     	    if (validateUserFromService) {
+    	        // we search user by id first, if available
     			if(ud.getId() != null) {
     				user = userService.get((Long) ud.getId());
-    			} else if (ud.getName() != null){
+    			}
+    			// then by name if no id is available or the service cannot search by id (e.g. LDAP)
+    			if (user == null && ud.getName() != null){
     				try {
-    					// in case of external authentication provider the user may not come from the UserService
-    					// so try to use the name to retrieve from the userservice (that should be populated in the meanwhile).
     					user = userService.get(ud.getName());
     				} catch (NotFoundServiceEx e) {
     					LOGGER.error("User " + ud.getName() + " not found on the database because of an exception", e);
     				}  
-    			} else  {
-    				LOGGER.error("User login success, but couldn't retrieve  a session. Probably auth user and  and userService are out of sync.");
     			}
-    			
-    			
     	    } else {
     	        user = ud;
     	    }
     	    if (user != null) {
                 return createAuthenticationForUser(user);
+            } else {
+            	LOGGER.error("User login success, but couldn't retrieve  a session. Probably auth user and  and userService are out of sync.");
             }
     	}
         return null;

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserLdapAuthenticationProvider.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserLdapAuthenticationProvider.java
@@ -133,7 +133,7 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
                     Set<UserGroup> groups = new HashSet<UserGroup>();
                     Role role = extractUserRoleAndGroups(user.getRole(), authorities, groups);
                     user.setRole(role);
-                    user.setGroups(checkReservedGroups(groups));
+                    user.setGroups(GroupReservedNames.checkReservedGroups(groups));
 
                     if (userService != null)
                         userService.update(user);
@@ -159,7 +159,7 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
                     Set<UserGroup> groups = new HashSet<UserGroup>();
                     Role role = extractUserRoleAndGroups(null, authorities, groups);
                     user.setRole(role);
-                    user.setGroups(checkReservedGroups(groups));
+                    user.setGroups(GroupReservedNames.checkReservedGroups(groups));
                     if(userMapper != null) {
                         userMapper.mapUser(ldapUser, user);
                     }
@@ -248,24 +248,5 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
         } else {
             return group;
         }
-    }
-
-	 /**
-     * Utility method to remove Reserved group (for example EVERYONE) from a group list
-     * 
-     * @param groups
-     * @return
-     */
-    private Set<UserGroup> checkReservedGroups(Set<UserGroup> groups){
-        List<UserGroup> reserved = new ArrayList<UserGroup>();
-        for(UserGroup ug : groups){
-            if(!GroupReservedNames.isAllowedName(ug.getGroupName())){
-                reserved.add(ug);
-            }
-        }
-        for(UserGroup ug : reserved){
-			groups.remove(ug);
-        }
-        return groups;
     }
 }


### PR DESCRIPTION
Improves usability of LDAP compatible DAOs, for a better integration with MapStore authentication.
In particular:
 * all user configuration (included groups and role, via the new adminRoleGroup property) are fetched by the UserDAO
 * write operations fail silently instead of throwing, waiting for an explicit support for readonly DAOs from the services
 * more fallbacks to using search by name when search by id does not return a valid user (LDAP id is fake, and cannot be used for searching)