### PR TITLE
(#290) LDAP UserDAO avoid loading groups' nested users

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserDAOImpl.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 
 import javax.naming.directory.SearchControls;
 
+import it.geosolutions.geostore.core.dao.search.GeoStoreISearchWrapper;
 import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.DirContextProcessor;
@@ -221,7 +222,8 @@ public class UserDAOImpl extends LdapBaseDAOImpl implements UserDAO {
             Search searchCriteria = new Search(UserGroup.class);
             searchCriteria.addFilterSome("user",
                     new Filter("name", ctx.getNameInNamespace(), Filter.OP_EQUAL));
-            for (UserGroup ug : userGroupDAO.search(searchCriteria)) {
+            GeoStoreISearchWrapper searchWrapper=new GeoStoreISearchWrapper(searchCriteria,this.getClass());
+            for (UserGroup ug : userGroupDAO.search(searchWrapper)) {
                 if (isAdminGroup(ug)) {
                     user.setRole(Role.ADMIN);
                 }

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/search/GeoStoreISearchWrapper.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/search/GeoStoreISearchWrapper.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (C) 2007 - 2022 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package it.geosolutions.geostore.core.dao.search;
+
+import com.googlecode.genericdao.search.Field;
+import com.googlecode.genericdao.search.Filter;
+import com.googlecode.genericdao.search.ISearch;
+import com.googlecode.genericdao.search.Sort;
+
+import java.util.List;
+
+/**
+ * A wrapper for an ISearch. It is meant to provide the callerContext as a Class.
+ */
+public class GeoStoreISearchWrapper implements ISearch {
+
+    private ISearch delegate;
+
+    private Class<?> callerContext;
+
+    public GeoStoreISearchWrapper(ISearch delegate, Class<?> callerContext){
+        this.delegate=delegate;
+        this.callerContext = callerContext;
+    }
+    @Override
+    public int getFirstResult() {
+        return delegate.getFirstResult();
+    }
+
+    @Override
+    public int getMaxResults() {
+        return delegate.getMaxResults();
+    }
+
+    @Override
+    public int getPage() {
+        return delegate.getPage();
+    }
+
+    @Override
+    public Class<?> getSearchClass() {
+        return delegate.getSearchClass();
+    }
+
+    @Override
+    public List<Filter> getFilters() {
+        return delegate.getFilters();
+    }
+
+    @Override
+    public boolean isDisjunction() {
+        return delegate.isDisjunction();
+    }
+
+    @Override
+    public List<Sort> getSorts() {
+        return delegate.getSorts();
+    }
+
+    @Override
+    public List<Field> getFields() {
+        return delegate.getFields();
+    }
+
+    @Override
+    public boolean isDistinct() {
+        return delegate.isDistinct();
+    }
+
+    @Override
+    public List<String> getFetches() {
+        return delegate.getFetches();
+    }
+
+    @Override
+    public int getResultMode() {
+        return delegate.getResultMode();
+    }
+
+    /**
+     * @return the caller context if present, null otherwise.
+     */
+    public Class<?> getCallerContext() {
+        return callerContext;
+    }
+}

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/BaseDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/BaseDAOTest.java
@@ -210,6 +210,14 @@ public abstract class BaseDAOTest {
                                 }
                                 return "";
                             }
+
+                            @Override
+                            public String [] getStringAttributes(String name){
+                                if ("member".equals(name)){
+                                    return new String [] {"username"};
+                                }
+                                return super.getStringAttributes(name);
+                            }
                             
                         }, new BasicAttributes());
                         return new IterableNamingEnumeration(Collections.singletonList(sr));
@@ -227,6 +235,14 @@ public abstract class BaseDAOTest {
                                     return "group";
                                 }
                                 return "";
+                            }
+
+                            @Override
+                            public String [] getStringAttributes(String name){
+                                if ("member".equals(name)){
+                                    return new String [] {"username"};
+                                }
+                                return super.getStringAttributes(name);
                             }
                             
                         }, new BasicAttributes());


### PR DESCRIPTION
Avoid the loading the Users nested into UserGroup when returning user search results.