### PR TITLE
Restored resource entity XML serialization.

### DIFF
--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Resource.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Resource.java
@@ -47,6 +47,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 /**
@@ -69,6 +70,7 @@ import javax.xml.bind.annotation.XmlTransient;
             @Index(name = "idx_resource_category", columnList = "category_id")
         })
 // @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "gs_resource")
+@XmlRootElement(name = "Resource")
 public class Resource implements Serializable, CycleRecoverable {
 
     private static final long serialVersionUID = 4852100679788007328L;


### PR DESCRIPTION
This change follows the issue reported [here](https://github.com/geosolutions-it/MapStore2/pull/10731#pullrequestreview-2578725752).

The annotation used to serialize and deserialize the Resource entity was removed causing regression.
This PR restores it.