### PR TITLE
Review of endpoints to return a single resource

### DIFF
--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Resource.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Resource.java
@@ -187,7 +187,7 @@ public class Resource implements Serializable, CycleRecoverable {
         this.metadata = metadata;
     }
 
-    /** @return the attribute */
+    /** @return the attributes */
     @XmlElementWrapper(name = "Attributes")
     public List<Attribute> getAttribute() {
         return attribute;

--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/User.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/User.java
@@ -152,7 +152,7 @@ public class User implements Serializable {
         return groups;
     }
 
-    /** @param group the group to set */
+    /** @param groups the group to set */
     public void setGroups(Set<UserGroup> groups) {
         this.groups = groups;
     }

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/PermissionService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/PermissionService.java
@@ -28,23 +28,55 @@ public interface PermissionService {
      * @param user
      * @param resource
      * @return @return <code>true</code> if the user is the owner of the resource, <code>false
-     *     </code> otherwise
+     * </code> otherwise
      * @throws IllegalArgumentException if the user security rules have not been initialized
      *     properly
      */
     boolean isUserOwner(User user, Resource resource);
 
     /**
-     * GUEST users can not access to the delete and edit (resource, data blob is editable) services,
-     * so only admins and authenticated users with write permissions can.
+     * Verifies whether the user or any of their groups is the owner of the resource and has read
+     * permissions on it.
+     *
+     * <p>Be aware to fetch the user security rules prior to call this method.
+     *
+     * @param user
+     * @param resourceId
+     * @return <code>true</code> if the user can read the resource, <code>false</code> otherwise
+     * @throws IllegalArgumentException if the user security rules have not been initialized
+     *     properly
+     */
+    boolean canUserReadResource(User user, Long resourceId);
+
+    /**
+     * Verifies whether the user or any of their groups is the owner of the resource and has write
+     * permissions on it.
+     *
+     * <p>GUEST users can not access to the delete and edit (resource, data blob is editable)
+     * services, so only admins and authenticated users with write permissions can.
      *
      * <p>Be aware to fetch the user security rules prior to call this method.
      *
      * @param user
      * @param resource
-     * @return <code>true</code> if the user can access the resource, <code>false</code> otherwise
+     * @return <code>true</code> if the user can write the resource, <code>false</code> otherwise
      * @throws IllegalArgumentException if the user security rules have not been initialized
      *     properly
      */
-    boolean canUserAccessResource(User user, Resource resource);
+    boolean canUserWriteResource(User user, Resource resource);
+
+    /**
+     * Verifies whether the user or any of their groups is the owner of the resource and has both
+     * read and write permissions on it.
+     *
+     * <p>Be aware to fetch the user security rules prior to call this method.
+     *
+     * @param user
+     * @param resource
+     * @return <code>true</code> if the user can read and write the resource, <code>false</code>
+     *     otherwise
+     * @throws IllegalArgumentException if the user security rules have not been initialized
+     *     properly
+     */
+    boolean canUserReadAndWriteResource(User user, Resource resource);
 }

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/ResourceService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/ResourceService.java
@@ -92,6 +92,14 @@ public interface ResourceService extends SecurityService {
     Resource get(long id);
 
     /**
+     * @param id
+     * @param includeAttributes
+     * @param includePermissions
+     * @return long
+     */
+    Resource getResource(long id, boolean includeAttributes, boolean includePermissions);
+
+    /**
      * @param resourceSearchParameters the object encapsulating search criteria such as pagination,
      *     sorting options, filters, user context, and additional settings for resource retrieval.
      * @return List<ShortResource>

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/SecurityService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/SecurityService.java
@@ -37,7 +37,7 @@ public interface SecurityService {
     List<SecurityRule> getUserSecurityRule(String userName, long entityId);
 
     /**
-     * @param groupName
+     * @param groupNames
      * @param entityId entityId the Id of the entity (f.e. Resource, Category, StoredData...) that
      *     the underlying implementation will be responsible for retrieve security rules
      * @return

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
@@ -130,8 +130,8 @@ public interface UserService {
     public Collection<User> getByGroup(UserGroup group);
 
     /**
-     * Initialize the user entity by fetching its security rules and group security rules from the
-     * database.
+     * Update the user entity by fetching its security rules and group security rules
+     * from the database.
      *
      * @param user
      */

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/PermissionServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/PermissionServiceImpl.java
@@ -11,8 +11,15 @@ public class PermissionServiceImpl implements PermissionService {
 
     private final BiFunction<SecurityRule, Resource, Boolean> resourceOwnership =
             (rule, resource) -> resource.getId().equals(rule.getResource().getId());
+    private final BiFunction<SecurityRule, Resource, Boolean> resourceOwnershipWithReadPermission =
+            (rule, resource) -> resourceOwnership.apply(rule, resource) && rule.isCanRead();
     private final BiFunction<SecurityRule, Resource, Boolean> resourceOwnershipWithWritePermission =
             (rule, resource) -> resourceOwnership.apply(rule, resource) && rule.isCanWrite();
+    private final BiFunction<SecurityRule, Resource, Boolean>
+            resourceOwnershipWithReadAndWritePermission =
+                    (rule, resource) ->
+                            resourceOwnershipWithWritePermission.apply(rule, resource)
+                                    && resourceOwnershipWithReadPermission.apply(rule, resource);
 
     @Override
     public boolean isResourceAvailableForUser(Resource resource, User user) {
@@ -23,40 +30,83 @@ public class PermissionServiceImpl implements PermissionService {
 
     @Override
     public boolean isUserOwner(User user, Resource resource) {
-        if (user.getSecurity() == null) {
-            throw new IllegalArgumentException(
-                    "set user security rules prior checking for ownership");
-        }
-
+        checkUserSecurityRules(user);
         return user.getSecurity().stream()
                 .anyMatch(rule -> resourceOwnership.apply(rule, resource));
     }
 
     @Override
-    public boolean canUserAccessResource(User user, Resource resource) {
+    public boolean canUserReadResource(User user, Long resourceId) {
+        Resource resource = new Resource();
+        resource.setId(resourceId);
+
+        return user.getRole().equals(Role.ADMIN)
+                || isUserOwnerWithReadPermission(user, resource)
+                || haveUserGroupsOwnershipWithReadPermission(user, resource);
+    }
+
+    private boolean isUserOwnerWithReadPermission(User user, Resource resource) {
+        checkUserSecurityRules(user);
+        return checkSecurityRulesAgainstResource(
+                user.getSecurity(), resource, resourceOwnershipWithReadPermission);
+    }
+
+    private boolean haveUserGroupsOwnershipWithReadPermission(User user, Resource resource) {
+        return checkUserGroupsSecurityRulesAgainstResource(
+                user, resource, resourceOwnershipWithReadPermission);
+    }
+
+    @Override
+    public boolean canUserWriteResource(User user, Resource resource) {
         return !user.getRole().equals(Role.GUEST)
                 && (user.getRole().equals(Role.ADMIN)
                         || isUserOwnerWithWritePermission(user, resource)
-                        || haveUserGroupsWritePermission(user, resource));
+                        || haveUserGroupsOwnershipWithWritePermission(user, resource));
     }
 
     private boolean isUserOwnerWithWritePermission(User user, Resource resource) {
-        if (user.getSecurity() == null) {
-            throw new IllegalArgumentException(
-                    "set user security rules prior checking for ownership");
-        }
+        checkUserSecurityRules(user);
         return checkSecurityRulesAgainstResource(
                 user.getSecurity(), resource, resourceOwnershipWithWritePermission);
     }
 
-    private boolean haveUserGroupsWritePermission(User user, Resource resource) {
+    private boolean haveUserGroupsOwnershipWithWritePermission(User user, Resource resource) {
+        return checkUserGroupsSecurityRulesAgainstResource(
+                user, resource, resourceOwnershipWithWritePermission);
+    }
+
+    @Override
+    public boolean canUserReadAndWriteResource(User user, Resource resource) {
+        return user.getRole().equals(Role.ADMIN)
+                || isUserOwnerWithReadAndWritePermission(user, resource)
+                || haveUserGroupOwnershipWithReadAndWritePermission(user, resource);
+    }
+
+    private boolean isUserOwnerWithReadAndWritePermission(User user, Resource resource) {
+        checkUserSecurityRules(user);
+        return checkSecurityRulesAgainstResource(
+                user.getSecurity(), resource, resourceOwnershipWithReadAndWritePermission);
+    }
+
+    private void checkUserSecurityRules(User user) {
+        if (user.getSecurity() == null) {
+            throw new IllegalArgumentException(
+                    "set user security rules prior checking for permissions");
+        }
+    }
+
+    private boolean haveUserGroupOwnershipWithReadAndWritePermission(User user, Resource resource) {
+        return checkUserGroupsSecurityRulesAgainstResource(
+                user, resource, resourceOwnershipWithReadAndWritePermission);
+    }
+
+    private boolean checkUserGroupsSecurityRulesAgainstResource(
+            User user, Resource resource, BiFunction<SecurityRule, Resource, Boolean> check) {
         return user.getGroups().stream()
                 .anyMatch(
                         group ->
                                 checkSecurityRulesAgainstResource(
-                                        group.getSecurity(),
-                                        resource,
-                                        resourceOwnershipWithWritePermission));
+                                        group.getSecurity(), resource, check));
     }
 
     private boolean checkSecurityRulesAgainstResource(

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
@@ -625,31 +625,31 @@ public class ResourceServiceImpl implements ResourceService {
             boolean includeData,
             boolean includePermissions) {
 
-        Resource res = new Resource();
+        Resource configuredResource = new Resource();
 
-        res.setCategory(resource.getCategory());
-        res.setCreation(resource.getCreation());
-        res.setDescription(resource.getDescription());
-        res.setAdvertised(resource.isAdvertised());
-        res.setId(resource.getId());
-        res.setLastUpdate(resource.getLastUpdate());
-        res.setName(resource.getName());
-        res.setCreator(resource.getCreator());
-        res.setEditor(resource.getEditor());
+        configuredResource.setCategory(resource.getCategory());
+        configuredResource.setCreation(resource.getCreation());
+        configuredResource.setDescription(resource.getDescription());
+        configuredResource.setAdvertised(resource.isAdvertised());
+        configuredResource.setId(resource.getId());
+        configuredResource.setLastUpdate(resource.getLastUpdate());
+        configuredResource.setName(resource.getName());
+        configuredResource.setCreator(resource.getCreator());
+        configuredResource.setEditor(resource.getEditor());
 
         if (includeData) {
-            res.setData(resource.getData());
+            configuredResource.setData(resource.getData());
         }
 
         if (includeAttributes) {
-            res.setAttribute(resource.getAttribute());
+            configuredResource.setAttribute(resource.getAttribute());
         }
 
         if (includePermissions) {
-            res.setSecurity(resource.getSecurity());
+            configuredResource.setSecurity(getSecurityRules(resource.getId()));
         }
 
-        return res;
+        return configuredResource;
     }
 
     @Override

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
@@ -54,9 +54,7 @@ import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
 import it.geosolutions.geostore.util.SearchConverter;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -369,7 +367,17 @@ public class ResourceServiceImpl implements ResourceService {
      */
     @Override
     public Resource get(long id) {
+        return resourceDAO.find(id);
+    }
+
+    @Override
+    public Resource getResource(long id, boolean includeAttributes, boolean includePermissions) {
+
         Resource resource = resourceDAO.find(id);
+
+        if (resource != null) {
+            resource = configResource(resource, includeAttributes, false, includePermissions);
+        }
 
         return resource;
     }
@@ -465,12 +473,7 @@ public class ResourceServiceImpl implements ResourceService {
      * @return List<ShortAttribute>
      */
     private List<ShortAttribute> convertToShortAttributeList(List<Attribute> list) {
-        List<ShortAttribute> swList = new ArrayList<ShortAttribute>(list.size());
-        for (Attribute attribute : list) {
-            swList.add(new ShortAttribute(attribute));
-        }
-
-        return swList;
+        return list.stream().map(ShortAttribute::new).collect(Collectors.toList());
     }
 
     /*
@@ -597,52 +600,56 @@ public class ResourceServiceImpl implements ResourceService {
 
     public List<Resource> getResources(ResourceSearchParameters resourceSearchParameters)
             throws BadRequestServiceEx, InternalErrorServiceEx {
-
-        List<Resource> resources = searchResources(resourceSearchParameters);
-        resources =
-                this.configResourceList(
-                        resources,
-                        resourceSearchParameters.isIncludeAttributes(),
-                        resourceSearchParameters.isIncludeData());
-
-        return resources;
+        return this.configResourceList(
+                searchResources(resourceSearchParameters),
+                resourceSearchParameters.isIncludeAttributes(),
+                resourceSearchParameters.isIncludeData());
     }
 
     /**
-     * @param list
+     * @param resources
      * @param includeAttributes
      * @param includeData
      * @return List<Resource>
      */
     private List<Resource> configResourceList(
-            List<Resource> list, boolean includeAttributes, boolean includeData) {
-        List<Resource> rList = new LinkedList<>();
+            List<Resource> resources, boolean includeAttributes, boolean includeData) {
+        return resources.stream()
+                .map(r -> configResource(r, includeAttributes, includeData, false))
+                .collect(Collectors.toList());
+    }
 
-        for (Resource resource : list) {
-            Resource res = new Resource();
+    private Resource configResource(
+            Resource resource,
+            boolean includeAttributes,
+            boolean includeData,
+            boolean includePermissions) {
 
-            res.setCategory(resource.getCategory());
-            res.setCreation(resource.getCreation());
-            res.setDescription(resource.getDescription());
-            res.setAdvertised(resource.isAdvertised());
-            res.setId(resource.getId());
-            res.setLastUpdate(resource.getLastUpdate());
-            res.setName(resource.getName());
-            res.setCreator(resource.getCreator());
-            res.setEditor(resource.getEditor());
+        Resource res = new Resource();
 
-            if (includeData) {
-                res.setData(resource.getData());
-            }
+        res.setCategory(resource.getCategory());
+        res.setCreation(resource.getCreation());
+        res.setDescription(resource.getDescription());
+        res.setAdvertised(resource.isAdvertised());
+        res.setId(resource.getId());
+        res.setLastUpdate(resource.getLastUpdate());
+        res.setName(resource.getName());
+        res.setCreator(resource.getCreator());
+        res.setEditor(resource.getEditor());
 
-            if (includeAttributes) {
-                res.setAttribute(resource.getAttribute());
-            }
-
-            rList.add(res);
+        if (includeData) {
+            res.setData(resource.getData());
         }
 
-        return rList;
+        if (includeAttributes) {
+            res.setAttribute(resource.getAttribute());
+        }
+
+        if (includePermissions) {
+            res.setSecurity(resource.getSecurity());
+        }
+
+        return res;
     }
 
     @Override
@@ -703,7 +710,7 @@ public class ResourceServiceImpl implements ResourceService {
     private ShortResource createShortResource(User user, Resource resource) {
         ShortResource shortResource = new ShortResource(resource);
 
-        if (user != null && permissionService.canUserAccessResource(user, resource)) {
+        if (user != null && permissionService.canUserWriteResource(user, resource)) {
             shortResource.setCanEdit(true);
             shortResource.setCanDelete(true);
         }

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/SecurityRuleList.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/SecurityRuleList.java
@@ -29,10 +29,10 @@
 package it.geosolutions.geostore.services.rest.model;
 
 import it.geosolutions.geostore.core.model.SecurityRule;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -50,10 +50,12 @@ public class SecurityRuleList implements Iterable<RESTSecurityRule> {
 
     /** @param list */
     public SecurityRuleList(List<SecurityRule> list) {
-        this.list = new ArrayList<RESTSecurityRule>();
-        for (SecurityRule rule : list) {
-            this.list.add(new RESTSecurityRule(rule));
+        if (list == null) {
+            this.list = null;
+            return;
         }
+
+        this.list = list.stream().map(RESTSecurityRule::new).collect(Collectors.toList());
     }
 
     /** @return List<Category> */

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/model/ExtShortResource.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/model/ExtShortResource.java
@@ -1,15 +1,20 @@
 package it.geosolutions.geostore.services.model;
 
 import it.geosolutions.geostore.services.dto.ShortResource;
+import it.geosolutions.geostore.services.rest.model.SecurityRuleList;
 import it.geosolutions.geostore.services.rest.model.ShortAttributeList;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-/** An extended version of the {@link ShortResource} class that includes attributes list. */
+/**
+ * An extended version of the {@link ShortResource} class that includes {@link ShortAttributeList}
+ * and {@link SecurityRuleList} for the resource.
+ */
 @XmlRootElement(name = "ShortResource")
 public class ExtShortResource extends ShortResource {
 
     @XmlElement private ShortAttributeList attributeList;
+    @XmlElement private SecurityRuleList securityRuleList;
 
     public ExtShortResource() {}
 
@@ -26,10 +31,15 @@ public class ExtShortResource extends ShortResource {
         this.setAdvertised(builder.shortResource.isAdvertised());
 
         this.attributeList = builder.attributeList;
+        this.securityRuleList = builder.securityRuleList;
     }
 
     public ShortAttributeList getAttributeList() {
         return attributeList;
+    }
+
+    public SecurityRuleList getSecurityRuleList() {
+        return securityRuleList;
     }
 
     public static Builder builder(ShortResource resource) {
@@ -39,6 +49,7 @@ public class ExtShortResource extends ShortResource {
     public static class Builder {
         private final ShortResource shortResource;
         public ShortAttributeList attributeList;
+        public SecurityRuleList securityRuleList;
 
         private Builder(ShortResource shortResource) {
             this.shortResource = shortResource;
@@ -46,6 +57,11 @@ public class ExtShortResource extends ShortResource {
 
         public Builder withAttributes(ShortAttributeList attributeList) {
             this.attributeList = attributeList;
+            return this;
+        }
+
+        public Builder withSecurityRules(SecurityRuleList securityRuleList) {
+            this.securityRuleList = securityRuleList;
             return this;
         }
 

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/model/ExtShortResource.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/model/ExtShortResource.java
@@ -1,0 +1,56 @@
+package it.geosolutions.geostore.services.model;
+
+import it.geosolutions.geostore.services.dto.ShortResource;
+import it.geosolutions.geostore.services.rest.model.ShortAttributeList;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/** An extended version of the {@link ShortResource} class that includes attributes list. */
+@XmlRootElement(name = "ShortResource")
+public class ExtShortResource extends ShortResource {
+
+    @XmlElement private ShortAttributeList attributeList;
+
+    public ExtShortResource() {}
+
+    private ExtShortResource(Builder builder) {
+        this.setId(builder.shortResource.getId());
+        this.setName(builder.shortResource.getName());
+        this.setDescription(builder.shortResource.getDescription());
+        this.setCreation(builder.shortResource.getCreation());
+        this.setLastUpdate(builder.shortResource.getLastUpdate());
+        this.setCanEdit(builder.shortResource.isCanEdit());
+        this.setCanDelete(builder.shortResource.isCanDelete());
+        this.setCreator(builder.shortResource.getCreator());
+        this.setEditor(builder.shortResource.getEditor());
+        this.setAdvertised(builder.shortResource.isAdvertised());
+
+        this.attributeList = builder.attributeList;
+    }
+
+    public ShortAttributeList getAttributeList() {
+        return attributeList;
+    }
+
+    public static Builder builder(ShortResource resource) {
+        return new Builder(resource);
+    }
+
+    public static class Builder {
+        private final ShortResource shortResource;
+        public ShortAttributeList attributeList;
+
+        private Builder(ShortResource shortResource) {
+            this.shortResource = shortResource;
+        }
+
+        public Builder withAttributes(ShortAttributeList attributeList) {
+            this.attributeList = attributeList;
+            return this;
+        }
+
+        public ExtShortResource build() {
+            return new ExtShortResource(this);
+        }
+    }
+}

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/RESTExtJsService.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/RESTExtJsService.java
@@ -28,12 +28,13 @@
  */
 package it.geosolutions.geostore.services.rest;
 
-import it.geosolutions.geostore.services.dto.ShortResource;
 import it.geosolutions.geostore.services.dto.search.SearchFilter;
 import it.geosolutions.geostore.services.model.ExtGroupList;
 import it.geosolutions.geostore.services.model.ExtResourceList;
+import it.geosolutions.geostore.services.model.ExtShortResource;
 import it.geosolutions.geostore.services.model.ExtUserList;
 import it.geosolutions.geostore.services.rest.exception.BadRequestWebEx;
+import it.geosolutions.geostore.services.rest.exception.ForbiddenErrorWebEx;
 import it.geosolutions.geostore.services.rest.exception.InternalErrorWebEx;
 import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
 import it.geosolutions.geostore.services.rest.model.Sort;
@@ -184,10 +185,24 @@ public interface RESTExtJsService {
             @QueryParam("all") @DefaultValue("false") boolean all)
             throws BadRequestWebEx;
 
+    /**
+     * Retrieve the resource.
+     *
+     * @param sc security context
+     * @param id the id of the resource to fetch
+     * @param includeAttributes whether to include attributes in the returned resource
+     * @param includePermissions whether to include permissions in the returned resource
+     * @return the resource
+     * @throws ForbiddenErrorWebEx if the resource is protected
+     * @throws NotFoundWebEx if the resource is not found
+     */
     @GET
     @Path("/resource/{id}")
     @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_JSON})
     @Secured({"ROLE_USER", "ROLE_ADMIN", "ROLE_ANONYMOUS"})
-    ShortResource getResource(@Context SecurityContext sc, @PathParam("id") long id)
-            throws NotFoundWebEx;
+    ExtShortResource getExtResource(
+            @Context SecurityContext sc,
+            @PathParam("id") long id,
+            @QueryParam("includeAttributes") @DefaultValue("false") boolean includeAttributes,
+            @QueryParam("includePermissions") @DefaultValue("false") boolean includePermissions);
 }

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
@@ -56,6 +56,7 @@ import it.geosolutions.geostore.services.rest.exception.BadRequestWebEx;
 import it.geosolutions.geostore.services.rest.exception.ForbiddenErrorWebEx;
 import it.geosolutions.geostore.services.rest.exception.InternalErrorWebEx;
 import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
+import it.geosolutions.geostore.services.rest.model.SecurityRuleList;
 import it.geosolutions.geostore.services.rest.model.ShortAttributeList;
 import it.geosolutions.geostore.services.rest.model.Sort;
 import java.util.Arrays;
@@ -695,6 +696,7 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
 
         return ExtShortResource.builder(shortResource)
                 .withAttributes(createShortAttributeList(resource.getAttribute()))
+                .withSecurityRules(new SecurityRuleList(resource.getSecurity()))
                 .build();
     }
 

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
@@ -1275,7 +1275,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
             assertEquals(1, attributes.size());
             ShortAttribute attribute = attributes.get(0);
             assertEquals(attributeB.getName(), attribute.getName());
-            assertEquals("2024-08-31T16:22:45.654+0200", attribute.getValue());
+            assertTrue(attribute.getValue().matches("2024-08-31T16:22:45.654\\+\\d+"));
             assertEquals(attributeB.getType(), attribute.getType());
         }
 

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTServiceImpl.java
@@ -43,7 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.ws.rs.core.SecurityContext;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -250,49 +249,6 @@ public abstract class RESTServiceImpl {
         return false;
     }
 
-    public ResourceAuth getResourceAuth(User authUser, long resourceId) {
-        if (authUser.getRole().equals(Role.ADMIN)) {
-            return new ResourceAuth(true, true);
-        }
-
-        List<SecurityRule> userSecurityRules =
-                getSecurityService().getUserSecurityRule(authUser.getName(), resourceId);
-
-        ResourceAuth ret = new ResourceAuth();
-
-        if (CollectionUtils.isNotEmpty(userSecurityRules)) {
-            // take the more permissive grants
-            for (SecurityRule rule : userSecurityRules) {
-                ret.canRead |= rule.isCanRead();
-                ret.canWrite |= rule.isCanWrite();
-
-                if (ret.canRead && ret.canWrite) { // short circuit
-                    return ret;
-                }
-            }
-        }
-
-        List<String> groupNames = extratcGroupNames(authUser.getGroups());
-        if (!groupNames.isEmpty()) {
-            List<SecurityRule> groupSecurityRules =
-                    getSecurityService().getGroupSecurityRule(groupNames, resourceId);
-
-            if (CollectionUtils.isNotEmpty(groupSecurityRules)) {
-                // take the more permissive grants
-                for (SecurityRule rule : groupSecurityRules) {
-                    ret.canRead |= rule.isCanRead();
-                    ret.canWrite |= rule.isCanWrite();
-
-                    if (ret.canRead && ret.canWrite) { // short circuit
-                        return ret;
-                    }
-                }
-            }
-        }
-
-        return ret;
-    }
-
     /**
      * Creates a Guest principal with Username="guest" password="" and role ROLE_GUEST. The guest
      * principal should be used with unauthenticated users.
@@ -321,20 +277,5 @@ public abstract class RESTServiceImpl {
         groups.add(everyoneGroup);
         guest.setGroups(groups);
         return new UsernamePasswordAuthenticationToken(guest, "", authorities);
-    }
-
-    protected static class ResourceAuth {
-
-        boolean canRead;
-        boolean canWrite;
-
-        public ResourceAuth() {
-            this(false, false);
-        }
-
-        public ResourceAuth(boolean canRead, boolean canWrite) {
-            this.canRead = canRead;
-            this.canWrite = canWrite;
-        }
     }
 }


### PR DESCRIPTION
Changes as per #380:
- Added following information to the resource fetching, controlled by query parameters:
  - attributes (parameter `includeAttributes`): the returned payload contains an `AttributeList` element
  - permissions (parameter `includePermissions`): the returned payload contains a `SecurityRuleList` element
  
  Example:
  ```xml
  <ShortResource>
      <advertised>false</advertised>
      <canDelete>false</canDelete>
      <canEdit>false</canEdit>
      <creation>2025-01-17T19:04:03.379+00:00</creation>
      <creator>Y</creator>
      <editor>editore</editor>
      <id>101</id>
      <name>user owned readonly</name>
      <attributeList>
          <Attribute>
              <name>resource 101 attr</name>
              <type>STRING</type>
              <value>prova</value>
          </Attribute>
      </attributeList>
      <securityRuleList>
          <SecurityRule>
              <canRead>true</canRead>
              <canWrite>false</canWrite>
              <group>
                  <groupName>testGroup1</groupName>
                  <id>4</id>
              </group>
          </SecurityRule>
          <SecurityRule>
              <canRead>true</canRead>
              <canWrite>false</canWrite>
              <user>
                  <id>7</id>
                  <name>user</name>
              </user>
          </SecurityRule>
      </securityRuleList>
  </ShortResource>

Closes #380