### PR TITLE
change hibernate and google genric-dao versions

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -123,8 +123,8 @@
 <!--        <postgis-jdbc-version>1.3.3</postgis-jdbc-version>-->
 
         <persistence-version>1.0</persistence-version>
-        <hibernate-version>5.5.0.Final</hibernate-version>
-        <hibernate-generic-dao-version>1.2.0</hibernate-generic-dao-version>
+        <hibernate-version>5.4.33.Final</hibernate-version>
+        <hibernate-generic-dao-version>geosolutions-1.3.0</hibernate-generic-dao-version>
         <asm-version>2.2.3</asm-version>
         <cglib-version>2.1_3</cglib-version>
         <guava-version>18.0</guava-version>
@@ -739,7 +739,7 @@
             <dependency>
                 <groupId>com.googlecode.genericdao</groupId>
                 <artifactId>dao-hibernate</artifactId>
-                <version>1.3.0-SNAPSHOT</version>
+                <version>geosolutions-1.3.0</version>
             </dependency>
 
             <!--dependency>
@@ -750,7 +750,7 @@
             <dependency>
                 <groupId>com.googlecode.genericdao</groupId>
                 <artifactId>search-jpa-hibernate</artifactId>
-                <version>1.3.0-SNAPSHOT</version>
+                <version>geosolutions-1.3.0</version>
 <!--                <groupId>com.trg</groupId>
                 <artifactId>trg-search-jpa-hibernate</artifactId>
                 <version>${hibernate-generic-dao-version}</version>-->


### PR DESCRIPTION
Follow up the changes in googlecode genric dao and spring 5.3.18 and updates maven versions.