### PR TITLE
[Backport 1.7.x] Upgrading log4j to a version that does not support RCEs (#243)

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -105,7 +105,7 @@
         <jaxb-api-version>2.1</jaxb-api-version>
         <jaxb-impl-version>2.1.2</jaxb-impl-version>
 
-        <log4j-version>1.2.16</log4j-version>
+        <log4j-version>1.2.17.norce</log4j-version>
         <slf4japi-version>1.7.2</slf4japi-version>
         <dom4j-version>1.6.1</dom4j-version>
 


### PR DESCRIPTION
[Backport 1.7.x] Upgrading log4j to a version that does not support RCEs (#243)