### PR TITLE
[FIXES #2408] C206-DEUTSCHE_BAHN-2023-SUPPORT - SSO - Supported OpenID services

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/keycloak/GeoStoreKeycloakAuthProvider.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/keycloak/GeoStoreKeycloakAuthProvider.java
@@ -86,7 +86,7 @@ public class GeoStoreKeycloakAuthProvider implements AuthenticationProvider {
         HttpServletRequest request = getRequest();
         // set tokens as request attributes so that can made available in a cookie for the frontend
         // on the callback url.
-        if (accessToken != null) {
+        if (accessToken != null && !accessToken.isExpired()) {
             expiration = accessToken.getExp();
             if (request != null) request.setAttribute(ACCESS_TOKEN_PARAM, accessToken);
         }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/keycloak/KeyCloakFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/keycloak/KeyCloakFilter.java
@@ -169,7 +169,7 @@ public class KeyCloakFilter extends GenericFilterBean {
             KeyCloakHelper helper = GeoStoreContext.bean(KeyCloakHelper.class);
             KeycloakTokenDetails keycloakDetails = (KeycloakTokenDetails) details;
             String accessToken = keycloakDetails.getAccessToken();
-            if (accessToken != null) {
+            if (accessToken != null && !accessToken.isEmpty()) {
                 cache.putCacheEntry(accessToken, authentication);
                 if (helper != null) {
                     HttpFacade facade = new SimpleHttpFacade(getRequest(), getResponse());

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -422,7 +422,7 @@ public class OAuth2Configuration extends IdPConfiguration {
                     configuration.clientId,
                     configuration
                             .clientSecret); // Set client ID and client secret for authentication
-        else if (accessToken != null) {
+        else if (accessToken != null && !accessToken.isEmpty()) {
             headers.set("Authorization", "Bearer " + accessToken);
         }
         return headers;

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -304,7 +304,9 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         LOGGER.debug("About to configure the REST Resource Template");
         configureRestTemplate();
 
-        if (accessToken != null) {
+        if (accessToken != null
+                && accessToken.getValue() != null
+                && !accessToken.getValue().isEmpty()) {
             LOGGER.debug("Setting the access token on the OAuth2ClientContext");
             restTemplate.getOAuth2ClientContext().setAccessToken(accessToken);
         }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreSecurityConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreSecurityConfiguration.java
@@ -54,8 +54,8 @@ import org.springframework.security.oauth2.client.token.grant.password.ResourceO
 import org.springframework.security.oauth2.common.AuthenticationScheme;
 
 /**
- * Base abstract class for @Configuration classes providing needed beans from the Spring OAuth2
- * mechanism.
+ * Base abstract class for @Configuration classes providing the necessary beans from the Spring
+ * OAuth2 mechanism.
  */
 @Configuration
 public abstract class OAuth2GeoStoreSecurityConfiguration implements ApplicationContextAware {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectFilter.java
@@ -91,7 +91,10 @@ public class OpenIdConnectFilter extends OAuth2GeoStoreAuthenticationFilter {
             }
             // we must validate
             String token = null;
-            if (accessToken != null) {
+            if (accessToken != null
+                    && !accessToken.isExpired()
+                    && accessToken.getValue() != null
+                    && !accessToken.getValue().isEmpty()) {
                 token = accessToken.getValue();
             } else {
                 token = (String) req.getAttribute(OAuth2AuthenticationDetails.ACCESS_TOKEN_VALUE);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectSecurityConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectSecurityConfiguration.java
@@ -141,7 +141,7 @@ public class OpenIdConnectSecurityConfiguration extends OAuth2GeoStoreSecurityCo
                 oidcTokenServices(),
                 oauth2RestTemplate(),
                 configuration(),
-                oidcCache(),
+                oAuth2Cache(),
                 openIdConnectBearerTokenValidator());
     }
 
@@ -157,7 +157,7 @@ public class OpenIdConnectSecurityConfiguration extends OAuth2GeoStoreSecurityCo
     }
 
     @Bean
-    public TokenAuthenticationCache oidcCache() {
+    public TokenAuthenticationCache oAuth2Cache() {
         return new TokenAuthenticationCache();
     }
 }

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/oauth2/openid_connect/OpenIdConnectIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/oauth2/openid_connect/OpenIdConnectIntegrationTest.java
@@ -153,7 +153,7 @@ public class OpenIdConnectIntegrationTest {
                         securityConfiguration.oidcTokenServices(),
                         restTemplate,
                         configuration,
-                        securityConfiguration.oidcCache(),
+                        securityConfiguration.oAuth2Cache(),
                         securityConfiguration.openIdConnectBearerTokenValidator());
     }
 


### PR DESCRIPTION
The current PR addresses few issues mainly related to the `refreshToken` endpoint:

1. The main issue is due to the fact that if the current condition is met `if ((expiresIn == null || fiveMinutesFromNow.after(expiresIn)) && refreshToken != null)`, i.e. the `refreshToken` is not expired yet, the `sessionToken` sent back will be `NULL` resulting in an `204: empty response` causing the client to lose the current `accessToken`
2. The `cache bean` of the `OIDC` has a wrong name causing a `context exception` when trying to retrieve it from a new `thread`
3. Generally speaking the code checks only for `accessToken` nullability but consider it valid in the case it's `empty`, and this is an error and must be threated as an error.
4. The `doRefresh` method does not send the `client_id` to the IDP Refresh Endpoint, and this is can cause issues for strict compliant providers like Microsoft Azure