### PR TITLE
Cleaning up redundant dependancy

### DIFF
--- a/src/core/persistence/pom.xml
+++ b/src/core/persistence/pom.xml
@@ -73,10 +73,6 @@
         <!-- 4J UTILS -->
         <!-- ================================================================-->
         <dependency>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>

--- a/src/core/security/pom.xml
+++ b/src/core/security/pom.xml
@@ -64,10 +64,6 @@
         <!-- 4J UTILS -->
         <!-- ================================================================-->
         <dependency>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>

--- a/src/core/services-api/pom.xml
+++ b/src/core/services-api/pom.xml
@@ -96,10 +96,6 @@
 <!--            </exclusions>-->
 <!--        </dependency>-->
         <dependency>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>

--- a/src/core/services-impl/pom.xml
+++ b/src/core/services-impl/pom.xml
@@ -100,11 +100,6 @@
         <!-- MISC -->
 
         <dependency>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -105,7 +105,6 @@
         <jaxb-impl-version>2.1.2</jaxb-impl-version>
 
         <log4j-version>2.19.0</log4j-version>
-        <dom4j-version>1.6.1</dom4j-version>
 
         <maven-assembly-plugin-version>2.2-beta-5</maven-assembly-plugin-version>
 
@@ -328,11 +327,6 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-1.2-api</artifactId>
                 <version>${log4j-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>dom4j</groupId>
-                <artifactId>dom4j</artifactId>
-                <version>${dom4j-version}</version>
             </dependency>
 
 		    <!-- =========================================================== -->


### PR DESCRIPTION
- Removed dom4j dependancy. Now it comes transitively with hibernate-core