### PR TITLE
refreshed token is ignored

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -115,7 +115,7 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         if ((expiresIn == null || fiveMinutesFromNow.after(expiresIn)) && refreshToken != null) {
             if (LOGGER.isDebugEnabled())
                 LOGGER.info("Going to refresh the token.");
-            doRefresh(refreshToken, accessToken, configuration);
+            sessionToken = doRefresh(refreshToken, accessToken, configuration);
         }
         if (sessionToken == null)
             sessionToken = sessionToken(accessToken, refreshToken, currentToken.getExpiration());


### PR DESCRIPTION
The refreshed session token from the doRefresh method is ignored.

The sessionToken == null test on line 120 is always true and the expiration of the current (possibly expired) token is used for the session token.
