### PR TITLE
Fix modules

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -1191,24 +1191,15 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <modules>
+        <module>core</module>
+        <module>modules</module>
+        <module>web</module>
+    </modules>
     <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>core</module>
-                <module>modules</module>
-                <module>web</module>
-            </modules>
-        </profile>
         <profile>
             <id>all</id>
             <modules>
-                <module>core</module>
-                <module>modules</module>
-                <module>web</module>
                 <module>cli</module>
             </modules>
         </profile>


### PR DESCRIPTION
Fix #365 .
The issue was caused by the new profiles, activated by the `qa` property set to true in pom, that made skip the `default` profile that contained all modules.
I solved this issue once for all removing the  default profile and moving the modules that should be always build in the  root of the pom.
So only additional modules will be activated by profiles (in particular `cli`)