### PR TITLE
Upgrade of Spring dependency to a more recent version

### DIFF
--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>1.7-SNAPSHOT</version>
+        <version>1.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-cli</artifactId>

--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.168</version>
+            <version>1.3.175</version>
         </dependency>
 
    	    <!-- Apache Commons -->

--- a/src/core/model/pom.xml
+++ b/src/core/model/pom.xml
@@ -43,46 +43,7 @@
             <artifactId>jaxb-impl</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-annotations</artifactId>
-            <!-- need transitive dependency: service-API looks for annotation and would complain about these -->
-            <!--<scope>provided</scope> -->
-            <exclusions>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm-attrs</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>cglib</groupId>
-                    <artifactId>cglib</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-commons-annotations</artifactId>
-            <scope>provided</scope> <!-- the dao module should import them for runtime -->
-            <exclusions>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm-attrs</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>cglib</groupId>
-                    <artifactId>cglib</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
+        
 		<!-- HIBERNATE-SPATIAL -->
         <dependency>
             <groupId>org.hibernatespatial</groupId>

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Attribute.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Attribute.java
@@ -41,6 +41,9 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Index;
+import javax.persistence.ForeignKey;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
@@ -56,8 +59,6 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.Index;
 
 /**
  * Class Attribute.
@@ -67,8 +68,15 @@ import org.hibernate.annotations.Index;
  */
 @Entity(name = "Attribute")
 @Table(name = "gs_attribute", uniqueConstraints = { @UniqueConstraint(columnNames = { "name",
-        "resource_id" }) })
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_attribute")
+        "resource_id" }) }, indexes= {
+                @Index(name = "idx_attribute_name", columnList = "name"),
+                @Index(name = "idx_attribute_text", columnList = "attribute_text"),
+                @Index(name = "idx_attribute_number", columnList = "attribute_number"),
+                @Index(name = "idx_attribute_date", columnList = "attribute_date"),
+                @Index(name = "idx_attribute_type", columnList = "attribute_type"),
+                @Index(name = "idx_attribute_resource", columnList = "resource_id"),
+        })
+//@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_attribute")
 @XmlRootElement(name = "Attribute")
 public class Attribute implements Serializable {
 
@@ -80,30 +88,25 @@ public class Attribute implements Serializable {
     private Long id;
 
     @Column(name = "name", nullable = false, updatable = true)
-    @Index(name = "idx_attribute_name")
+    
     private String name;
 
     @Column(name = "attribute_text", nullable = true, updatable = true)
-    @Index(name = "idx_attribute_text")
     private String textValue;
 
     @Column(name = "attribute_number", nullable = true, updatable = true)
-    @Index(name = "idx_attribute_number")
     private Double numberValue;
 
     @Column(name = "attribute_date", nullable = true, updatable = true)
-    @Index(name = "idx_attribute_date")
     @Temporal(TemporalType.TIMESTAMP)
     private Date dateValue;
 
     @Column(name = "attribute_type", nullable = false, updatable = false)
-    @Index(name = "idx_attribute_type")
     @Enumerated(EnumType.STRING)
     private DataType type;
 
     @ManyToOne(optional = false)
-    @Index(name = "idx_attribute_resource")
-    @ForeignKey(name = "fk_attribute_resource")
+    @JoinColumn(foreignKey=@ForeignKey(name="fk_attribute_resource"))
     private Resource resource;
 
     /**

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Category.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Category.java
@@ -39,13 +39,13 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.persistence.Index;
 import javax.persistence.UniqueConstraint;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Index;
 
 /**
  * Class Category.
@@ -54,8 +54,10 @@ import org.hibernate.annotations.Index;
  * @author Emanuele Tajariol (etj at geo-solutions.it)
  */
 @Entity(name = "Category")
-@Table(name = "gs_category", uniqueConstraints = { @UniqueConstraint(columnNames = { "name" }) })
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_category")
+@Table(name = "gs_category", uniqueConstraints = { @UniqueConstraint(columnNames = { "name" }) }, indexes = {
+        @Index(name = "idx_category_type", columnList = "name")
+})
+//@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_category")
 @XmlRootElement(name = "Category")
 public class Category implements Serializable {
 
@@ -64,9 +66,8 @@ public class Category implements Serializable {
     @Id
     @GeneratedValue
     private Long id;
-
     @Column(name = "name", nullable = false, updatable = false)
-    @Index(name = "idx_category_type")
+    
     private String name;
 
     /*

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Resource.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Resource.java
@@ -44,6 +44,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.Index;
 import javax.persistence.UniqueConstraint;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
@@ -53,8 +54,6 @@ import com.sun.xml.bind.CycleRecoverable;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.Index;
 
 /**
  * Class Resource.
@@ -63,8 +62,15 @@ import org.hibernate.annotations.Index;
  * @author Emanuele Tajariol (etj at geo-solutions.it)
  */
 @Entity(name = "Resource")
-@Table(name = "gs_resource", uniqueConstraints = { @UniqueConstraint(columnNames = { "name" }) })
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_resource")
+@Table(name = "gs_resource", uniqueConstraints = { @UniqueConstraint(columnNames = { "name" }) }, indexes = {
+        @Index(name = "idx_resource_name", columnList = "name"),
+        @Index(name = "idx_resource_description", columnList = "description"),
+        @Index(name = "idx_resource_creation", columnList = "creation"),
+        @Index(name = "idx_resource_update", columnList = "lastUpdate"),
+        @Index(name = "idx_resource_metadata", columnList = "metadata"),
+        @Index(name = "idx_resource_category", columnList = "category_id")
+})
+// @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_resource")
 @XmlRootElement(name = "Resource")
 public class Resource implements Serializable, CycleRecoverable {
 
@@ -75,25 +81,20 @@ public class Resource implements Serializable, CycleRecoverable {
     private Long id;
 
     @Column(nullable = false, updatable = true)
-    @Index(name = "idx_resource_name")
     private String name;
 
     @Column(nullable = true, updatable = true, length = 10000)
-    @Index(name = "idx_resource_description")
     private String description;
 
     @Column(nullable = false, updatable = false)
     @Temporal(TemporalType.TIMESTAMP)
-    @Index(name = "idx_resource_creation")
     private Date creation;
 
     @Column(nullable = true, updatable = true)
     @Temporal(TemporalType.TIMESTAMP)
-    @Index(name = "idx_resource_update")
     private Date lastUpdate;
 
     @Column(nullable = true, updatable = true, length = 30000)
-    @Index(name = "idx_resource_metadata")
     private String metadata;
 
     @OneToMany(mappedBy = "resource", cascade = CascadeType.REMOVE, fetch = FetchType.EAGER)
@@ -103,8 +104,7 @@ public class Resource implements Serializable, CycleRecoverable {
     private StoredData data;
 
     @ManyToOne(optional = false)
-    @Index(name = "idx_resource_category")
-    @ForeignKey(name = "fk_resource_category")
+    // @ForeignKey(name = "fk_resource_category")
     private Category category;
 
     /*

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/SecurityRule.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/SecurityRule.java
@@ -33,9 +33,12 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.ForeignKey;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
+import javax.persistence.Index;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -43,8 +46,6 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.Index;
 
 /**
  * Class Security.
@@ -60,8 +61,17 @@ import org.hibernate.annotations.Index;
                                                                         * ,
                                                                         * 
                                                                         * @UniqueConstraint(columnNames = {"category_id", "group_id"})
-                                                                        */})
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_security")
+                                                                        */
+        }, indexes = {
+                @Index(name = "idx_security_resource", columnList = "resource_id"),
+                @Index(name = "idx_security_user", columnList = "user_id"),
+                @Index(name = "idx_security_group", columnList = "group_id"),
+                @Index(name = "idx_security_read", columnList = "canread"),
+                @Index(name = "idx_security_write", columnList = "canwrite"),
+                @Index(name = "idx_security_username", columnList = "username"),
+                @Index(name = "idx_security_groupname", columnList = "groupname")
+        })
+//@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_security")
 @XmlRootElement(name = "Security")
 public class SecurityRule implements Serializable {
 
@@ -77,8 +87,7 @@ public class SecurityRule implements Serializable {
      * TODO: it would be nice to have a DB constraint on nonnullability on them.
      */
     @ManyToOne(optional = true)
-    @Index(name = "idx_security_resource")
-    @ForeignKey(name = "fk_security_resource")
+    @JoinColumn(foreignKey=@ForeignKey(name="fk_security_resource"))
     private Resource resource;
 
     // /**
@@ -91,29 +100,23 @@ public class SecurityRule implements Serializable {
     // private Category category;
 
     @ManyToOne(optional = true)
-    @Index(name = "idx_security_user")
-    @ForeignKey(name = "fk_security_user")
+    @JoinColumn(foreignKey=@ForeignKey(name="fk_security_user"))
     private User user;
 
     @ManyToOne(optional = true)
-    @Index(name = "idx_security_group")
-    @ForeignKey(name = "fk_security_group")
+    @JoinColumn(foreignKey=@ForeignKey(name="fk_security_group"))
     private UserGroup group;
 
     @Column(nullable = false, updatable = true)
-    @Index(name = "idx_security_read")
     private boolean canRead;
 
     @Column(nullable = false, updatable = true)
-    @Index(name = "idx_security_write")
     private boolean canWrite;
     
     @Column(nullable = true, updatable = true)
-    @Index(name = "idx_security_username")
     private String username;
     
     @Column(nullable = true, updatable = true)
-    @Index(name = "idx_security_groupname")
     private String groupname;
 
     /**

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/StoredData.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/StoredData.java
@@ -31,7 +31,9 @@ import java.io.Serializable;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ForeignKey;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -39,7 +41,6 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.ForeignKey;
 
 /**
  * Class StoredData.
@@ -50,7 +51,7 @@ import org.hibernate.annotations.ForeignKey;
  */
 @Entity(name = "StoreData")
 @Table(name = "gs_stored_data")
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_stored_data")
+//@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_stored_data")
 @XmlRootElement(name = "StoredData")
 public class StoredData implements Serializable {
 
@@ -63,7 +64,7 @@ public class StoredData implements Serializable {
     private String data;
 
     @OneToOne(optional = false)
-    @ForeignKey(name = "fk_data_resource")
+    @JoinColumn(foreignKey=@ForeignKey(name="fk_data_resource"))
     private Resource resource;
 
     /**

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/User.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/User.java
@@ -44,6 +44,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
+import javax.persistence.ForeignKey;
+import javax.persistence.Index;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -57,7 +59,6 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Type;
 
 /**
@@ -67,8 +68,12 @@ import org.hibernate.annotations.Type;
  * @author Emanuele Tajariol (etj at geo-solutions.it)
  */
 @Entity(name = "User")
-@Table(name = "gs_user", uniqueConstraints = { @UniqueConstraint(columnNames = { "name" }) })
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_user")
+@Table(name = "gs_user", uniqueConstraints = { @UniqueConstraint(columnNames = { "name" }) }, indexes = {
+        @Index(name = "idx_user_name", columnList = "name"),
+        @Index(name = "idx_user_password", columnList = "user_password"),
+        @Index(name = "idx_user_role", columnList = "user_role")
+})
+//@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_user")
 @XmlRootElement(name = "User")
 public class User implements Serializable {
 
@@ -85,15 +90,12 @@ public class User implements Serializable {
     private Long id;
 
     @Column(nullable = false, updatable = false, length = 255)
-    @Index(name = "idx_user_name")
     private String name;
 
     @Column(name = "user_password", updatable = true)
-    @Index(name = "idx_user_password")
     private String password;
 
     @Column(name = "user_role", nullable = false, updatable = true)
-    @Index(name = "idx_user_role")
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -117,7 +119,6 @@ public class User implements Serializable {
     @JoinTable(name = "gs_usergroup_members", 
         joinColumns = { @JoinColumn(name = "user_id", nullable = false, updatable = false) },
         inverseJoinColumns = { @JoinColumn(name = "group_id", nullable = false, updatable = false) })
-    @Index(name = "idx_user_group")
     private Set<UserGroup> groups;
 
     @Type(type="yes_no")

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/UserAttribute.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/UserAttribute.java
@@ -34,6 +34,9 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.ForeignKey;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -42,8 +45,6 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.Index;
 
 /**
  * Class Attribute.
@@ -53,8 +54,12 @@ import org.hibernate.annotations.Index;
  */
 @Entity(name = "UserAttribute")
 @Table(name = "gs_user_attribute", uniqueConstraints = { @UniqueConstraint(columnNames = { "name",
-        "user_id" }) })
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_user_attribute")
+        "user_id" }) }, indexes = {
+                @Index(name = "idx_user_attribute_name", columnList = "name"),
+                @Index(name = "idx_user_attribute_text", columnList = "string"),
+                @Index(name = "idx_attribute_user", columnList = "user_id")
+        })
+//@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_user_attribute")
 @XmlRootElement(name = "UserAttribute")
 public class UserAttribute implements Serializable {
 
@@ -65,16 +70,13 @@ public class UserAttribute implements Serializable {
     private Long id;
 
     @Column(name = "name", nullable = false, updatable = true)
-    @Index(name = "idx_user_attribute_name")
     private String name;
 
     @Column(name = "string", nullable = true, updatable = true)
-    @Index(name = "idx_user_attribute_text")
     private String value;
 
     @ManyToOne(optional = false)
-    @Index(name = "idx_attribute_user")
-    @ForeignKey(name = "fk_uattrib_user")
+    @JoinColumn(foreignKey=@ForeignKey(name="fk_uattrib_user"))
     private User user;
 
     /**

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/UserGroup.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/UserGroup.java
@@ -35,8 +35,11 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -44,7 +47,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Type;
 
 /**
@@ -54,8 +56,10 @@ import org.hibernate.annotations.Type;
  * 
  */
 @Entity(name = "UserGroup")
-@Table(name = "gs_usergroup", uniqueConstraints = { @UniqueConstraint(columnNames = { "groupName" }) })
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_usergroup")
+@Table(name = "gs_usergroup", uniqueConstraints = { @UniqueConstraint(columnNames = { "groupName" }) }, indexes = {
+        @Index(name = "idx_usergroup_name", columnList = "groupName")
+})
+//@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_usergroup")
 @XmlRootElement(name = "UserGroup")
 public class UserGroup implements Serializable {
 
@@ -68,7 +72,6 @@ public class UserGroup implements Serializable {
     private Long id;
 
     @Column(nullable = false, updatable = false, length = 255)
-    @Index(name = "idx_usergroup_name")
     private String groupName;
 
     @Column(nullable = true, updatable = true, length = 255)

--- a/src/core/persistence/pom.xml
+++ b/src/core/persistence/pom.xml
@@ -120,17 +120,23 @@
 <!--		<dependency>
 		    <groupId>org.springframework.security</groupId>
 		    <artifactId>spring-security-core</artifactId>
-		</dependency>-->
+		</dependency>
         <dependency>
             <groupId>javax.persistence</groupId>
             <artifactId>persistence-api</artifactId>
-<!--            <scope>provided</scope>-->
+        </dependency>-->
+
+        <!-- https://mvnrepository.com/artifact/org.hibernate.javax.persistence/hibernate-jpa-2.1-api -->
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.1-api</artifactId>
         </dependency>
+
 
 		<!-- HIBERNATE-GENERIC-DAO -->
         <dependency>
             <groupId>com.googlecode.genericdao</groupId>
-            <artifactId>dao</artifactId>
+            <artifactId>dao-hibernate</artifactId>
 <!--            <groupId>com.trg</groupId>
             <artifactId>trg-dao</artifactId>-->
         </dependency>
@@ -145,39 +151,18 @@
         <dependency>
 		    <groupId>com.h2database</groupId>
 		    <artifactId>h2</artifactId>
-		    <version>1.3.168</version>
+		    <version>1.3.175</version>
 		</dependency>
 
 		<!-- HIBERNATE -->
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-annotations</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>asm</groupId>
-                    <artifactId>asm-attrs</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>cglib</groupId>
-                    <artifactId>cglib</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-commons-annotations</artifactId>
-        </dependency>
+        
 <!--        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>-->
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
+            <artifactId>hibernate-core</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>asm</groupId>
@@ -192,6 +177,10 @@
                     <artifactId>cglib</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-ehcache</artifactId>
         </dependency>
 
   	<!-- CGLIB -->

--- a/src/core/persistence/src/main/resources/applicationContext-geostoreDatasource.xml
+++ b/src/core/persistence/src/main/resources/applicationContext-geostoreDatasource.xml
@@ -74,6 +74,7 @@
         <property name="jpaPropertyMap">
             <map>
                 <entry key="hibernate.cache.provider_class" value="org.hibernate.cache.EhCacheProvider"/>
+                <entry key="hibernate.cache.region.factory_class" value="org.hibernate.cache.ehcache.EhCacheRegionFactory"/>
                 <entry key="hibernate.cache.provider_configuration_file_resource_path" value="classpath:geostore-ehcache.xml"/>
                 <entry key="hibernate.cache.use_second_level_cache" value="true"/>
                 <entry key="hibernate.connection.autocommit" value="true"/>

--- a/src/core/persistence/src/main/resources/geostore-ehcache.xml
+++ b/src/core/persistence/src/main/resources/geostore-ehcache.xml
@@ -3,7 +3,7 @@
 
 	<diskStore path="java.io.tmpdir" />
 
-	<defaultCache maxElementsInMemory="10000" eternal="false"
+	<!-- defaultCache maxElementsInMemory="10000" eternal="false"
 		timeToIdleSeconds="120" timeToLiveSeconds="120" overflowToDisk="true"
 		diskPersistent="false" diskExpiryThreadIntervalSeconds="120"
 		memoryStoreEvictionPolicy="LRU" />
@@ -60,6 +60,6 @@
 		name="org.hibernate.cache.UpdateTimestampsCache"
 		maxElementsInMemory="5000"
 		eternal="true"
-		overflowToDisk="true"/>
+		overflowToDisk="true"/>-->
 
 </ehcache>

--- a/src/core/security/pom.xml
+++ b/src/core/security/pom.xml
@@ -106,6 +106,10 @@
 	      <groupId>org.jasypt</groupId>
 	      <artifactId>jasypt</artifactId>
 	   </dependency>
+       <dependency>
+            <groupId>org.acegisecurity</groupId>
+            <artifactId>acegi-security-tiger</artifactId>
+        </dependency>
 	   <dependency>
              <groupId>org.springframework.security</groupId>
              <artifactId>spring-security-ldap</artifactId>

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/ldap/MockDirContextOperations.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/ldap/MockDirContextOperations.java
@@ -484,4 +484,10 @@ public class MockDirContextOperations implements DirContextOperations{
         return null;
     }
 
+    @Override
+    public boolean attributeExists(String arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
 }

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/SimpleGrantedAuthoritiesMapper.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/SimpleGrantedAuthoritiesMapper.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
  * Map based implementation of GrantedAuthoritiesMapper.
@@ -60,7 +60,7 @@ public class SimpleGrantedAuthoritiesMapper implements GrantedAuthoritiesMapper 
         List<GrantedAuthority> result = new ArrayList<GrantedAuthority>();
         for(GrantedAuthority authority : authorities) {
             if(mappings.containsKey(authority.getAuthority())) {
-                result.add(new GrantedAuthorityImpl(mappings.get(authority.getAuthority())));
+                result.add(new SimpleGrantedAuthority(mappings.get(authority.getAuthority())));
             } else {
                 result.add(authority);
             }

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/CustomAttributesLdapUserDetailsMapper.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/CustomAttributesLdapUserDetailsMapper.java
@@ -54,7 +54,7 @@ public class CustomAttributesLdapUserDetailsMapper extends LdapUserDetailsMapper
 
     @Override
     public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
-            Collection<GrantedAuthority> authorities) {
+            Collection<? extends GrantedAuthority> authorities) {
         LdapUserDetails details =  (LdapUserDetails)super.mapUserFromContext(ctx, username, authorities);
         LdapUserDetailsWithAttributes detailsWithAttributes = new LdapUserDetailsWithAttributes(details);
         for(String attributeName : attributeMappings.keySet()) {

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/LdapUserDetailsWithAttributes.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/LdapUserDetailsWithAttributes.java
@@ -64,7 +64,7 @@ public class LdapUserDetailsWithAttributes implements LdapUserDetails, UserDetai
         return attributes.get(name);
     }
     
-    public Collection<GrantedAuthority> getAuthorities() {
+    public Collection<? extends GrantedAuthority> getAuthorities() {
         return delegate.getAuthorities();
     }
 

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/LdapUserDetailsWithAttributes.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/ldap/LdapUserDetailsWithAttributes.java
@@ -107,6 +107,11 @@ public class LdapUserDetailsWithAttributes implements LdapUserDetails, UserDetai
     public String toString() {
         return delegate.toString();
     }
+
+    @Override
+    public void eraseCredentials() {
+        delegate.eraseCredentials();
+    }
     
     
 }

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/AbstractGeoStorePasswordEncoder.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/AbstractGeoStorePasswordEncoder.java
@@ -19,8 +19,8 @@
  */
 package it.geosolutions.geostore.core.security.password;
 
+import org.acegisecurity.providers.encoding.PasswordEncoder;
 import org.springframework.dao.DataAccessException;
-import org.springframework.security.authentication.encoding.PasswordEncoder;
 
 /**
  * Abstract base implementation, delegating the encoding 
@@ -90,9 +90,19 @@ public abstract class AbstractGeoStorePasswordEncoder implements GeoStorePasswor
         return null;
     }
     
-    @Override
     public String encodePassword(String rawPass, Object salt) throws DataAccessException {
         return doEncodePassword(getStringEncoder().encodePassword(rawPass, salt));
+    }
+
+    @Override
+    public String encode(CharSequence rawPass) {
+        return doEncodePassword(getStringEncoder().encodePassword(rawPass.toString(), "salt"));
+    }
+
+    @Override
+    public boolean matches(CharSequence encPass, String rawPass) {
+        if (encPass==null) return false;
+        return getStringEncoder().isPasswordValid(stripPrefix(encPass.toString()), rawPass, "salt");
     }
 
     @Override
@@ -119,7 +129,6 @@ public abstract class AbstractGeoStorePasswordEncoder implements GeoStorePasswor
         return buff;
     }
 
-    @Override
     public boolean isPasswordValid(String encPass, String rawPass, Object salt)
             throws DataAccessException {
         if (encPass==null) return false;

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/GeoStoreAESEncoder.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/GeoStoreAESEncoder.java
@@ -8,10 +8,9 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
-
+import org.acegisecurity.providers.encoding.PasswordEncoder;
 import org.apache.commons.codec.binary.Base64;
 import org.springframework.dao.DataAccessException;
-import org.springframework.security.authentication.encoding.PasswordEncoder;
 /**
  * This class wraps the old password encoding and decoding system
  * @author Lorenzo Natali (lorenzo.natali at geo-solutions.it)

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/GeoStoreDigestPasswordEncoder.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/GeoStoreDigestPasswordEncoder.java
@@ -21,7 +21,7 @@ package it.geosolutions.geostore.core.security.password;
 
 import org.apache.commons.codec.binary.Base64;
 import org.jasypt.digest.StandardByteDigester;
-import org.jasypt.spring.security3.PasswordEncoder;
+import org.jasypt.spring.security.PasswordEncoder;
 import org.jasypt.util.password.StrongPasswordEncryptor;
 import static it.geosolutions.geostore.core.security.password.SecurityUtils.toBytes;
 

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/GeoStorePBEPasswordEncoder.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/GeoStorePBEPasswordEncoder.java
@@ -26,12 +26,11 @@ import static it.geosolutions.geostore.core.security.password.SecurityUtils.toCh
 
 import java.io.IOException;
 import java.util.Arrays;
-
+import java.util.Base64;
+import org.acegisecurity.providers.encoding.PasswordEncoder;
 import org.jasypt.encryption.pbe.StandardPBEByteEncryptor;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
-import org.jasypt.spring.security3.PBEPasswordEncoder;
-import org.springframework.security.authentication.encoding.PasswordEncoder;
-import org.springframework.security.crypto.codec.Base64;
+import org.jasypt.spring.security.PBEPasswordEncoder;
 /**
  * Password Encoder using symmetric encryption
  * 
@@ -127,7 +126,7 @@ public class GeoStorePBEPasswordEncoder extends AbstractGeoStorePasswordEncoder 
 			@Override
 			public boolean isPasswordValid(String encPass, char[] rawPass,
 					Object salt) {
-				byte[] decoded = Base64.decode(encPass.getBytes());
+				byte[] decoded = Base64.getDecoder().decode(encPass.getBytes());
 				byte[] decrypted = byteEncrypter.decrypt(decoded);
 
 				char[] chars = toChars(decrypted);
@@ -143,7 +142,7 @@ public class GeoStorePBEPasswordEncoder extends AbstractGeoStorePasswordEncoder 
 			public String encodePassword(char[] rawPass, Object salt) {
 				byte[] bytes = toBytes(rawPass);
 				try {
-					return new String(Base64.encode(byteEncrypter
+					return new String(Base64.getEncoder().encode(byteEncrypter
 							.encrypt(bytes)));
 				} finally {
 					scramble(bytes);
@@ -190,7 +189,7 @@ public class GeoStorePBEPasswordEncoder extends AbstractGeoStorePasswordEncoder 
 			getCharEncoder();
 		}
 
-		byte[] decoded = Base64.decode(removePrefix(encPass).getBytes());
+		byte[] decoded = Base64.getDecoder().decode(removePrefix(encPass).getBytes());
 		byte[] bytes = byteEncrypter.decrypt(decoded);
 		try {
 			return toChars(bytes);

--- a/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/GeoStorePasswordEncoder.java
+++ b/src/core/security/src/main/java/it/geosolutions/geostore/core/security/password/GeoStorePasswordEncoder.java
@@ -1,9 +1,7 @@
 package it.geosolutions.geostore.core.security.password;
 
 import org.springframework.beans.factory.BeanNameAware;
-import org.springframework.security.authentication.encoding.PasswordEncoder;
-
-
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
  * Password encoders have to implement this interface to be used in GeoStore
@@ -51,6 +49,8 @@ public interface GeoStorePasswordEncoder extends PasswordEncoder, BeanNameAware 
 	 * @see #encodePassword(String, Object)
 	 */
 	String encodePassword(char[] password, Object salt);
+	
+	String encodePassword(String password, Object salt);
 
 	/**
 	 * Validates a specified "raw" password (as char array) against an encoded
@@ -59,6 +59,8 @@ public interface GeoStorePasswordEncoder extends PasswordEncoder, BeanNameAware 
 	 * @see {@link #isPasswordValid(String, String, Object)
 	 */
 	boolean isPasswordValid(String encPass, char[] rawPass, Object salt);
+	
+	boolean isPasswordValid(String encPass, String rawPass, Object salt);
 
 	/**
 	 * @return a prefix which is stored with the password. This prefix must be

--- a/src/core/security/src/test/java/it/geosolutions/geostore/core/security/SimpleGrantedAuthoritiesMapperTest.java
+++ b/src/core/security/src/test/java/it/geosolutions/geostore/core/security/SimpleGrantedAuthoritiesMapperTest.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 public class SimpleGrantedAuthoritiesMapperTest {
     
@@ -29,7 +29,7 @@ public class SimpleGrantedAuthoritiesMapperTest {
    @Test
    public void testMapping() {
        roleMappings.put("A", "B");
-       authorities.add(new GrantedAuthorityImpl("A"));
+       authorities.add(new SimpleGrantedAuthority("A"));
        Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(authorities);
        assertEquals(1, mapped.size());
        assertEquals("B", mapped.iterator().next().getAuthority());

--- a/src/core/services-api/pom.xml
+++ b/src/core/services-api/pom.xml
@@ -50,12 +50,16 @@
                     <groupId>org.hibernate</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-ehcache</artifactId>
+                </exclusion>
+                <exclusion>
                     <artifactId>hibernate</artifactId>
                     <groupId>org.hibernate</groupId>
                 </exclusion>
                 <exclusion>
                     <artifactId>hibernate-commons-annotations</artifactId>
-                    <groupId>org.hibernate</groupId>
+                    <groupId>org.hibernate.common</groupId>
                 </exclusion>
                 <exclusion>
                     <artifactId>hibernate-spatial</artifactId>

--- a/src/core/services-impl/pom.xml
+++ b/src/core/services-impl/pom.xml
@@ -124,7 +124,7 @@
 -->        <dependency>
             <groupId>com.googlecode.genericdao</groupId>
 <!--            <groupId>com.trg</groupId>-->
-            <artifactId>dao</artifactId>
+            <artifactId>dao-hibernate</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -198,6 +198,18 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
 <!--            <scope>test</scope>-->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-extension-providers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-json-basic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
         </dependency>
 
 	    <!-- JUnit -->

--- a/src/modules/rest/api/pom.xml
+++ b/src/modules/rest/api/pom.xml
@@ -61,6 +61,18 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-extension-providers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-json-basic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+        </dependency>
 		<!-- dependency>
 			<groupId>com.google.code.cxf-spring-security</groupId>
 			<artifactId>cxf-spring-security</artifactId>

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTBackupService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTBackupService.java
@@ -79,7 +79,7 @@ public interface RESTBackupService {
      */
     @GET
     @Path("/quick")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN" })
     @Secured({ "ROLE_ADMIN" })
     RESTQuickBackup quickBackup(@Context SecurityContext sc) throws BadRequestServiceEx;
@@ -91,7 +91,7 @@ public interface RESTBackupService {
      */
     @PUT
     @Path("/quick")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN" })
     @Secured({ "ROLE_ADMIN" })
     String quickRestore(@Context SecurityContext sc, @Multipart("backup") RESTQuickBackup backup)

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTCategoryService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTCategoryService.java
@@ -67,7 +67,7 @@ public interface RESTCategoryService {
     @POST
     @Path("/")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML })
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN" })
     @Secured({ "ROLE_ADMIN" })
     long insert(@Context SecurityContext sc, @Multipart("category") Category category)
@@ -82,6 +82,7 @@ public interface RESTCategoryService {
     @PUT
     @Path("/category/{id}")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN" })
     @Secured({ "ROLE_ADMIN" })
     long update(@Context SecurityContext sc, @PathParam("id") long id,
@@ -104,7 +105,7 @@ public interface RESTCategoryService {
      */
     @GET
     @Path("/category/{id}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     Category get(@Context SecurityContext sc, @PathParam("id") long id) throws NotFoundWebEx;
@@ -129,6 +130,7 @@ public interface RESTCategoryService {
      */
     @GET
     @Path("/count/{nameLike}")
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     long getCount(@Context SecurityContext sc, @PathParam("nameLike") String nameLike);

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTMiscService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTMiscService.java
@@ -58,6 +58,7 @@ public interface RESTMiscService {
 
     @GET
     @Path("/category/name/{cname}/resource/name/{rname}/data")
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     String getData(@Context SecurityContext sc, @PathParam("cname") String cname,

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTResourceService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTResourceService.java
@@ -94,6 +94,7 @@ public interface RESTResourceService {
     @PUT
     @Path("/resource/{id}")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML })
+    @Produces({MediaType.TEXT_PLAIN})
     // @RolesAllowed({ "ADMIN", "USER" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     long update(@Context SecurityContext sc, @PathParam("id") long id,
@@ -128,7 +129,7 @@ public interface RESTResourceService {
      */
     @GET
     @Path("/resource/{id}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     Resource get(@Context SecurityContext sc, @PathParam("id") long id,
@@ -144,7 +145,7 @@ public interface RESTResourceService {
      */
     @GET
     @Path("/")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     ShortResourceList getAll(@Context SecurityContext sc, @QueryParam("page") Integer page,
@@ -159,7 +160,7 @@ public interface RESTResourceService {
      */
     @GET
     @Path("/search/{nameLike}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     ShortResourceList getList(@Context SecurityContext sc, @PathParam("nameLike") String nameLike,
@@ -173,7 +174,7 @@ public interface RESTResourceService {
     @POST
     @GET
     @Path("/search")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
@@ -195,7 +196,7 @@ public interface RESTResourceService {
     @POST
     @GET
     @Path("/search/list")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
@@ -211,6 +212,7 @@ public interface RESTResourceService {
      */
     @GET
     @Path("/count/{nameLike}")
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     long getCount(@Context SecurityContext sc, @PathParam("nameLike") String nameLike);
@@ -222,7 +224,7 @@ public interface RESTResourceService {
      */
     @GET
     @Path("/resource/{id}/attributes")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     ShortAttributeList getAttributes(@Context SecurityContext sc, @PathParam("id") long id)
@@ -236,7 +238,7 @@ public interface RESTResourceService {
      */
     @GET
     @Path("/resource/{id}/attributes/{name}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     String getAttribute(@Context SecurityContext sc, @PathParam("id") long id,
@@ -253,7 +255,7 @@ public interface RESTResourceService {
      */
     @PUT
     @Path("/resource/{id}/attributes/")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     @Consumes(MediaType.APPLICATION_JSON)
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     long updateAttribute(
@@ -272,7 +274,7 @@ public interface RESTResourceService {
      */
     @PUT
     @Path("/resource/{id}/attributes/{name}/{value}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN", "USER" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     long updateAttribute(@Context SecurityContext sc, @PathParam("id") long id,
@@ -289,7 +291,7 @@ public interface RESTResourceService {
      */
     @PUT
     @Path("/resource/{id}/attributes/{name}/{value}/{type}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN", "USER" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     long updateAttribute(@Context SecurityContext sc, @PathParam("id") long id,
@@ -309,7 +311,7 @@ public interface RESTResourceService {
     
     @GET
     @Path("/resource/{id}/permissions")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     SecurityRuleList getSecurityRules(@Context SecurityContext sc, @PathParam("id") long id);
 

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTStoredDataService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTStoredDataService.java
@@ -57,7 +57,7 @@ public interface RESTStoredDataService {
     @Path("/{id}")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML, MediaType.TEXT_PLAIN,
             MediaType.APPLICATION_JSON })
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN", "USER" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     long update(@Context SecurityContext sc, @PathParam("id") long id,
@@ -89,7 +89,7 @@ public interface RESTStoredDataService {
      */
     @GET
     @Path("/{id}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN", "USER", "GUEST" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     String get(@Context SecurityContext sc, @Context HttpHeaders headers, @PathParam("id") long id)
@@ -98,6 +98,7 @@ public interface RESTStoredDataService {
     @GET
     @Path("/{id}/raw")
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     Response getRaw(
     		@Context SecurityContext sc,
     		@Context HttpHeaders headers,

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserGroupService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserGroupService.java
@@ -54,7 +54,7 @@ public interface RESTUserGroupService {
     @POST
     @Path("/")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML,MediaType.APPLICATION_JSON })
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     @Secured({ "ROLE_ADMIN" })
     long insert(@Context SecurityContext sc, @Multipart("userGroup") UserGroup userGroup)
             throws BadRequestWebEx;
@@ -67,13 +67,13 @@ public interface RESTUserGroupService {
     @GET
 	@Path("/group/{id}")
     @Secured({ "ROLE_ADMIN" })
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     RESTUserGroup get(@Context SecurityContext sc, @PathParam("id") long id) throws NotFoundWebEx;
     
     @GET
 	@Path("/group/name/{name}")
     @Secured({ "ROLE_ADMIN" })
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     RESTUserGroup get(@Context SecurityContext sc, @PathParam("id") String name) throws NotFoundWebEx;
     
     @POST
@@ -90,7 +90,7 @@ public interface RESTUserGroupService {
     
     @GET
     @Path("/")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     @Secured({ "ROLE_ADMIN" })
     UserGroupList getAll(@Context SecurityContext sc, @QueryParam("page") Integer page,
             @QueryParam("entries") Integer entries, @QueryParam("all") @DefaultValue("false") boolean all, @QueryParam("users") @DefaultValue("true") boolean includeUsers) throws BadRequestWebEx;
@@ -98,7 +98,7 @@ public interface RESTUserGroupService {
     @PUT
     @Path("/update_security_rules/{groupId}/{canRead}/{canWrite}")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })    
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })    
     @Secured({ "ROLE_ADMIN" })
     ShortResourceList updateSecurityRules(@Context SecurityContext sc, @Multipart("resourcelist")ShortResourceList resourcesToSet, @PathParam("groupId") Long groupId, @PathParam("canRead") Boolean canRead, @PathParam("canWrite") Boolean canWrite) throws BadRequestWebEx, NotFoundWebEx;
 }

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserService.java
@@ -62,7 +62,7 @@ public interface RESTUserService {
     @POST
     @Path("/")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML, MediaType.APPLICATION_JSON  })
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_PLAIN })
     // @RolesAllowed({ "ADMIN" })
     @Secured({ "ROLE_ADMIN" })
     long insert(@Context SecurityContext sc, @Multipart("user") User user)
@@ -71,6 +71,7 @@ public interface RESTUserService {
     @PUT
     @Path("/user/{id}")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML,MediaType.APPLICATION_JSON  })
+    @Produces({MediaType.TEXT_PLAIN})
     // @RolesAllowed({ "ADMIN", "USER" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     long update(@Context SecurityContext sc, @PathParam("id") long id, @Multipart("user") User user)
@@ -84,7 +85,7 @@ public interface RESTUserService {
 
     @GET
     @Path("/user/{id}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN" })
     @Secured({ "ROLE_ADMIN" })
     User get(@Context SecurityContext sc, @PathParam("id") long id,
@@ -93,7 +94,7 @@ public interface RESTUserService {
 
     @GET
     @Path("/search/{name}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN" })
     @Secured({ "ROLE_ADMIN" })
     User get(@Context SecurityContext sc, @PathParam("name") String name,
@@ -103,10 +104,12 @@ public interface RESTUserService {
     @GET
     @Path("/")
     // @RolesAllowed({ "ADMIN" })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     @Secured({ "ROLE_ADMIN" })
     UserList getAll(@Context SecurityContext sc, @QueryParam("page") Integer page,
             @QueryParam("entries") Integer entries) throws BadRequestWebEx;
 
+    @Produces({ MediaType.TEXT_PLAIN })
     @GET
     @Path("/count/{nameLike}")
     // @RolesAllowed({ "ADMIN" })
@@ -115,7 +118,7 @@ public interface RESTUserService {
 
     @GET
     @Path("/user/details/")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN", "USER" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     User getAuthUserDetails(@Context SecurityContext sc,
@@ -123,7 +126,7 @@ public interface RESTUserService {
 
     @GET
     @Path("/search/list/{nameLike}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     // @RolesAllowed({ "ADMIN", "USER" })
     @Secured({ "ROLE_USER", "ROLE_ADMIN" })
     UserList getUserList(@Context SecurityContext sc, @PathParam("nameLike") String nameLike,

--- a/src/modules/rest/auditing/pom.xml
+++ b/src/modules/rest/auditing/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-core</artifactId>
+            <artifactId>cxf-rt-transports-http</artifactId>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/src/modules/rest/auditing/src/main/java/it/geosolutions/geostore/services/rest/auditing/AuditInfoExtractor.java
+++ b/src/modules/rest/auditing/src/main/java/it/geosolutions/geostore/services/rest/auditing/AuditInfoExtractor.java
@@ -67,7 +67,7 @@ final class AuditInfoExtractor {
         return auditInfo;
     }
 
-    static Integer
+    static Long
     getResponseLength(Message message) {
         try {
             CachedOutputStream outputStream = (CachedOutputStream) message.getContent(OutputStream.class);

--- a/src/modules/rest/auditing/src/main/java/it/geosolutions/geostore/services/rest/auditing/AuditingInterceptorPostMarshall.java
+++ b/src/modules/rest/auditing/src/main/java/it/geosolutions/geostore/services/rest/auditing/AuditingInterceptorPostMarshall.java
@@ -43,7 +43,7 @@ public final class AuditingInterceptorPostMarshall extends AbstractPhaseIntercep
 
     @Override
     public void handleMessage(Message message) throws Fault {
-        Integer responseLength = AuditInfoExtractor.getResponseLength(message);
+        Long responseLength = AuditInfoExtractor.getResponseLength(message);
         if (responseLength != null) {
             message.getExchange().put(AuditInfo.RESPONSE_LENGTH.getKey(), responseLength.toString());
         }

--- a/src/modules/rest/auditing/src/test/java/it/geosolutions/geostore/services/rest/auditing/AuditInfoExtractorTest.java
+++ b/src/modules/rest/auditing/src/test/java/it/geosolutions/geostore/services/rest/auditing/AuditInfoExtractorTest.java
@@ -99,7 +99,7 @@ public final class AuditInfoExtractorTest extends AuditingTestsBase {
 
     private static CachedOutputStream getCacheOutputStream() {
         CachedOutputStream outputStream = Mockito.mock(CachedOutputStream.class);
-        Mockito.when(outputStream.size()).thenReturn(100);
+        Mockito.when(outputStream.size()).thenReturn(100L);
         return outputStream;
     }
 

--- a/src/modules/rest/client/src/main/java/it/geosolutions/geostore/services/security/GeoStoreAuthenticationProvider.java
+++ b/src/modules/rest/client/src/main/java/it/geosolutions/geostore/services/security/GeoStoreAuthenticationProvider.java
@@ -11,7 +11,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import com.sun.jersey.api.client.ClientHandlerException;
@@ -86,7 +86,7 @@ public class GeoStoreAuthenticationProvider implements AuthenticationProvider {
 			}
 //				return null;
 			List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-			authorities.add(new GrantedAuthorityImpl("ROLE_" + role));
+			authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
 			Authentication a = new UsernamePasswordAuthenticationToken(us, pw,
 					authorities);
 			// a.setAuthenticated(true);

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/RESTExtJsService.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/RESTExtJsService.java
@@ -113,7 +113,7 @@ public interface RESTExtJsService {
     @POST
     @GET
     @Path("/search/list")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     @Consumes({ MediaType.APPLICATION_XML, MediaType.TEXT_XML })
     @Secured({ "ROLE_ADMIN", "ROLE_USER", "ROLE_ANONYMOUS" })
     ExtResourceList getExtResourcesList(@Context SecurityContext sc,
@@ -147,7 +147,7 @@ public interface RESTExtJsService {
      */
     @GET
     @Path("/search/groups/{nameLike}")
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     @Secured({ "ROLE_ADMIN", "ROLE_USER"})
     ExtGroupList getGroupsList(@Context SecurityContext sc,
             @PathParam("nameLike") String nameLike,
@@ -158,7 +158,7 @@ public interface RESTExtJsService {
 
     @GET
     @Path("/resource/{id}")
-    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @Produces({ MediaType.TEXT_XML, MediaType.APPLICATION_JSON })
     @Secured({ "ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS" })
     ShortResource getResource(@Context SecurityContext sc,
             @PathParam("id") long id)

--- a/src/modules/rest/extjs/src/main/resources/applicationContext.xml
+++ b/src/modules/rest/extjs/src/main/resources/applicationContext.xml
@@ -20,7 +20,7 @@
 	<!-- Load CXF modules from cxf.jar -->
     <import resource="classpath:META-INF/cxf/cxf.xml"/>
     <import resource="classpath:META-INF/cxf/cxf-servlet.xml"/>
-    <import resource="classpath:META-INF/cxf/cxf-extension-jaxrs-binding.xml" />
+    <!--import resource="classpath:META-INF/cxf/cxf-extension-jaxrs-binding.xml" /-->
 
     <!-- ====================================================================-->
     <!-- === Service providers ==============================================-->

--- a/src/modules/rest/impl/pom.xml
+++ b/src/modules/rest/impl/pom.xml
@@ -104,6 +104,18 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-extension-providers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-json-basic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+        </dependency>
 		<!-- dependency>
 			<groupId>com.google.code.cxf-spring-security</groupId>
 			<artifactId>cxf-spring-security</artifactId>

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTServiceImpl.java
@@ -52,7 +52,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
  * Class RESTServiceImpl.
@@ -277,7 +277,7 @@ public abstract class RESTServiceImpl{
      */
     public Principal createGuestPrincipal(){
         List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new GrantedAuthorityImpl("ROLE_GUEST"));
+        authorities.add(new SimpleGrantedAuthority("ROLE_GUEST"));
         try {
             User u = userService.get(UserReservedNames.GUEST.userName());
             return new UsernamePasswordAuthenticationToken(u,"", authorities);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/GeoStoreAuthenticationFilter.java
@@ -50,7 +50,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.filter.GenericFilterBean;
 
 /**
@@ -168,7 +168,7 @@ public abstract class GeoStoreAuthenticationFilter extends GenericFilterBean {
             String role = user.getRole().toString();
 
             List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-            authorities.add(new GrantedAuthorityImpl("ROLE_" + role));
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
             return new UsernamePasswordAuthenticationToken(user, user.getPassword(), authorities);
         } else {
             LOGGER.error(USER_NOT_FOUND_MSG);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/GeoStoreLdapAuthoritiesPopulator.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/GeoStoreLdapAuthoritiesPopulator.java
@@ -40,7 +40,7 @@ import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.support.AbstractContextMapper;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
 import org.springframework.util.Assert;
@@ -254,7 +254,7 @@ public class GeoStoreLdapAuthoritiesPopulator extends
 
         String prefix = (authorityPrefix != null && !authority.startsWith(authorityPrefix) ? authorityPrefix : "");
         
-        GrantedAuthorityImpl role = new GrantedAuthorityImpl(prefix + authority);
+        SimpleGrantedAuthority role = new SimpleGrantedAuthority(prefix + authority);
         if (!authorities.contains(role)) {
             authorities.add(role);
             return true;

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/HeadersAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/HeadersAuthenticationFilter.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import it.geosolutions.geostore.core.model.User;
@@ -91,7 +91,7 @@ public class HeadersAuthenticationFilter extends GeoStoreAuthenticationFilter {
                     group.setId(groupCounter++);
                     group.setEnabled(true);
                     user.getGroups().add(group);
-                    groupAuthorities.add(new GrantedAuthorityImpl(groupName));
+                    groupAuthorities.add(new SimpleGrantedAuthority(groupName));
                 }
                 
             }
@@ -101,7 +101,7 @@ public class HeadersAuthenticationFilter extends GeoStoreAuthenticationFilter {
                 group.setId(groupCounter++);
                 group.setEnabled(true);
                 user.getGroups().add(group);
-                groupAuthorities.add(new GrantedAuthorityImpl(GroupReservedNames.EVERYONE.groupName()));
+                groupAuthorities.add(new SimpleGrantedAuthority(GroupReservedNames.EVERYONE.groupName()));
             }
             Set<GrantedAuthority> authorities = new HashSet<GrantedAuthority>();
             String role = req.getHeader(roleHeader);
@@ -136,8 +136,8 @@ public class HeadersAuthenticationFilter extends GeoStoreAuthenticationFilter {
         return Role.GUEST;
     }
 
-    private GrantedAuthorityImpl createRole(String role) {
-        return new GrantedAuthorityImpl("ROLE_" + role);
+    private SimpleGrantedAuthority createRole(String role) {
+        return new SimpleGrantedAuthority("ROLE_" + role);
     }
 
     private Role getUserRole(String role) {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/RestAuthenticationEntryPoint.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/RestAuthenticationEntryPoint.java
@@ -52,7 +52,7 @@ public class RestAuthenticationEntryPoint extends  BasicAuthenticationEntryPoint
 	@Override
 	public void commence(HttpServletRequest request,
 			HttpServletResponse response, AuthenticationException authException)
-			throws IOException, ServletException {
+			throws IOException {
 			URI url=null;
 			try {
 				url = new URI(request.getRequestURI());

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserLdapAuthenticationProvider.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserLdapAuthenticationProvider.java
@@ -28,7 +28,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.security.ldap.authentication.LdapAuthenticator;
@@ -189,7 +189,7 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
      */
     protected Authentication prepareAuthentication(String pw, User user, Role role) {
         List<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
-        grantedAuthorities.add(new GrantedAuthorityImpl("ROLE_" + role));
+        grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_" + role));
         Authentication a = new UsernamePasswordAuthenticationToken(user, pw, grantedAuthorities);
         // a.setAuthenticated(true);
         return a;

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserLdapAuthenticationProvider.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserLdapAuthenticationProvider.java
@@ -99,7 +99,7 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
         LdapUserDetails ldapUser = null;
         if (authentication.isAuthenticated()) {
 
-            Collection<GrantedAuthority> authorities = null;
+            Collection<? extends GrantedAuthority> authorities = null;
 
             ldapUser = (LdapUserDetails) authentication.getPrincipal();
 
@@ -203,7 +203,7 @@ private final static Logger LOGGER = Logger.getLogger(UserLdapAuthenticationProv
      * @throws BadRequestServiceEx
      */
     protected Role extractUserRoleAndGroups(Role userRole,
-            Collection<GrantedAuthority> authorities, Set<UserGroup> groups)
+            Collection<? extends GrantedAuthority> authorities, Set<UserGroup> groups)
             throws BadRequestServiceEx {
         Role role = (userRole != null ? userRole : Role.USER);
         for (GrantedAuthority a : authorities) {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserServiceAuthenticationProvider.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/UserServiceAuthenticationProvider.java
@@ -15,7 +15,7 @@ import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 /**
@@ -72,7 +72,7 @@ public class UserServiceAuthenticationProvider implements AuthenticationProvider
             String role = user.getRole().toString();
             // return null;
             List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-            authorities.add(new GrantedAuthorityImpl("ROLE_" + role));
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
             Authentication a = new UsernamePasswordAuthenticationToken(user, pw, authorities);
             // a.setAuthenticated(true);
             return a;

--- a/src/modules/rest/impl/src/main/resources/applicationContext.xml
+++ b/src/modules/rest/impl/src/main/resources/applicationContext.xml
@@ -29,7 +29,7 @@
 	<import resource="classpath:META-INF/cxf/cxf.xml" />
 	<import resource="classpath*:META-INF/cxf/cxf-*.xml" />
 	<import resource="classpath:META-INF/cxf/cxf-servlet.xml" />
-	<import resource="classpath:META-INF/cxf/cxf-extension-jaxrs-binding.xml" />
+	<!-- import resource="classpath:META-INF/cxf/cxf-extension-jaxrs-binding.xml" /> -->
 
 	<!-- === SEC ======================================================== -->
 	<import resource="classpath*:geostore-spring-security.xml" />
@@ -227,9 +227,10 @@
 
         <jaxrs:providers>
            <ref bean="jaxbXmlProvider"/>
-           <bean class="org.apache.cxf.jaxrs.provider.JSONProvider">
+           <ref bean="jsonProvider"/>
+           <!--bean class="org.apache.cxf.jaxrs.provider.json.JSONProvider">
 	           <property name="dropRootElement" value="true"/>
-	     </bean>
+	     </bean-->
            <ref bean="jaxbContextResolver"/>
            <bean class="it.geosolutions.geostore.services.rest.security.SecurityExceptionMapper"/>
         </jaxrs:providers>    
@@ -264,7 +265,7 @@
 	<!-- === CXF Providers ================================================== -->
 	<!-- ==================================================================== -->
 	<bean id="jaxbXmlProvider" class="org.apache.cxf.jaxrs.provider.JAXBElementProvider" />
-	<bean id="jsonProvider" class="org.apache.cxf.jaxrs.provider.JSONProvider" />
+	<bean id="jsonProvider" class="org.apache.cxf.jaxrs.provider.json.JSONProvider" />
 	<bean id="jaxbContextResolver"
 		class="it.geosolutions.geostore.services.rest.utils.JAXBContextResolver" />
 

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/HeadersAuthenticationFilterTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/HeadersAuthenticationFilterTest.java
@@ -46,7 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import com.google.common.collect.Lists;
 import it.geosolutions.geostore.core.model.User;
@@ -178,7 +178,7 @@ public class HeadersAuthenticationFilterTest {
                     Collection<? extends GrantedAuthority> authorities) {
                 for (GrantedAuthority authority : authorities) {
                     if (ROLE_GROUP.equals(authority.getAuthority())) {
-                        return Lists.newArrayList(new GrantedAuthorityImpl("ADMIN"));
+                        return Lists.newArrayList(new SimpleGrantedAuthority("ADMIN"));
                     }
                 }
                 return Lists.newArrayList();

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/MockDirContextOperations.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/MockDirContextOperations.java
@@ -478,4 +478,10 @@ public class MockDirContextOperations implements DirContextOperations {
 
     }
 
+    @Override
+    public boolean attributeExists(String arg0) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
 }

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/UserLdapAuthenticationProviderTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/UserLdapAuthenticationProviderTest.java
@@ -21,21 +21,19 @@ package it.geosolutions.geostore.rest.security;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
 import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
 import it.geosolutions.geostore.services.rest.security.UserLdapAuthenticationProvider;
 import it.geosolutions.geostore.services.rest.utils.MockedUserGroupService;
 import it.geosolutions.geostore.services.rest.utils.MockedUserService;
-
-import java.util.Collections;
-import java.util.Set;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
 
 public class UserLdapAuthenticationProviderTest {
     private static final String TEST_GROUP = "testgroup";
@@ -50,7 +48,7 @@ public class UserLdapAuthenticationProviderTest {
 
             @Override
             public Set<GrantedAuthority> getAllGroups() {
-                return Collections.singleton((GrantedAuthority)new GrantedAuthorityImpl(TEST_GROUP));
+                return Collections.singleton((GrantedAuthority)new SimpleGrantedAuthority(TEST_GROUP));
             }
             
         });

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -74,11 +74,11 @@
         spring-security-core 3.0.4 requires spring-core 3.x, otherwise we'd normally use 2.5.6, which
         is what the rest of the app uses
         -->
-        <spring-version>3.0.5.RELEASE</spring-version>
+        <spring-version>3.1.1.RELEASE</spring-version>
 
         <!-- 2.5.6.SEC01 is the version used by smix-->
         <!-- 2.5.5       is the version used by memberService-->
-        <spring-security-version>3.0.5.RELEASE</spring-security-version>
+        <spring-security-version>3.1.1.RELEASE</spring-security-version>
         <spring-security-crypto-version>3.1.3.RELEASE</spring-security-crypto-version>
         <camel-version>1.6.1.2-fuse</camel-version>
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -66,7 +66,7 @@
         <geostore-version>1.8-SNAPSHOT</geostore-version>
         <main-prefix>geostore</main-prefix>
 
-        <cxf-version>2.3.2</cxf-version>
+        <cxf-version>3.4.4</cxf-version>
         <activemq-version>5.3.0.4-fuse</activemq-version>
 
         <jersey-version>2.5.1</jersey-version>
@@ -74,12 +74,11 @@
         spring-security-core 3.0.4 requires spring-core 3.x, otherwise we'd normally use 2.5.6, which
         is what the rest of the app uses
         -->
-        <spring-version>3.1.1.RELEASE</spring-version>
+        <spring-version>5.3.9</spring-version>
 
         <!-- 2.5.6.SEC01 is the version used by smix-->
         <!-- 2.5.5       is the version used by memberService-->
-        <spring-security-version>3.1.1.RELEASE</spring-security-version>
-        <spring-security-crypto-version>3.1.3.RELEASE</spring-security-crypto-version>
+        <spring-security-version>5.3.10.RELEASE</spring-security-version>
         <camel-version>1.6.1.2-fuse</camel-version>
 
         <velocity-version>1.6.2</velocity-version>
@@ -118,16 +117,14 @@
         <aspectj-version>1.5.4</aspectj-version>
         <ubl-version>2.0</ubl-version>
         <jetty-version>6.1.0.1-fuse</jetty-version>
-        <jettison-version>1.2</jettison-version>
+        <jettison-version>1.4.0</jettison-version>
 
 <!--        <postgis-jdbc-version>1.1.6</postgis-jdbc-version>-->
 <!--        <postgis-jdbc-version>1.3.3</postgis-jdbc-version>-->
 
         <persistence-version>1.0</persistence-version>
-        <hibernate-version>3.3.2.GA</hibernate-version>
-        <hibernate-annotations-version>3.3.1.GA</hibernate-annotations-version>
-        <hibernate-commons-annotations-version>3.3.0.ga</hibernate-commons-annotations-version>
-        <hibernate-generic-dao-version>0.5.1</hibernate-generic-dao-version>
+        <hibernate-version>5.5.0.Final</hibernate-version>
+        <hibernate-generic-dao-version>1.2.0</hibernate-generic-dao-version>
         <asm-version>2.2.3</asm-version>
         <cglib-version>2.1_3</cglib-version>
         <guava-version>18.0</guava-version>
@@ -435,6 +432,23 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-rs-extension-providers</artifactId>
+                <version>${cxf-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-rs-json-basic</artifactId>
+                <version>${cxf-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-rs-client</artifactId>
+                <version>${cxf-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http-jetty</artifactId>
                 <version>${cxf-version}</version>
             </dependency>
@@ -580,12 +594,6 @@
                 <version>${spring-version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-remoting</artifactId>
-                <version>${spring-version}</version>
-            </dependency>
-
             <!-- =========================================================== -->
             <!--     SPRING SECURITY                                          -->
             <!-- ===========================================================  -->
@@ -625,21 +633,37 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-crypto</artifactId>
-                <version>3.1.3.RELEASE</version>
+                <version>${spring-security-version}</version>
             </dependency>
             <dependency>
               <groupId>org.jasypt</groupId>
               <artifactId>jasypt</artifactId>
               <version>1.8</version>
             </dependency>
+            <dependency>
+                <groupId>org.acegisecurity</groupId>
+                <artifactId>acegi-security-tiger</artifactId>
+                <version>1.0.7</version>
+            </dependency>
+
 		    <!-- =========================================================== -->
 		    <!--     JAVAX PERSISTENCE                                       -->
 		    <!-- =========================================================== -->
-            <dependency>
+            <!--dependency>
                 <groupId>javax.persistence</groupId>
                 <artifactId>persistence-api</artifactId>
                 <version>${persistence-version}</version>
+            </dependency-->
+
+            <!-- https://mvnrepository.com/artifact/org.hibernate.javax.persistence/hibernate-jpa-2.0-api -->
+            <!-- https://mvnrepository.com/artifact/org.hibernate.javax.persistence/hibernate-jpa-2.1-api -->
+            <dependency>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.1-api</artifactId>
+                <version>1.0.2.Final</version>
             </dependency>
+
+
 
 		    <!-- =========================================================== -->
 		    <!--     JAVAX SERVLET                                           -->
@@ -703,19 +727,22 @@
 		    <!-- =========================================================== -->
 		    <!--     HIBERNATE-GENERIC-DAO                                   -->
 		    <!-- =========================================================== -->
+            <!-- https://mvnrepository.com/artifact/com.googlecode.genericdao/dao-hibernate -->
             <dependency>
+                <groupId>com.googlecode.genericdao</groupId>
+                <artifactId>dao-hibernate</artifactId>
+                <version>1.3.0-SNAPSHOT</version>
+            </dependency>
+
+            <!--dependency>
                 <groupId>com.googlecode.genericdao</groupId>
                 <artifactId>dao</artifactId>
                 <version>1.1.0</version>
-<!--            </dependency>            <dependency>
-                <groupId>com.trg</groupId>
-                <artifactId>trg-dao</artifactId>
-                <version>${hibernate-generic-dao-version}</version>-->
-            </dependency>
+            </dependency-->
             <dependency>
                 <groupId>com.googlecode.genericdao</groupId>
                 <artifactId>search-jpa-hibernate</artifactId>
-                <version>1.1.0</version>
+                <version>1.3.0-SNAPSHOT</version>
 <!--                <groupId>com.trg</groupId>
                 <artifactId>trg-search-jpa-hibernate</artifactId>
                 <version>${hibernate-generic-dao-version}</version>-->
@@ -725,24 +752,21 @@
 		    <!-- =========================================================== -->
             <dependency>
                 <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-annotations</artifactId>
-                <version>${hibernate-annotations-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-commons-annotations</artifactId>
-                <version>${hibernate-commons-annotations-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-entitymanager</artifactId>
+                <artifactId>hibernate-core</artifactId>
                 <version>${hibernate-version}</version>
             </dependency>
+            <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-ehcache -->
             <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-ehcache</artifactId>
+                <version>${hibernate-version}</version>
+            </dependency>
+
+            <!--dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>3.0.0.ga</version>
-            </dependency>
+            </dependency-->
 
 		    <!-- =========================================================== -->
 		    <!--     HIBERNATE-SPATIAL                                       -->
@@ -958,14 +982,14 @@
             </snapshots>
         </repository>
         <!-- JBoss -->
-        <repository>
+        <!--repository>
             <id>jboss-repo</id>
             <name>JBoss Maven2 Repository</name>
             <url>http://repository.jboss.com/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-        </repository>
+        </repository-->
 
         <!-- Spring -->
         <repository>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -45,6 +45,18 @@
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
             <!-- <scope>test</scope> -->
         </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-extension-providers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-json-basic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+        </dependency>
 
         <!-- =========================================================== -->
         <!-- TEST -->
@@ -62,6 +74,11 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http-jetty</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/web/app/src/main/resources/geostore-spring-security.xml
+++ b/src/web/app/src/main/resources/geostore-spring-security.xml
@@ -22,6 +22,7 @@
 
 	<security:http auto-config="true" create-session="never" >
 		<security:http-basic entry-point-ref="restAuthenticationEntryPoint"/>
+		<security:csrf disabled="true"/>
 		<security:custom-filter ref="authenticationTokenProcessingFilter" before="FORM_LOGIN_FILTER"/>
 		<security:custom-filter ref="sessionTokenProcessingFilter" after="FORM_LOGIN_FILTER"/>
 		<!--

--- a/src/web/app/src/main/webapp/WEB-INF/web.xml
+++ b/src/web/app/src/main/webapp/WEB-INF/web.xml
@@ -20,9 +20,9 @@
 		</context-param> -->
 
 	<!-- spring context loader -->
-	<listener>
+	<!--listener>
 		<listener-class>org.springframework.web.util.Log4jConfigListener</listener-class>
-	</listener>
+	</listener-->
 
 	<!--
       - Loads the root application context of this web app at startup.

--- a/src/web/app/src/test/resources/applicationContext-test.xml
+++ b/src/web/app/src/test/resources/applicationContext-test.xml
@@ -27,7 +27,7 @@
 	<import resource="classpath:META-INF/cxf/cxf.xml" />
 	<!-- import resource="classpath*:META-INF/cxf/cxf-*.xml" / -->
 	<!-- import resource="classpath:META-INF/cxf/cxf-servlet.xml" / -->
-	<import resource="classpath:META-INF/cxf/cxf-extension-jaxrs-binding.xml" />
+	<!--import resource="classpath:META-INF/cxf/cxf-extension-jaxrs-binding.xml" /-->
 	<import resource="classpath:META-INF/cxf/cxf-extension-http-jetty.xml" /> 
 
 	<!-- === SEC ======================================================== -->
@@ -234,7 +234,7 @@
 	<!-- === CXF Providers ================================================== -->
 	<!-- ==================================================================== -->
 	<bean id="jaxbXmlProvider" class="org.apache.cxf.jaxrs.provider.JAXBElementProvider" />
-	<bean id="jsonProvider" class="org.apache.cxf.jaxrs.provider.JSONProvider" />
+	<bean id="jsonProvider" class="org.apache.cxf.jaxrs.provider.json.JSONProvider" />
 	<bean id="jaxbContextResolver"
 		class="it.geosolutions.geostore.services.rest.utils.JAXBContextResolver" />
 


### PR DESCRIPTION
Connected to #232 

The purpose of this work is to upgrade the Spring dependency to a more recent version, to enable implementing features that depend on Spring libraries that are not compatible with the actual 3.0.5 version.

Upgrading Spring required upgrading other libraries that depend on it. A short list:

| Library      | Old |New|
| ----------- | ----------- |--|
| Spring| 3.0.5|5.3.9|
| Spring-security| 3.0.5        |5.3.10|
| CXF| 2.3.2        |3.4.4|
| Hibernate|      3.3.2   |5.5.0|
| JPA| 1.0        |2.1|
| hibernate-generic-dao| 0.5.1        |1.3.0-SNAPSHOT|

After upgrading the libraries, all tests have been run (both offline and online) and passing. Some manual testing has been done too, including tests with MapStore.

Most of the changes in code are for:
 - changes in JPA 2.1 annotations
 - Password encoding moved to agecisecurity module
 - cleanup / fixing of REST apis produced media types, that were not working correctly anymore with upgraded libraries

**BREAKING CHANGES:**
 - csrf is enabled by default by the new spring security library, and this is conflicting with CXF endpoints, so this needs to be disabled in the geostore spring security configuration file (geostore-spring-security.xml):

```xml
<security:http auto-config="true" create-session="never" >
   ...
   <security:csrf disabled="true"/>
   ...
</security:http>
```

 - log4j and spring integration is automatic, and the related listener is not required anymore (and generates an error if not removed), so this needs to be removed from the application web.xml in depending projects (e.g. MapStore):

```xml
   <listener>
		<listener-class>org.springframework.web.util.Log4jConfigListener</listener-class>
   </listener>
```