### PR TITLE
Update master to 1.9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>it.geosolutions</groupId>
     <artifactId>geostore</artifactId>
-    <version>1.8-SNAPSHOT</version>
+    <version>1.9-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-cli</artifactId>

--- a/src/core/model/pom.xml
+++ b/src/core/model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-model</artifactId>

--- a/src/core/persistence/pom.xml
+++ b/src/core/persistence/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-persistence</artifactId>

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-core</artifactId>

--- a/src/core/security/pom.xml
+++ b/src/core/security/pom.xml
@@ -24,7 +24,7 @@
      <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-security</artifactId>

--- a/src/core/services-api/pom.xml
+++ b/src/core/services-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-services-api</artifactId>

--- a/src/core/services-impl/pom.xml
+++ b/src/core/services-impl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-services-impl</artifactId>

--- a/src/modules/pom.xml
+++ b/src/modules/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-modules</artifactId>

--- a/src/modules/rest/api/pom.xml
+++ b/src/modules/rest/api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-api</artifactId>

--- a/src/modules/rest/auditing/pom.xml
+++ b/src/modules/rest/auditing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
     <artifactId>geostore-rest-auditing</artifactId>
     <name>GeoStore - Modules - REST auditing</name>

--- a/src/modules/rest/client/pom.xml
+++ b/src/modules/rest/client/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-client</artifactId>

--- a/src/modules/rest/extjs/pom.xml
+++ b/src/modules/rest/extjs/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-extjs</artifactId>

--- a/src/modules/rest/impl/pom.xml
+++ b/src/modules/rest/impl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-impl</artifactId>

--- a/src/modules/rest/pom.xml
+++ b/src/modules/rest/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-modules</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-root</artifactId>

--- a/src/modules/rest/test/pom.xml
+++ b/src/modules/rest/test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-test</artifactId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>it.geosolutions</groupId>
         <artifactId>geostore</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <groupId>it.geosolutions.geostore</groupId>
@@ -63,7 +63,7 @@
     </profiles>
 
     <properties>
-        <geostore-version>1.8-SNAPSHOT</geostore-version>
+        <geostore-version>1.9-SNAPSHOT</geostore-version>
         <main-prefix>geostore</main-prefix>
 
         <cxf-version>3.4.4</cxf-version>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-web</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-webapp</artifactId>

--- a/src/web/pom.xml
+++ b/src/web/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>1.8-SNAPSHOT</version>
+        <version>1.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-web</artifactId>


### PR DESCRIPTION
There was a recent update in 1.8.x to upgrade HTTPClient from 3.x to 4.x
This resulted in MapStore2-C039 inheriting that HTTP upgrade although one of its module was still using the older one, so it ended up in using 2 different versions.

https://github.com/geosolutions-it/webmapper-halliburton/issues/2327#issuecomment-1029150049

So the idea was to have a 1.8.x branch with the commit right before that HTTP client upgrade and have master moving to 1.9.x



