### PR TITLE
remove xom depedencies

### DIFF
--- a/src/modules/rest/impl/pom.xml
+++ b/src/modules/rest/impl/pom.xml
@@ -202,13 +202,6 @@
             <artifactId>gson</artifactId>
         </dependency>
 
-
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <version>1.1</version>
-        </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
-XOM dependencies is introducing xerces transitive dependency that has been causing trouble to geostore startup.
- the depedency seems to be related to serialization and deserialization of XML payloads and seems to not be actually needed. 
- Build is successful and testing endpoint with xml output/input doesn't cause any error once xom is removed.