### PR TITLE
OIDC okta testing

### DIFF
--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/SessionToken.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/SessionToken.java
@@ -5,10 +5,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 public class SessionToken {
-    String token_type;
-    String access_token;
-    String refresh_token;
-    Long expires;
+    private String token_type;
+    private String access_token;
+    private String refresh_token;
+    private Long expires;
+    private String error;
+    private String warning;
 
     @XmlElement(name = "token_type")
     public String getTokenType() {
@@ -38,11 +40,29 @@ public class SessionToken {
     }
 
     @XmlElement(name = "refresh_token")
+    public String getRefreshToken() {
+        return refresh_token;
+    }
+
     public void setRefreshToken(String refresh_token) {
         this.refresh_token = refresh_token;
     }
 
-    public String getRefreshToken() {
-        return refresh_token;
+    @XmlElement(name = "error")
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    @XmlElement(name = "warning")
+    public String getWarning() {
+        return warning;
+    }
+
+    public void setWarning(String warning) {
+        this.warning = warning;
     }
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -42,37 +42,103 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * This class represents the geostore configuration for an OAuth2/OpenId provider. An
- * OAuth2Configuration bean should be provided for each OAuth2 provider. The bean id has to be
+ * This class represents the OAuth2/OpenID Connect configuration for GeoStore. It includes settings
+ * for endpoints, client credentials, and other OAuth2 provider details. Each OAuth2 provider
+ * requires a specific OAuth2Configuration bean, identified with the naming convention
  * {providerName}OAuth2Config.
  */
 public class OAuth2Configuration extends IdPConfiguration {
 
+    private static final Logger LOGGER = LogManager.getLogger(OAuth2Configuration.class);
+
+    // Constants
     public static final String CONFIG_NAME_SUFFIX = "OAuth2Config";
     public static final String CONFIGURATION_NAME = "CONFIGURATION_NAME";
-    private static final Logger LOGGER =
-            LogManager.getLogger(OAuth2GeoStoreAuthenticationFilter.class);
-    protected String clientId;
-    protected String clientSecret;
-    protected String accessTokenUri;
-    protected String authorizationUri;
-    protected String checkTokenEndpointUrl;
-    protected String logoutUri;
-    protected boolean globalLogoutEnabled = false;
-    protected String scopes;
-    protected String idTokenUri;
-    protected String discoveryUrl;
-    protected String revokeEndpoint;
-    protected boolean enableRedirectEntryPoint = false;
-    protected String principalKey;
-    protected String rolesClaim;
-    protected String groupsClaim;
+
+    // OAuth2 provider client details
+    private String clientId;
+    private String clientSecret;
+
+    // OAuth2 URIs and endpoints
+    private String accessTokenUri;
+    private String authorizationUri;
+    private String checkTokenEndpointUrl;
+    private String logoutUri;
+    private String revokeEndpoint;
+
+    // Additional settings
+    private boolean globalLogoutEnabled = false;
+    private String scopes;
+    private String idTokenUri;
+    private String discoveryUrl;
+    private boolean enableRedirectEntryPoint = false;
+    private String principalKey;
+    private String rolesClaim;
+    private String groupsClaim;
+
+    // Retry and backoff configurations
+    private long initialBackoffDelay = 1000; // Default: 1 second
+    private double backoffMultiplier = 2.0; // Default multiplier
+    private int maxRetries = 3; // Default max retries
 
     /**
-     * Get an authentication entry point instance meant to handle redirect to the authorization
-     * page.
+     * Gets the maximum number of retries allowed for refreshing tokens.
      *
-     * @return the authentication entry point.
+     * @return maxRetries - the maximum retry attempts.
+     */
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    /**
+     * Sets the maximum number of retries allowed for refreshing tokens.
+     *
+     * @param maxRetries - the maximum retry attempts to set.
+     */
+    public void setMaxRetries(int maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    /**
+     * Gets the initial backoff delay (in milliseconds) for retry attempts.
+     *
+     * @return initialBackoffDelay - the initial delay in milliseconds.
+     */
+    public long getInitialBackoffDelay() {
+        return initialBackoffDelay;
+    }
+
+    /**
+     * Sets the initial backoff delay (in milliseconds) for retry attempts.
+     *
+     * @param initialBackoffDelay - the initial delay in milliseconds.
+     */
+    public void setInitialBackoffDelay(long initialBackoffDelay) {
+        this.initialBackoffDelay = initialBackoffDelay;
+    }
+
+    /**
+     * Gets the multiplier applied to backoff delay for each retry attempt.
+     *
+     * @return backoffMultiplier - the multiplier for exponential backoff.
+     */
+    public double getBackoffMultiplier() {
+        return backoffMultiplier;
+    }
+
+    /**
+     * Sets the multiplier for exponential backoff delay between retry attempts.
+     *
+     * @param backoffMultiplier - the multiplier for backoff.
+     */
+    public void setBackoffMultiplier(double backoffMultiplier) {
+        this.backoffMultiplier = backoffMultiplier;
+    }
+
+    /**
+     * Provides an entry point to redirect to the authorization page for authentication.
+     *
+     * @return the AuthenticationEntryPoint handling authorization redirection.
      */
     public AuthenticationEntryPoint getAuthenticationEntryPoint() {
         return (request, response, authException) -> {
@@ -82,77 +148,80 @@ public class OAuth2Configuration extends IdPConfiguration {
     }
 
     /**
-     * Build the authorization uri to the OAuth2 provider.
+     * Builds the authorization URI, adding response type, client ID, scope, and redirect URI.
      *
-     * @return the authorization uri completed with the various query strings.
+     * @return the complete authorization URI.
      */
     public String buildLoginUri() {
         return buildLoginUri(null, new String[] {});
     }
 
     /**
-     * Build the authorization uri to the OAuth2 provider.
+     * Builds the authorization URI with an optional access type.
      *
-     * @param accessType the access type request param value. Can be null.
-     * @return the authorization uri completed with the various query strings.
+     * @param accessType - the access type, e.g., "offline" or "online"; can be null.
+     * @return the complete authorization URI.
      */
     public String buildLoginUri(String accessType) {
         return buildLoginUri(accessType, new String[] {});
     }
 
     /**
-     * @param accessType the access type request param value. Can be null.
-     * @param additionalScopes additional scopes aren't set at from geostore-ovr.properties. Can be
-     *     null.
-     * @return the
+     * Builds the authorization URI with access type and additional scopes.
+     *
+     * @param accessType - the type of access requested, can be null.
+     * @param additionalScopes - additional scopes required beyond configured scopes.
+     * @return the complete authorization URI.
      */
     public String buildLoginUri(String accessType, String... additionalScopes) {
-        final StringBuilder loginUri = new StringBuilder(getAuthorizationUri());
-        loginUri.append("?")
-                .append("response_type=code")
-                .append("&")
-                .append("client_id=")
+        StringBuilder loginUri = new StringBuilder(getAuthorizationUri());
+        loginUri.append("?response_type=code")
+                .append("&client_id=")
                 .append(getClientId())
-                .append("&")
-                .append("scope=")
+                .append("&scope=")
                 .append(getScopes().replace(",", "%20"));
-        for (String s : additionalScopes) {
-            loginUri.append("%20").append(s);
+
+        for (String scope : additionalScopes) {
+            loginUri.append("%20").append(scope);
         }
-        loginUri.append("&").append("redirect_uri=").append(getRedirectUri());
-        if (accessType != null) loginUri.append("&").append("access_type=").append(accessType);
-        String finalUrl = loginUri.toString();
-        if (LOGGER.isDebugEnabled())
-            LOGGER.info("Going to request authorization to this endpoint {}", finalUrl);
-        return finalUrl;
+
+        loginUri.append("&redirect_uri=").append(getRedirectUri());
+
+        if (accessType != null) {
+            loginUri.append("&access_type=").append(accessType);
+        }
+
+        LOGGER.debug("Authorization endpoint URI built: {}", loginUri);
+        return loginUri.toString();
     }
 
     /**
-     * Builds the refresh token URI.
+     * Constructs a URI to refresh the access token.
      *
-     * @return the complete refresh token uri.
+     * @return the refresh token URI.
      */
     public String buildRefreshTokenURI() {
         return buildRefreshTokenURI(null);
     }
 
     /**
-     * Builds the refresh token URI.
+     * Constructs a URI to refresh the access token with an optional access type.
      *
-     * @param accessType the access type request param.
-     * @return the complete refresh token uri.
+     * @param accessType - access type to be appended to the URI.
+     * @return the complete refresh token URI.
      */
     public String buildRefreshTokenURI(String accessType) {
-        final StringBuilder refreshUri = new StringBuilder(getAccessTokenUri());
-        refreshUri
-                .append("?")
-                .append("&")
-                .append("client_id=")
-                .append(getClientId())
-                .append("&")
-                .append("scope=")
-                .append(getScopes().replace(",", "%20"));
-        if (accessType != null) refreshUri.append("&").append("access_type=").append(accessType);
+        StringBuilder refreshUri =
+                new StringBuilder(getAccessTokenUri())
+                        .append("?client_id=")
+                        .append(getClientId())
+                        .append("&scope=")
+                        .append(getScopes().replace(",", "%20"));
+
+        if (accessType != null) {
+            refreshUri.append("&access_type=").append(accessType);
+        }
+
         return refreshUri.toString();
     }
 
@@ -337,16 +406,14 @@ public class OAuth2Configuration extends IdPConfiguration {
     }
 
     /**
-     * Append the request params to the URL.
+     * Appends query parameters to a URL.
      *
-     * @param params the request params.
-     * @param url the url.
-     * @return the complete url.
+     * @param params - the request parameters.
+     * @param url - the base URL.
+     * @return the URL with appended parameters.
      */
     protected String appendParameters(MultiValueMap<String, String> params, String url) {
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url);
-        builder.queryParams(params);
-        return builder.build().toUriString();
+        return UriComponentsBuilder.fromHttpUrl(url).queryParams(params).build().toUriString();
     }
 
     protected static void getLogoutRequestParams(
@@ -358,28 +425,25 @@ public class OAuth2Configuration extends IdPConfiguration {
     }
 
     /**
-     * Build the revoke endpoint.
+     * Builds the endpoint for token revocation.
      *
-     * @param token the access_token to revoke.
-     * @return the revoke endpoint.
+     * @param token - the token to be revoked.
+     * @param accessToken - the access token for authorization.
+     * @param configuration - OAuth2 configuration.
+     * @return the configured revoke endpoint, or null if not available.
      */
     public Endpoint buildRevokeEndpoint(
             String token, String accessToken, OAuth2Configuration configuration) {
-        Endpoint result = null;
-        if (revokeEndpoint != null) {
-            HttpHeaders headers = getHttpHeaders(accessToken, configuration);
+        if (revokeEndpoint == null) return null;
 
-            MultiValueMap<String, String> bodyParams = new LinkedMultiValueMap<>();
-            bodyParams.add("token", token);
-            bodyParams.add("client_id", clientId);
+        HttpHeaders headers = getHttpHeaders(accessToken, configuration);
+        MultiValueMap<String, String> bodyParams = new LinkedMultiValueMap<>();
+        bodyParams.add("token", token);
+        bodyParams.add("client_id", clientId);
 
-            HttpEntity<MultiValueMap<String, String>> requestEntity =
-                    new HttpEntity<>(bodyParams, headers);
-
-            result = new Endpoint(HttpMethod.POST, revokeEndpoint);
-            result.setRequestEntity(requestEntity);
-        }
-        return result;
+        HttpEntity<MultiValueMap<String, String>> requestEntity =
+                new HttpEntity<>(bodyParams, headers);
+        return new Endpoint(HttpMethod.POST, revokeEndpoint, requestEntity);
     }
 
     private static HttpHeaders getHttpHeaders(
@@ -390,27 +454,23 @@ public class OAuth2Configuration extends IdPConfiguration {
     }
 
     /**
-     * Build the logout endpoint.
+     * Builds the endpoint for logout.
      *
-     * @param token the current access_token.
-     * @return the logout endpoint.
+     * @param token - the token for the session to end.
+     * @param accessToken - access token to authorize the logout.
+     * @param configuration - OAuth2 configuration.
+     * @return the logout endpoint with parameters appended, or null if logoutUri is null.
      */
     public Endpoint buildLogoutEndpoint(
             String token, String accessToken, OAuth2Configuration configuration) {
-        Endpoint result = null;
-        if (logoutUri != null) {
-            HttpHeaders headers = getHeaders(accessToken, configuration);
+        if (logoutUri == null) return null;
 
-            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-            getLogoutRequestParams(token, clientId, params);
+        HttpHeaders headers = getHeaders(accessToken, configuration);
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        getLogoutRequestParams(token, clientId, params);
 
-            HttpEntity<MultiValueMap<String, String>> requestEntity =
-                    new HttpEntity<>(null, headers);
-
-            result = new Endpoint(HttpMethod.GET, appendParameters(params, logoutUri));
-            result.setRequestEntity(requestEntity);
-        }
-        return result;
+        return new Endpoint(
+                HttpMethod.GET, appendParameters(params, logoutUri), new HttpEntity<>(headers));
     }
 
     private static HttpHeaders getHeaders(String accessToken, OAuth2Configuration configuration) {
@@ -493,18 +553,17 @@ public class OAuth2Configuration extends IdPConfiguration {
         this.groupsClaim = groupsClaim;
     }
 
-    /** Class the representing and endpoint with a HTTP method. */
+    /** Represents a configurable HTTP endpoint with method and request entity. */
     public static class Endpoint {
 
-        private String url;
+        private final String url;
+        private final HttpMethod method;
+        private final HttpEntity<?> requestEntity;
 
-        private HttpMethod method;
-
-        private HttpEntity<?> requestEntity;
-
-        public Endpoint(HttpMethod method, String url) {
+        public Endpoint(HttpMethod method, String url, HttpEntity<?> requestEntity) {
             this.method = method;
             this.url = url;
+            this.requestEntity = requestEntity;
         }
 
         /** @return the url. */
@@ -512,37 +571,14 @@ public class OAuth2Configuration extends IdPConfiguration {
             return url;
         }
 
-        /**
-         * Set the url.
-         *
-         * @param url the url.
-         */
-        public void setUrl(String url) {
-            this.url = url;
-        }
-
         /** @return the HttpMethod. */
         public HttpMethod getMethod() {
             return method;
         }
 
-        /**
-         * Set the HttpMethod.
-         *
-         * @param method the HttpMethod.
-         */
-        public void setMethod(HttpMethod method) {
-            this.method = method;
-        }
-
         /** @return */
         public HttpEntity<?> getRequestEntity() {
             return requestEntity;
-        }
-
-        /** @param requestEntity */
-        public void setRequestEntity(HttpEntity<?> requestEntity) {
-            this.requestEntity = requestEntity;
         }
     }
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectConfiguration.java
@@ -123,13 +123,12 @@ public class OpenIdConnectConfiguration extends OAuth2Configuration {
                 params.put(
                         "post_logout_redirect_uri",
                         Collections.singletonList(getPostLogoutRedirectUri()));
-            getLogoutRequestParams(token, clientId, params);
+            getLogoutRequestParams(token, getClientId(), params);
 
             HttpEntity<MultiValueMap<String, String>> requestEntity =
                     new HttpEntity<>(null, headers);
 
-            result = new Endpoint(HttpMethod.GET, appendParameters(params, uri));
-            result.setRequestEntity(requestEntity);
+            result = new Endpoint(HttpMethod.GET, appendParameters(params, uri), requestEntity);
         }
         return result;
     }


### PR DESCRIPTION
In this updated version of the `SessionDelegate` upon a `Refresh` request the backend also checks:

- The remote `refresh-token` request is returning a valid code
- The current `accessToken` is still valid in the case the previous one fails for some reason

Other than that, the `SessionToken` bean has been updated in order to return back also a `Warning` or `Error` message with the explanation of the failuers.

As an instance, in the case the remote `refresh-token` request throws a `UserRedirectException` because it need manual validation but the current `AccessToken` is still valid (not expired), the `SessionToken` will be still valid, by using the current `AccessToken` but it will provide a `Warning` message like the one below

```json
{
    "sessionToken": {
        "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJwMlZ4YnZGUm1mWlJkWXRtdTUtWGx3eDRvQjg4cVNYQ0ItOUdIWVBuMzdRIn0.eyJleHAiOjE3MzEzMzU2NzAsImlhdCI6MTczMTMzNTM3MCwiYXV0aF90aW1lIjoxNzMxMzM1MzcwLCJqdGkiOiJiZDFjMzMxZS05ODJkLTQxZmUtOWJhZi0wNWY3ZDIyNjliOGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgxODAvcmVhbG1zL21hcHN0b3JlIiwiYXVkIjpbImdzLXRlc3QiLCJhY2NvdW50Il0sInN1YiI6ImU2ZmZmYmI3LTQ4ZTEtNGM0My04MjkyLTY5YzNmY2Y2ZjM5NyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImdzLXRlc3QiLCJzZXNzaW9uX3N0YXRlIjoiMDkxMmI5OGYtOTZmMi00ZDkyLThkYTQtY2ZjMzZiOTYxNTBlIiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyIvKiJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiVEVTVCIsIm9mZmxpbmVfYWNjZXNzIiwiZGVmYXVsdC1yb2xlcy1tYXBzdG9yZSIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgbWljcm9wcm9maWxlLWp3dCBwcm9maWxlIGdyb3VwcyBlbWFpbCByb2xlcyBvZmZsaW5lX2FjY2VzcyBwaG9uZSBzYXItZHJpZnQgYWRkcmVzcyIsInNpZCI6IjA5MTJiOThmLTk2ZjItNGQ5Mi04ZGE0LWNmYzM2Yjk2MTUwZSIsInVwbiI6InRlc3QiLCJhZGRyZXNzIjp7fSwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJBbGVzc2lvIEZhYmlhbmkiLCJncm91cHMiOlsiVEVTVCIsIm9mZmxpbmVfYWNjZXNzIiwiZGVmYXVsdC1yb2xlcy1tYXBzdG9yZSIsInVtYV9hdXRob3JpemF0aW9uIiwiVEVTVCIsIm9mZmxpbmVfYWNjZXNzIiwiZGVmYXVsdC1yb2xlcy1tYXBzdG9yZSIsInVtYV9hdXRob3JpemF0aW9uIl0sInByZWZlcnJlZF91c2VybmFtZSI6InRlc3QiLCJnaXZlbl9uYW1lIjoiQWxlc3NpbyIsImZhbWlseV9uYW1lIjoiRmFiaWFuaSIsImVtYWlsIjoiYWxlc3Npby5mYWJpYW5pQGdlb3NvbHV0aW9uc2dyb3VwLmNvbSJ9.DvhqSf0kK8v5UUtqTjlOpd52z6IuWg0wihBHbvkvY3GAaiuwxWnla7zQzr45V0D_LE65gcvQYCb4_YYWraBQFOuYzoNbFwE1Jz8MDsvEBqXM5BdNxmP9NTnB64w-wxCVCS4nMYZNMBjVYxXwTa4c3I6ReoACYFHndOBUs44mpjeqmO7v8n0b1P60QiPv2KyE_Kmuu97sICyQIdwWkXCQHWq3ixC2bUNihs5wvwWJQHZxv_OlNCgz7UTB7UpNtjpAff0lV0RUF_OpVDTUEmMLSyhiF6BF2pbNG_FUngL4Uk9JXxrMrUG7LqPdigBkdlIurfGus0Xmo3td5xNikUmhuQ",
        "refresh_token": "eyJhbGciOiJIUzUxMiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI1NWFkNWJlNS1jOTA3LTRjOWYtYWU2Yi1iYjUwZGU0MmFkMTAifQ.eyJpYXQiOjE3MzEzMzUzNzAsImp0aSI6IjUxMWIxZWNhLWFjZjAtNDhiOC1iNTg5LTdlMDkzNGQ4MDdjYSIsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODE4MC9yZWFsbXMvbWFwc3RvcmUiLCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjgxODAvcmVhbG1zL21hcHN0b3JlIiwic3ViIjoiZTZmZmZiYjctNDhlMS00YzQzLTgyOTItNjljM2ZjZjZmMzk3IiwidHlwIjoiT2ZmbGluZSIsImF6cCI6ImdzLXRlc3QiLCJzZXNzaW9uX3N0YXRlIjoiMDkxMmI5OGYtOTZmMi00ZDkyLThkYTQtY2ZjMzZiOTYxNTBlIiwic2NvcGUiOiJvcGVuaWQgbWljcm9wcm9maWxlLWp3dCBwcm9maWxlIGdyb3VwcyBlbWFpbCByb2xlcyBvZmZsaW5lX2FjY2VzcyBwaG9uZSBzYXItZHJpZnQgYWRkcmVzcyIsInNpZCI6IjA5MTJiOThmLTk2ZjItNGQ5Mi04ZGE0LWNmYzM2Yjk2MTUwZSJ9.M12uG9hmb9gkkE9ioVX2weXXHR3u5yMbU_BpARCL016lR2DAL9QyEe-eps4RomlLBpTKhkmWUTC4yI6pM6xr4g",
        "token_type": "bearer",
        "warning": "A redirect is required to get the user's approval."
    }
}
```

In case of `Errors`, the returned `AccessToken` and `RefreshToken` will be `EMPTY` with an `ErrorMessage` explaining the cause.

More Unit Tests have been added and the old ones updated accordingly to the new behavior.