### PR TITLE
[Backport to 2.2.x][FIXES #398] Session Refresh method should update the access_token to…

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTSessionServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTSessionServiceImpl.java
@@ -179,7 +179,7 @@ public class RESTSessionServiceImpl extends RESTServiceImpl implements RESTSessi
             return null;
         }
         SessionToken token = new SessionToken();
-        token.setAccessToken(accessToken);
+        token.setAccessToken(sessionToken.getId());
         token.setRefreshToken(sessionToken.getRefreshToken());
         token.setExpires(sessionToken.getExpirationInterval());
         token.setTokenType(BEARER_TYPE);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/SessionServiceDelegateImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/SessionServiceDelegateImpl.java
@@ -30,7 +30,7 @@ public class SessionServiceDelegateImpl implements SessionServiceDelegate {
                     "Refresh token was not provided or session is already expired.");
         }
         SessionToken token = new SessionToken();
-        token.setAccessToken(accessToken);
+        token.setAccessToken(sessionToken.getId());
         token.setRefreshToken(sessionToken.getRefreshToken());
         token.setExpires(sessionToken.getExpirationInterval());
         token.setTokenType(BEARER_TYPE);


### PR DESCRIPTION
…o and not only the refresh one (#399)

(cherry picked from commit c446939c63f14822368b8baccdcd510a41357569)

# Conflicts:
#	src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java