### PR TITLE
Fix versions for 2.3-SNAPSHOT

### DIFF
--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-cli</artifactId>

--- a/src/core/model/pom.xml
+++ b/src/core/model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-model</artifactId>
@@ -43,7 +43,7 @@
             <artifactId>jaxb-impl</artifactId>
         </dependency>
 
-        
+
 		<!-- HIBERNATE-SPATIAL -->
         <dependency>
             <groupId>org.hibernatespatial</groupId>

--- a/src/core/persistence/pom.xml
+++ b/src/core/persistence/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-persistence</artifactId>

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-core</artifactId>

--- a/src/core/security/pom.xml
+++ b/src/core/security/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-security</artifactId>

--- a/src/core/services-api/pom.xml
+++ b/src/core/services-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-services-api</artifactId>

--- a/src/core/services-impl/pom.xml
+++ b/src/core/services-impl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-core</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-services-impl</artifactId>

--- a/src/modules/pom.xml
+++ b/src/modules/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-modules</artifactId>

--- a/src/modules/rest/api/pom.xml
+++ b/src/modules/rest/api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-api</artifactId>

--- a/src/modules/rest/auditing/pom.xml
+++ b/src/modules/rest/auditing/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
     <artifactId>geostore-rest-auditing</artifactId>
     <name>GeoStore - Modules - REST auditing</name>

--- a/src/modules/rest/client/pom.xml
+++ b/src/modules/rest/client/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-client</artifactId>

--- a/src/modules/rest/extjs/pom.xml
+++ b/src/modules/rest/extjs/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-extjs</artifactId>

--- a/src/modules/rest/impl/pom.xml
+++ b/src/modules/rest/impl/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-impl</artifactId>

--- a/src/modules/rest/pom.xml
+++ b/src/modules/rest/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-modules</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-root</artifactId>

--- a/src/modules/rest/test/pom.xml
+++ b/src/modules/rest/test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-rest-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-rest-test</artifactId>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-web</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-webapp</artifactId>

--- a/src/web/pom.xml
+++ b/src/web/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-web</artifactId>


### PR DESCRIPTION
Due to the issue #365 , the Bump version was not applied to all the modules.
So this have to be updated manually before to go.