### PR TITLE
Bump org.mortbay.jetty:jetty from 6.1.14 to 6.1.23 in /src

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -147,7 +147,7 @@
         <freemarker.version>2.3.20</freemarker.version>
         <apacheds-all.version>1.5.5</apacheds-all.version>
         <shared-ldap.version>0.9.16</shared-ldap.version>
-        <jetty.version>6.1.14</jetty.version>
+        <jetty.version>6.1.23</jetty.version>
         <jstl.version>1.2</jstl.version>
         <json-lib.version>2.4.2-geoserver</json-lib.version>
     </properties>


### PR DESCRIPTION
Bumps org.mortbay.jetty:jetty from 6.1.14 to 6.1.23.

---
updated-dependencies:
- dependency-name: org.mortbay.jetty:jetty dependency-type: direct:production ...