### PR TITLE
Review of usergroup endpoint

### DIFF
--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserGroupService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserGroupService.java
@@ -60,20 +60,12 @@ public interface UserGroupService {
     void deassignUserGroup(long userId, long groupId) throws NotFoundServiceEx;
 
     /**
-     * @param page
-     * @param entries
-     * @return
-     * @throws BadRequestServiceEx
-     */
-    List<UserGroup> getAll(Integer page, Integer entries) throws BadRequestServiceEx;
-
-    /**
      * Returns a list of groups that match searching criteria with pagination.
      *
      * @param user the user that performs the research
      * @param page the requested page number
      * @param entries max entries for page.
-     * @param nameLike a sub-string to search in group name
+     * @param nameLike a sub-string to filter groups names with ILIKE operator
      * @param all if <code>true</code> adds to result the 'everyone' group if it matches the
      *     searching criteria
      * @return a list of groups that match searching criteria with pagination.
@@ -83,7 +75,32 @@ public interface UserGroupService {
             User user, Integer page, Integer entries, String nameLike, boolean all)
             throws BadRequestServiceEx;
 
+    /**
+     * Returns a list of groups that match searching criteria with pagination.
+     *
+     * @param page the requested page number
+     * @param entries max entries for page.
+     * @return a list of groups that match searching criteria with pagination.
+     * @throws BadRequestServiceEx
+     */
+    List<UserGroup> getAll(Integer page, Integer entries) throws BadRequestServiceEx;
+
+    /**
+     * Returns a list of groups that match searching criteria with pagination.
+     *
+     * @param page the requested page number
+     * @param entries max entries for page.
+     * @param nameLike a sub-string to filter groups names with ILIKE operator
+     * @param all if <code>true</code> adds to result the 'everyone' group if it matches the
+     *     searching criteria
+     * @return a list of groups that match searching criteria with pagination.
+     * @throws BadRequestServiceEx
+     */
+    List<UserGroup> getAll(Integer page, Integer entries, String nameLike, boolean all)
+            throws BadRequestServiceEx;
+
     UserGroup get(long id) throws BadRequestServiceEx;
+
     /**
      * @param groupId
      * @param resourcesToSet
@@ -91,8 +108,7 @@ public interface UserGroupService {
      * @param canWrite
      * @return
      * @throws BadRequestServiceEx
-     * @throws BadRequestWebEx
-     * @throws NotFoundWebEx
+     * @throws NotFoundServiceEx
      */
     List<ShortResource> updateSecurityRules(
             Long groupId, List<Long> resourcesToSet, boolean canRead, boolean canWrite)
@@ -101,26 +117,27 @@ public interface UserGroupService {
     /**
      * Persist the special UserGroups, those that implies special behavior
      *
-     * <p>For obvious reasons this Method MUST NOT exposed through the rest interface.
+     * <p>For obvious reasons this Method MUST NOT be exposed through the rest interface.
      *
      * @return true if the persist operation finish with success, false otherwise
      */
-    public boolean insertSpecialUsersGroups();
+    boolean insertSpecialUsersGroups();
 
     /**
      * Remove the special UserGroups, those that implies special behavior
      *
-     * <p>For obvious reasons this Method MUST NOT exposed through the rest interface.
+     * <p>For obvious reasons this Method MUST NOT be exposed through the rest interface.
      *
      * @return true if the removal operation finish with success, false otherwise
      */
-    public boolean removeSpecialUsersGroups();
+    boolean removeSpecialUsersGroups();
+
     /**
      * Get The UserGroup from the name
      *
      * @param name
      */
-    public UserGroup get(String name);
+    UserGroup get(String name);
 
     /**
      * Returns the amount of groups that match searching criteria. The 'everyone' group is never

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
@@ -130,8 +130,8 @@ public interface UserService {
     public Collection<User> getByGroup(UserGroup group);
 
     /**
-     * Update the user entity by fetching its security rules and group security rules
-     * from the database.
+     * Update the user entity by fetching its security rules and group security rules from the
+     * database.
      *
      * @param user
      */

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserGroupService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserGroupService.java
@@ -95,6 +95,19 @@ public interface RESTUserGroupService {
             @PathParam("groupid") long groupId)
             throws NotFoundWebEx;
 
+    /**
+     * Returns groups that match searching criteria with pagination.
+     *
+     * @param sc the security context
+     * @param page the requested page number
+     * @param entries max entries for page
+     * @param nameLike a sub-string to search in group name with ILIKE operator
+     * @param all if <code>true</code> adds to result the 'everyone' group if it matches the
+     *     searching criteria
+     * @param includeUsers if to include group users in the results
+     * @return a list of groups that match searching criteria with pagination.
+     * @throws BadRequestWebEx
+     */
     @GET
     @Path("/")
     @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_JSON})
