### PR TITLE
Added count in get all usergroups operation result.

### DIFF
--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/ResourcePermissionService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/ResourcePermissionService.java
@@ -3,7 +3,7 @@ package it.geosolutions.geostore.services;
 import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.core.model.User;
 
-public interface PermissionService {
+public interface ResourcePermissionService {
     /**
      * This method allows us to know if we filter out "unadvertised" resources for
      * non-admin/non-owners, keeping only owned resources.

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserGroupService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserGroupService.java
@@ -140,15 +140,15 @@ public interface UserGroupService {
     UserGroup get(String name);
 
     /**
-     * Returns the amount of groups that match searching criteria. The 'everyone' group is never
-     * included.
+     * Returns the amount of groups that match searching criteria.
      *
-     * @param authUser the user that performs the research
      * @param nameLike a sub-string to search in group name
+     * @param all if <code>true</code> adds to result the 'everyone' group if it matches the
+     *     searching criteria
      * @return the amount of groups that match searching criteria
      * @throws BadRequestServiceEx
      */
-    long getCount(User authUser, String nameLike) throws BadRequestServiceEx;
+    long getCount(String nameLike, boolean all) throws BadRequestServiceEx;
 
     /**
      * Returns the amount of groups that match searching criteria.

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
@@ -7,7 +7,7 @@ import it.geosolutions.geostore.core.model.enums.Role;
 import java.util.List;
 import java.util.function.BiFunction;
 
-public class PermissionServiceImpl implements PermissionService {
+public class ResourcePermissionServiceImpl implements ResourcePermissionService {
 
     private final BiFunction<SecurityRule, Resource, Boolean> resourceOwnership =
             (rule, resource) -> resource.getId().equals(rule.getResource().getId());

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
@@ -86,7 +86,8 @@ public class ResourceServiceImpl implements ResourceService {
     private SecurityDAO securityDAO;
 
     private UserService userService;
-    private PermissionService permissionService;
+
+    private ResourcePermissionService resourcePermissionService;
 
     /** @param securityDAO the securityDAO to set */
     public void setSecurityDAO(SecurityDAO securityDAO) {
@@ -122,8 +123,8 @@ public class ResourceServiceImpl implements ResourceService {
         this.userService = userService;
     }
 
-    public void setPermissionService(PermissionService permissionService) {
-        this.permissionService = permissionService;
+    public void setPermissionService(ResourcePermissionService resourcePermissionService) {
+        this.resourcePermissionService = resourcePermissionService;
     }
 
     /*
@@ -702,7 +703,7 @@ public class ResourceServiceImpl implements ResourceService {
         userService.fetchSecurityRules(user);
 
         return resources.stream()
-                .filter(r -> permissionService.isResourceAvailableForUser(r, user))
+                .filter(r -> resourcePermissionService.isResourceAvailableForUser(r, user))
                 .map(r -> createShortResource(user, r))
                 .collect(Collectors.toList());
     }
@@ -710,7 +711,7 @@ public class ResourceServiceImpl implements ResourceService {
     private ShortResource createShortResource(User user, Resource resource) {
         ShortResource shortResource = new ShortResource(resource);
 
-        if (user != null && permissionService.canUserWriteResource(user, resource)) {
+        if (user != null && resourcePermissionService.canUserWriteResource(user, resource)) {
             shortResource.setCanEdit(true);
             shortResource.setCanDelete(true);
         }

--- a/src/core/services-impl/src/main/resources/applicationContext.xml
+++ b/src/core/services-impl/src/main/resources/applicationContext.xml
@@ -24,6 +24,6 @@
 
     <bean id="userSessionService" class="it.geosolutions.geostore.services.InMemoryUserSessionServiceImpl">    </bean>
 
-    <bean id="permissionService" class="it.geosolutions.geostore.services.PermissionServiceImpl">    </bean>
+    <bean id="resourcePermissionService" class="it.geosolutions.geostore.services.ResourcePermissionServiceImpl">    </bean>
 
 </beans>

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/UserGroupList.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/model/UserGroupList.java
@@ -31,18 +31,20 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class UserGroupList implements Iterable<RESTUserGroup> {
 
     private List<RESTUserGroup> list;
+    private long count;
 
     public UserGroupList() {
-        this.list = new ArrayList<RESTUserGroup>();
+        this.list = new ArrayList<>();
     }
 
     /** @param list */
-    public UserGroupList(List<RESTUserGroup> list) {
+    public UserGroupList(List<RESTUserGroup> list, long count) {
         super();
+        this.count = count;
         if (list != null) {
             this.list = list;
         } else {
-            this.list = new ArrayList<RESTUserGroup>();
+            this.list = new ArrayList<>();
         }
     }
 
@@ -55,6 +57,10 @@ public class UserGroupList implements Iterable<RESTUserGroup> {
     /** @param userGroup the userGroup to set */
     public void setUserGroupList(List<RESTUserGroup> userGroup) {
         this.list = userGroup;
+    }
+
+    public long getCount() {
+        return count;
     }
 
     @Override

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
@@ -535,7 +535,9 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
         }
 
         try {
-            nameLike = nameLike.replaceAll("[*]", "%");
+            if (nameLike != null) {
+                nameLike = nameLike.replaceAll("[*]", "%");
+            }
             List<UserGroup> groups =
                     groupService.getAllAllowed(authUser, page, limit, nameLike, all);
 

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
@@ -31,7 +31,7 @@ import it.geosolutions.geostore.core.model.Attribute;
 import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserGroup;
-import it.geosolutions.geostore.services.PermissionService;
+import it.geosolutions.geostore.services.ResourcePermissionService;
 import it.geosolutions.geostore.services.ResourceService;
 import it.geosolutions.geostore.services.SecurityService;
 import it.geosolutions.geostore.services.UserGroupService;
@@ -86,7 +86,7 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
 
     private UserGroupService groupService;
 
-    private PermissionService permissionService;
+    private ResourcePermissionService resourcePermissionService;
 
     /** @param resourceService */
     public void setResourceService(ResourceService resourceService) {
@@ -97,8 +97,8 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
         this.groupService = userGroupService;
     }
 
-    public void setPermissionService(PermissionService permissionService) {
-        this.permissionService = permissionService;
+    public void setPermissionService(ResourcePermissionService resourcePermissionService) {
+        this.resourcePermissionService = resourcePermissionService;
     }
 
     /* (non-Javadoc)
@@ -395,7 +395,7 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
         userService.fetchSecurityRules(user);
 
         return resources.stream()
-                .filter(r -> permissionService.isResourceAvailableForUser(r, user))
+                .filter(r -> resourcePermissionService.isResourceAvailableForUser(r, user))
                 .collect(Collectors.toList());
     }
 
@@ -422,7 +422,7 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
                         /* setting copy permission as in ResourceEnvelop.isCanCopy */
                         .withCanCopy(user != null);
 
-        if (permissionService.canUserWriteResource(user, resource)) {
+        if (resourcePermissionService.canUserWriteResource(user, resource)) {
             extResourceBuilder.withCanEdit(true).withCanDelete(true);
         }
 
@@ -684,12 +684,12 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
         User authUser = extractAuthUser(sc);
         userService.fetchSecurityRules(authUser);
 
-        if (!permissionService.canUserReadResource(authUser, id)) {
+        if (!resourcePermissionService.canUserReadResource(authUser, id)) {
             throw new ForbiddenErrorWebEx("Resource is protected");
         }
 
         ShortResource shortResource = new ShortResource(resource);
-        if (permissionService.canUserWriteResource(authUser, resource)) {
+        if (resourcePermissionService.canUserWriteResource(authUser, resource)) {
             shortResource.setCanEdit(true);
             shortResource.setCanDelete(true);
         }
@@ -755,7 +755,7 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
                 canEdit = sr.isCanEdit();
                 return;
             }
-            if (authUser != null && permissionService.canUserWriteResource(authUser, r)) {
+            if (authUser != null && resourcePermissionService.canUserWriteResource(authUser, r)) {
                 canEdit = true;
                 canDelete = true;
             }

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
@@ -39,6 +39,7 @@ import it.geosolutions.geostore.services.dto.search.BaseField;
 import it.geosolutions.geostore.services.dto.search.FieldFilter;
 import it.geosolutions.geostore.services.dto.search.GroupFilter;
 import it.geosolutions.geostore.services.dto.search.SearchOperator;
+import it.geosolutions.geostore.services.model.ExtGroupList;
 import it.geosolutions.geostore.services.model.ExtResource;
 import it.geosolutions.geostore.services.model.ExtResourceList;
 import it.geosolutions.geostore.services.model.ExtShortResource;
@@ -1518,6 +1519,38 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                     () ->
                             restExtJsService.getExtResource(
                                     user0SecurityContext, protectedGroupResourceId, true, true));
+        }
+    }
+
+    @Test
+    public void testGetGroupsList() throws Exception {
+        final String groupAName = "groupA";
+
+        long groupAId = createGroup(groupAName);
+        UserGroup groupA = userGroupService.get(groupAId);
+
+        createGroup("groupB");
+
+        long adminId = restCreateUser("admin", Role.ADMIN, null, "admin");
+        SecurityContext adminSecurityContext = new SimpleSecurityContext(adminId);
+
+        long userId = restCreateUser("u0", Role.USER, Collections.singleton(groupA), "p0");
+        SecurityContext userSecurityContext = new SimpleSecurityContext(userId);
+
+        {
+            ExtGroupList response =
+                    restExtJsService.getGroupsList(adminSecurityContext, null, 0, 1000, true);
+            List<UserGroup> resources = response.getList();
+            assertEquals(2, resources.size());
+        }
+
+        {
+            ExtGroupList response =
+                    restExtJsService.getGroupsList(userSecurityContext, null, 0, 1000, true);
+            List<UserGroup> userGroups = response.getList();
+            assertEquals(1, userGroups.size());
+            UserGroup userGroup = userGroups.get(0);
+            assertEquals(groupAName, userGroup.getGroupName());
         }
     }
 

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/ServiceTestBase.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/ServiceTestBase.java
@@ -68,7 +68,7 @@ public class ServiceTestBase {
     protected static CategoryService categoryService;
     protected static UserService userService;
     protected static UserGroupService userGroupService;
-    protected static PermissionService permissionService;
+    protected static ResourcePermissionService resourcePermissionService;
 
     protected static ResourceDAO resourceDAO;
     protected static UserDAO userDAO;
@@ -95,7 +95,8 @@ public class ServiceTestBase {
                 categoryService = (CategoryService) ctx.getBean("categoryService");
                 userService = (UserService) ctx.getBean("userService");
                 userGroupService = (UserGroupService) ctx.getBean("userGroupService");
-                permissionService = (PermissionService) ctx.getBean("permissionService");
+                resourcePermissionService =
+                        (ResourcePermissionService) ctx.getBean("resourcePermissionService");
 
                 resourceDAO = (ResourceDAO) ctx.getBean("resourceDAO");
                 userDAO = (UserDAO) ctx.getBean("userDAO");
@@ -125,7 +126,7 @@ public class ServiceTestBase {
         assertNotNull(categoryService);
         assertNotNull(userService);
         assertNotNull(userGroupService);
-        assertNotNull(permissionService);
+        assertNotNull(resourcePermissionService);
 
         assertNotNull(resourceDAO);
         assertNotNull(userDAO);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTUserGroupServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTUserGroupServiceImpl.java
@@ -178,7 +178,13 @@ public class RESTUserGroupServiceImpl implements RESTUserGroupService {
                     userGroupService.getAll(page, entries, nameLike, all).stream()
                             .map(ug -> createRestUserGroup(ug, includeUsers))
                             .collect(Collectors.toList());
-            return new UserGroupList(restUserGroups);
+
+            long count = 0;
+            if (!restUserGroups.isEmpty()) {
+                count = userGroupService.getCount(nameLike, all);
+            }
+
+            return new UserGroupList(restUserGroups, count);
         } catch (BadRequestServiceEx e) {
             LOGGER.error(e.getMessage(), e);
             throw new BadRequestWebEx(e.getMessage());
@@ -333,7 +339,7 @@ public class RESTUserGroupServiceImpl implements RESTUserGroupService {
                     groupStream
                             .map(g -> new RESTUserGroup(g, Collections.emptySet()))
                             .collect(Collectors.toList());
-            groupList = new UserGroupList(restGroups);
+            groupList = new UserGroupList(restGroups, restGroups.size());
         } else {
             groupList = new UserGroupList();
         }

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/keycloak/MockUserGroupService.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/keycloak/MockUserGroupService.java
@@ -111,7 +111,8 @@ class MockUserGroupService implements UserGroupService {
     }
 
     @Override
-    public long getCount(User authUser, String nameLike) throws BadRequestServiceEx {
+    public long getCount(String nameLike, boolean all) throws BadRequestServiceEx {
+        // TODO Auto-generated method stub
         return 0;
     }
 

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/service/impl/RESTUserGroupServiceImplTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/service/impl/RESTUserGroupServiceImplTest.java
@@ -111,6 +111,7 @@ public class RESTUserGroupServiceImplTest extends ServiceTestBase {
         SecurityContext sc = new MockSecurityContext(userService.get(adminID));
 
         UserGroupList firstPage = restService.getAll(sc, 0, 2, false, false, null);
+        assertEquals(3, firstPage.getCount());
         List<RESTUserGroup> firstPageGroups = firstPage.getUserGroupList();
         List<String> firstPageGroupsNames =
                 firstPageGroups.stream()
@@ -119,6 +120,7 @@ public class RESTUserGroupServiceImplTest extends ServiceTestBase {
         assertEquals(List.of(firstGroupName, secondGroupName), firstPageGroupsNames);
 
         UserGroupList secondPage = restService.getAll(sc, 1, 2, false, false, null);
+        assertEquals(3, firstPage.getCount());
         List<RESTUserGroup> secondPageGroups = secondPage.getUserGroupList();
         List<String> secondPageGroupsNames =
                 secondPageGroups.stream()

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserGroupService.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/utils/MockedUserGroupService.java
@@ -116,7 +116,7 @@ public class MockedUserGroupService implements UserGroupService {
     }
 
     @Override
-    public long getCount(User authUser, String nameLike) throws BadRequestServiceEx {
+    public long getCount(String nameLike, boolean all) throws BadRequestServiceEx {
         // TODO Auto-generated method stub
         return 0;
     }


### PR DESCRIPTION
This PR follows #394, since the `/rest/usergroups` pagination was missing the total count.

These changes add to the endpoint response the total count and the renaming of the PermissionService class to ResourcePermissionService.

There is also a specific unit test for the getGroupList operation, since it is going to be used to fetch user groups now.

Closes #381