### PR TITLE
Fixed group filter parsing in boolean filters.

### DIFF
--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/AndFilter.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/AndFilter.java
@@ -36,10 +36,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "AND")
 public class AndFilter extends SearchFilter {
 
-    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = -4055325472578322312L;
 
-    private List<SearchFilter> filters = new ArrayList<SearchFilter>();
+    private List<SearchFilter> filters = new ArrayList<>();
 
     public AndFilter() {}
 
@@ -55,7 +54,8 @@ public class AndFilter extends SearchFilter {
         @XmlElement(name = "OR", type = OrFilter.class),
         @XmlElement(name = "AND", type = AndFilter.class),
         @XmlElement(name = "FIELD", type = FieldFilter.class),
-        @XmlElement(name = "CATEGORY", type = CategoryFilter.class)
+        @XmlElement(name = "CATEGORY", type = CategoryFilter.class),
+        @XmlElement(name = "GROUP", type = GroupFilter.class)
     })
     public List<SearchFilter> getFilters() {
         return filters;
@@ -76,6 +76,6 @@ public class AndFilter extends SearchFilter {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[" + filters + '}';
+        return getClass().getSimpleName() + "[" + filters + ']';
     }
 }

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/OrFilter.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/OrFilter.java
@@ -36,10 +36,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "OR")
 public class OrFilter extends SearchFilter {
 
-    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = -1319295933578215551L;
 
-    private List<SearchFilter> filters = new ArrayList<SearchFilter>();
+    private List<SearchFilter> filters = new ArrayList<>();
 
     public OrFilter() {}
 
@@ -55,7 +54,8 @@ public class OrFilter extends SearchFilter {
         @XmlElement(name = "OR", type = OrFilter.class),
         @XmlElement(name = "AND", type = AndFilter.class),
         @XmlElement(name = "FIELD", type = FieldFilter.class),
-        @XmlElement(name = "CATEGORY", type = CategoryFilter.class)
+        @XmlElement(name = "CATEGORY", type = CategoryFilter.class),
+        @XmlElement(name = "GROUP", type = GroupFilter.class)
     })
     public List<SearchFilter> getFilters() {
         return filters;
@@ -76,6 +76,6 @@ public class OrFilter extends SearchFilter {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[" + filters + '}';
+        return getClass().getSimpleName() + "[" + filters + ']';
     }
 }


### PR DESCRIPTION
Group filter was missing in the list of parsable filters in the AND and OR search filters.
This caused to have filters like the following ignored:
```xml
<OR>
    <FIELD>
        <field>NAME</field>
        <operator>ILIKE</operator>
        <value>%user%</value>
    </FIELD>
    <AND>
        <NOT>
            <CATEGORY>
                <operator>EQUAL_TO</operator>
                <name>MAP</name>
            </CATEGORY>
        </NOT>
        <NOT>
            <GROUP>
                <operator>ILIKE</operator>
                <names>%group%</names>
            </GROUP>
        </NOT>
    </AND>
</OR>
```