@@ -104,7 +117,8 @@ public interface RESTUserGroupService {
             @QueryParam("page") Integer page,
             @QueryParam("entries") Integer entries,
             @QueryParam("all") @DefaultValue("false") boolean all,
-            @QueryParam("users") @DefaultValue("true") boolean includeUsers)
+            @QueryParam("users") @DefaultValue("true") boolean includeUsers,
+            @QueryParam("nameLike") String nameLike)
             throws BadRequestWebEx;
 
     @PUT

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/keycloak/MockUserGroupService.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/keycloak/MockUserGroupService.java
@@ -71,6 +71,12 @@ class MockUserGroupService implements UserGroupService {
     }
 
     @Override
+    public List<UserGroup> getAll(Integer page, Integer entries, String nameLike, boolean all)
+            throws BadRequestServiceEx {
+        return null;
+    }
+
+    @Override
     public List<UserGroup> getAllAllowed(
             User user, Integer page, Integer entries, String nameLike, boolean all)
             throws BadRequestServiceEx {

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/service/impl/RESTUserGroupServiceImplTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/service/impl/RESTUserGroupServiceImplTest.java
@@ -19,6 +19,7 @@
  */
 package it.geosolutions.geostore.rest.service.impl;
 
+import it.geosolutions.geostore.core.dao.UserGroupDAO;
 import it.geosolutions.geostore.core.model.enums.Role;
 import it.geosolutions.geostore.services.ServiceTestBase;
 import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
@@ -42,7 +43,7 @@ import org.junit.Test;
 public class RESTUserGroupServiceImplTest extends ServiceTestBase {
 
     RESTUserGroupServiceImpl restService;
-    long adminID;
+    UserGroupDAO userGroupDAO;
 
     @Before
     public void setUp() throws BadRequestServiceEx, NotFoundServiceEx {
@@ -68,7 +69,7 @@ public class RESTUserGroupServiceImplTest extends ServiceTestBase {
         SecurityContext sc = new MockSecurityContext(userService.get(adminID));
 
         // retrieve the list of usergroups (with users flag set to true)
-        UserGroupList res = restService.getAll(sc, 0, 1000, true, true);
+        UserGroupList res = restService.getAll(sc, 0, 1000, true, true, null);
         List<RESTUserGroup> groups = res.getUserGroupList();
         assertEquals(1, groups.size());
         RESTUserGroup group = groups.get(0);
@@ -87,7 +88,7 @@ public class RESTUserGroupServiceImplTest extends ServiceTestBase {
         SecurityContext sc = new MockSecurityContext(userService.get(adminID));
 
         // retrieve the list of usergroups (with users flag set to false)
-        UserGroupList res = restService.getAll(sc, 0, 1000, true, false);
+        UserGroupList res = restService.getAll(sc, 0, 1000, true, false, null);
         List<RESTUserGroup> groups = res.getUserGroupList();
         assertEquals(1, groups.size());
         RESTUserGroup group = groups.get(0);
@@ -109,14 +110,52 @@ public class RESTUserGroupServiceImplTest extends ServiceTestBase {
 
         SecurityContext sc = new MockSecurityContext(userService.get(adminID));
 
-        UserGroupList firstPage = restService.getAll(sc, 0, 2, false, false);
+        UserGroupList firstPage = restService.getAll(sc, 0, 2, false, false, null);
         List<RESTUserGroup> firstPageGroups = firstPage.getUserGroupList();
-        List<String> firstPageGroupsNames = firstPageGroups.stream().map(RESTUserGroup::getGroupName).collect(Collectors.toList());
-        assertEquals(firstPageGroupsNames, List.of(firstGroupName, secondGroupName));
+        List<String> firstPageGroupsNames =
+                firstPageGroups.stream()
+                        .map(RESTUserGroup::getGroupName)
+                        .collect(Collectors.toList());
+        assertEquals(List.of(firstGroupName, secondGroupName), firstPageGroupsNames);
 
-        UserGroupList secondPage = restService.getAll(sc, 1, 2, false, false);
+        UserGroupList secondPage = restService.getAll(sc, 1, 2, false, false, null);
         List<RESTUserGroup> secondPageGroups = secondPage.getUserGroupList();
-        List<String> secondPageGroupsNames = secondPageGroups.stream().map(RESTUserGroup::getGroupName).collect(Collectors.toList());
-        assertEquals(secondPageGroupsNames, List.of(thirdGroupName));
+        List<String> secondPageGroupsNames =
+                secondPageGroups.stream()
+                        .map(RESTUserGroup::getGroupName)
+                        .collect(Collectors.toList());
+        assertEquals(List.of(thirdGroupName), secondPageGroupsNames);
+    }
+
+    @Test
+    public void testGetAllFiltered() throws Exception {
+
+        final String groupAName = "group_A";
+        final String groupBName = "groupB";
+        final String groupCName = "this is group C";
+
+        long adminID = createUser("admin", Role.ADMIN, "admin");
+
+        createUserGroup(groupAName, new long[] {});
+        createUserGroup(groupBName, new long[] {});
+        createUserGroup(groupCName, new long[] {});
+
+        SecurityContext sc = new MockSecurityContext(userService.get(adminID));
+
+        UserGroupList allGroupsMatched = restService.getAll(sc, null, null, false, false, "group%");
+        List<RESTUserGroup> allGroupsMatchedGroups = allGroupsMatched.getUserGroupList();
+        List<String> allGroupsMatchedGroupsNames =
+                allGroupsMatchedGroups.stream()
+                        .map(RESTUserGroup::getGroupName)
+                        .collect(Collectors.toList());
+        assertTrue(List.of(groupAName, groupBName).containsAll(allGroupsMatchedGroupsNames));
+
+        UserGroupList oneGroupMatched = restService.getAll(sc, null, null, false, false, "group_a");
+        List<RESTUserGroup> oneGroupsMatchedGroups = oneGroupMatched.getUserGroupList();
+        List<String> oneGroupMatchedGroupsNames =
+                oneGroupsMatchedGroups.stream()
+                        .map(RESTUserGroup::getGroupName)
+                        .collect(Collectors.toList());
+        assertEquals(List.of(groupAName), oneGroupMatchedGroupsNames);
     }
 }

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/service/impl/RESTUserGroupServiceImplTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/service/impl/RESTUserGroupServiceImplTest.java
@@ -28,6 +28,7 @@ import it.geosolutions.geostore.services.rest.model.RESTUserGroup;
 import it.geosolutions.geostore.services.rest.model.UserGroupList;
 import it.geosolutions.geostore.services.rest.utils.MockSecurityContext;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.core.SecurityContext;
 import org.junit.After;
 import org.junit.Before;
@@ -91,5 +92,31 @@ public class RESTUserGroupServiceImplTest extends ServiceTestBase {
         assertEquals(1, groups.size());
         RESTUserGroup group = groups.get(0);
         assertEquals(0, group.getRestUsers().getList().size());
+    }
+
+    @Test
+    public void testGetAllPagination() throws Exception {
+
+        final String firstGroupName = "group1";
+        final String secondGroupName = "group2";
+        final String thirdGroupName = "group3";
+
+        long adminID = createUser("admin", Role.ADMIN, "admin");
+
+        createUserGroup(firstGroupName, new long[] {});
+        createUserGroup(secondGroupName, new long[] {});
+        createUserGroup(thirdGroupName, new long[] {});
+
+        SecurityContext sc = new MockSecurityContext(userService.get(adminID));
+
+        UserGroupList firstPage = restService.getAll(sc, 0, 2, false, false);
+        List<RESTUserGroup> firstPageGroups = firstPage.getUserGroupList();
+        List<String> firstPageGroupsNames = firstPageGroups.stream().map(RESTUserGroup::getGroupName).collect(Collectors.toList());
+        assertEquals(firstPageGroupsNames, List.of(firstGroupName, secondGroupName));
+
+        UserGroupList secondPage = restService.getAll(sc, 1, 2, false, false);
+        List<RESTUserGroup> secondPageGroups = secondPage.getUserGroupList();
+        List<String> secondPageGroupsNames = secondPageGroups.stream().map(RESTUserGroup::getGroupName).collect(Collectors.toList());
+        assertEquals(secondPageGroupsNames, List.of(thirdGroupName));
     }
 }

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserGroupService.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserGroupService.java
@@ -63,7 +63,13 @@ public class MockedUserGroupService implements UserGroupService {
 
     @Override
     public List<UserGroup> getAll(Integer page, Integer entries) throws BadRequestServiceEx {
-        return new ArrayList<UserGroup>(GROUPS.values());
+        return new ArrayList<>(GROUPS.values());
+    }
+
+    @Override
+    public List<UserGroup> getAll(Integer page, Integer entries, String nameLike, boolean all)
+            throws BadRequestServiceEx {
+        return new ArrayList<>(GROUPS.values());
     }
 
     @Override


### PR DESCRIPTION
Changes as per #381:

- added `nameLike`query parameter to the endpoint `/rest/usergroups`, to let the caller filter by usergroup name

The name of the parameter is aligned to the path parameters used for similar purposes all around the API; in this case it is a query parameter to better adhere to ReST standards.

For the same endpoint, pagination was already in place, so nothing has been done, apart from creating a unit test to verify the functionality.

Closes #381