### PR TITLE
[FIXES #398] Session Refresh method should update the access_token too and not only the refresh one

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTSessionServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTSessionServiceImpl.java
@@ -179,7 +179,7 @@ public class RESTSessionServiceImpl extends RESTServiceImpl implements RESTSessi
             return null;
         }
         SessionToken token = new SessionToken();
-        token.setAccessToken(accessToken);
+        token.setAccessToken(sessionToken.getId());
         token.setRefreshToken(sessionToken.getRefreshToken());
         token.setExpires(sessionToken.getExpirationInterval());
         token.setTokenType(BEARER_TYPE);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/SessionServiceDelegateImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/SessionServiceDelegateImpl.java
@@ -30,7 +30,7 @@ public class SessionServiceDelegateImpl implements SessionServiceDelegate {
                     "Refresh token was not provided or session is already expired.");
         }
         SessionToken token = new SessionToken();
-        token.setAccessToken(accessToken);
+        token.setAccessToken(sessionToken.getId());
         token.setRefreshToken(sessionToken.getRefreshToken());
         token.setExpires(sessionToken.getExpirationInterval());
         token.setTokenType(BEARER_TYPE);


### PR DESCRIPTION
Description:

This pull request introduces a new unit test to the RefreshTokenServiceTest suite, enhancing our OAuth2 session management by ensuring that the refresh method correctly updates the access_token when a new token is received during the refresh process.

Background:

In OAuth2-based authentication systems, refreshing tokens is a critical operation to maintain seamless user sessions without requiring repeated logins. Ensuring that both access_token and refresh_token are updated appropriately during this process is vital for security and functionality.

While existing tests (testRefreshWithValidTokens) verify that tokens are refreshed successfully, they implicitly cover the update of tokens. This PR adds an explicit test case to validate that when a new access_token is issued upon refresh, it replaces the old token both in the returned SessionToken and within the internal cache. This enhances test coverage and provides clearer documentation of expected behavior.

Fix https://github.com/geosolutions-it/webmapper-halliburton/issues/3595