### PR TITLE
Using LTS JDKs on TCK tested builds of OpenJDK.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,19 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java-version: [ 11 ]
+        distros: [ 'zulu', 'temurin' ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: ${{ matrix.java-version }}
+        distribution: ${{ matrix.distros }}
         cache: maven
     - name: Build with Maven
       run: mvn -B clean install -Pextjs,h2_disk,auditing


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. Using Zulu and Temurin as distros. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Added a matrix to conveniently add the next upcoming LTS version of the JDK (17) once it is released.