### PR TITLE
#6825: fixes password change for MapStore

### DIFF
--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserGroupService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserGroupService.java
@@ -110,6 +110,15 @@ public interface UserGroupService {
      * @return true if the persist operation finish with success, false otherwise  
      */
     public boolean insertSpecialUsersGroups();
+    
+    /**
+     * Remove the special UserGroups, those that implies special behavior
+     * 
+     * For obvious reasons this Method MUST NOT exposed through the rest interface.
+     * 
+     * @return true if the removal operation finish with success, false otherwise  
+     */
+    public boolean removeSpecialUsersGroups();
     /**
      * Get The UserGroup from the name
      * @param name

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserGroupServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserGroupServiceImpl.java
@@ -332,6 +332,25 @@ public class UserGroupServiceImpl implements UserGroupService {
         }
         return true;
     }
+    
+    public boolean removeSpecialUsersGroups(){
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Removing Reserved UsersGroup... ");
+        }
+        
+        Search search = new Search();
+        search.addFilterEqual("groupName", GroupReservedNames.EVERYONE.groupName());
+        List<UserGroup> ugEveryone = userGroupDAO.search(search);
+        if (ugEveryone.size() == 1) {
+            UserGroup ug = ugEveryone.get(0);
+            boolean res = userGroupDAO.removeById(ug.getId());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Special UserGroup '" + ug.getGroupName() + "' removed!");
+            }
+            return res;
+        }
+        return false;
+    }
 
     @Override
     public UserGroup get(long id) throws BadRequestServiceEx {

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
@@ -181,7 +181,7 @@ public class UserServiceImpl implements UserService {
         //
         // Checking User Group
         //
-        Set<UserGroup> groups = user.getGroups();
+        Set<UserGroup> groups = GroupReservedNames.checkReservedGroups(user.getGroups());
         List<String> groupNames = new ArrayList<String>();
         Set<UserGroup> existingGroups = new HashSet<UserGroup>();
         if (groups != null && groups.size() > 0) {

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ServiceTestBase.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ServiceTestBase.java
@@ -33,6 +33,7 @@ import it.geosolutions.geostore.core.model.StoredData;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
 import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.GroupReservedNames;
 import it.geosolutions.geostore.core.model.enums.Role;
 import it.geosolutions.geostore.services.dto.ShortResource;
 import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
@@ -127,11 +128,12 @@ public class ServiceTestBase extends TestCase {
         List<UserGroup> list = userGroupService.getAll(null, null);
         for (UserGroup item : list) {
             LOGGER.info("Removing User: " + item.getGroupName());
-
-            boolean ret = userGroupService.delete(item.getId());
-            assertTrue("Group not removed", ret);
+            if (GroupReservedNames.isAllowedName(item.getGroupName())) {
+                boolean ret = userGroupService.delete(item.getId());
+                assertTrue("Group not removed", ret);
+            }
         }
-
+        boolean res = userGroupService.removeSpecialUsersGroups();
         assertEquals("Group have not been properly deleted", 0, userService.getCount(null));
     }
 
@@ -327,6 +329,10 @@ public class ServiceTestBase extends TestCase {
     		userGroupService.assignUserGroup(userId, groupId);
     	}
     	return groupId;
+    }
+    
+    protected void createSpecialUserGroups() {
+        userGroupService.insertSpecialUsersGroups();
     }
     
     protected long createUser(String name, Role role, String password, List<UserAttribute> attributes) throws Exception {

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
 import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.GroupReservedNames;
 import it.geosolutions.geostore.core.model.enums.Role;
 import it.geosolutions.geostore.core.security.password.PwEncoder;
 
@@ -157,6 +158,59 @@ public class UserServiceImplTest extends ServiceTestBase {
         loaded = userService.get(userId);
         assertNotNull(loaded);
         assertTrue(PwEncoder.isPasswordValid(loaded.getPassword(),"testPW2"));
+    }
+    
+    @Test
+    public void testUpdateWithGroups() throws Exception {
+        final String NAME = "name1";
+
+        long userId = createUser(NAME, Role.USER, "testPW");
+        assertEquals(1, userService.getCount(null));
+        
+        createUserGroup("testgroup", new long[] {userId});
+        
+        User loaded = userService.get(userId);
+        assertNotNull(loaded);
+        assertEquals(NAME, loaded.getName());
+        assertTrue( PwEncoder.isPasswordValid(loaded.getPassword(),"testPW"));
+        assertEquals(Role.USER, loaded.getRole());
+        assertEquals(1, loaded.getGroups().size());
+
+        loaded.setNewPassword("testPW2");
+        userService.update(loaded);
+        
+        loaded = userService.get(userId);
+        assertNotNull(loaded);
+        assertTrue(PwEncoder.isPasswordValid(loaded.getPassword(),"testPW2"));
+        assertEquals(1, loaded.getGroups().size());
+    }
+    
+    @Test
+    public void testUpdateWithGroupsAndEveryone() throws Exception {
+        final String NAME = "name1";
+
+        createSpecialUserGroups();
+        
+        long userId = createUser(NAME, Role.USER, "testPW");
+        assertEquals(1, userService.getCount(null));
+        
+        createUserGroup("testgroup", new long[] {userId});
+        
+        
+        User loaded = userService.get(userId);
+        assertNotNull(loaded);
+        assertEquals(NAME, loaded.getName());
+        assertTrue( PwEncoder.isPasswordValid(loaded.getPassword(),"testPW"));
+        assertEquals(Role.USER, loaded.getRole());
+        assertEquals(2, loaded.getGroups().size());
+
+        loaded.setNewPassword("testPW2");
+        userService.update(loaded);
+        
+        loaded = userService.get(userId);
+        assertNotNull(loaded);
+        assertTrue(PwEncoder.isPasswordValid(loaded.getPassword(),"testPW2"));
+        assertEquals(2, loaded.getGroups().size());
     }
     
     @Test

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserGroupService.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserGroupService.java
@@ -86,6 +86,12 @@ public class MockedUserGroupService implements UserGroupService {
         // TODO Auto-generated method stub
         return false;
     }
+    
+    @Override
+    public boolean removeSpecialUsersGroups() {
+        // TODO Auto-generated method stub
+        return false;
+    }
 
     @Override
     public UserGroup get(String name) {


### PR DESCRIPTION
When updating a user, there is a check in UserServiceImpl to match the DTO user groups with existing groups in database.

Unfortunately, groups stored in database where filtered to remove the special everyone group, but the DTO user's group were not, so there was always a mismatch.
The fix in this PR changes the code so that also the DTO groups are filtered, restore the correct behaviour.
The fix is a one-liner. The remaining part of the PR is needed to add a unit test for this fix.