### PR TITLE
Optimized user permission checks on resource.

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/SecurityDAO.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/SecurityDAO.java
@@ -41,22 +41,18 @@ public interface SecurityDAO extends RestrictedGenericDAO<SecurityRule> {
      * @param resourceId
      * @return List<SecurityRule>
      */
-    public List<SecurityRule> findUserSecurityRule(String userName, long resourceId);
+    List<SecurityRule> findUserSecurityRule(String userName, long resourceId);
 
     /**
      * @param groupNames
      * @param resourceId
      * @return
      */
-    public List<SecurityRule> findGroupSecurityRule(List<String> groupNames, long resourceId);
+    List<SecurityRule> findGroupSecurityRule(List<String> groupNames, long resourceId);
 
     /**
      * @param resourceId
      * @return List<SecurityRule>
      */
-    public List<SecurityRule> findResourceSecurityRules(long resourceId);
-
-    List<SecurityRule> findUserSecurityRules(long userId);
-
-    List<SecurityRule> findUserGroupSecurityRules(long userGroupId);
+    List<SecurityRule> findResourceSecurityRules(long resourceId);
 }

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/UserDAO.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/UserDAO.java
@@ -20,10 +20,15 @@
 package it.geosolutions.geostore.core.dao;
 
 import it.geosolutions.geostore.core.model.User;
+import java.util.List;
 
 /**
  * Interface UserDAO.
  *
  * @author Tobia di Pisa (tobia.dipisa at geo-solutions.it)
  */
-public interface UserDAO extends RestrictedGenericDAO<User> {}
+public interface UserDAO extends RestrictedGenericDAO<User> {
+    default List<User> findFavoritedBy(Long resourceId) {
+        return null;
+    }
+}

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/SecurityDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/SecurityDAOImpl.java
@@ -246,39 +246,6 @@ public class SecurityDAOImpl extends BaseDAO<SecurityRule, Long> implements Secu
         return super.search(searchCriteria);
     }
 
-    /**
-     * @param userId
-     * @return List<SecurityRule>
-     */
-    @Override
-    public List<SecurityRule> findUserSecurityRules(long userId) {
-        Search searchCriteria = new Search(SecurityRule.class);
-
-        Filter securityFilter = Filter.equal("user.id", userId);
-
-        searchCriteria.addFilter(securityFilter);
-
-        return super.search(searchCriteria);
-    }
-
-    /**
-     * @param userGroupId
-     * @return List<SecurityRule>
-     */
-    @Override
-    public List<SecurityRule> findUserGroupSecurityRules(long userGroupId) {
-        Search searchCriteria = new Search(SecurityRule.class);
-
-        Filter securityFilter = Filter.equal("group.id", userGroupId);
-
-        searchCriteria.addFilter(securityFilter);
-
-        return super.search(searchCriteria);
-    }
-
-    /* (non-Javadoc)
-     * @see it.geosolutions.geostore.core.dao.ResourceDAO#findGroupSecurityRule(java.lang.String, long)
-     */
     @Override
     public List<SecurityRule> findGroupSecurityRule(List<String> groupNames, long resourceId) {
         List<SecurityRule> rules = findResourceSecurityRules(resourceId);

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/UserDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/UserDAOImpl.java
@@ -19,7 +19,9 @@
  */
 package it.geosolutions.geostore.core.dao.impl;
 
+import com.googlecode.genericdao.search.Filter;
 import com.googlecode.genericdao.search.ISearch;
+import com.googlecode.genericdao.search.Search;
 import it.geosolutions.geostore.core.dao.UserDAO;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
@@ -166,5 +168,15 @@ public class UserDAOImpl extends BaseDAO<User, Long> implements UserDAO {
         }
 
         return super.save(entities);
+    }
+
+    @Override
+    public List<User> findFavoritedBy(Long resourceId) {
+
+        Search searchCriteria = new Search(User.class);
+
+        searchCriteria.addFilter(Filter.some("favorites", Filter.equal("id", resourceId)));
+
+        return super.search(searchCriteria);
     }
 }

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/ResourcePermissionService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/ResourcePermissionService.java
@@ -6,48 +6,35 @@ import it.geosolutions.geostore.core.model.User;
 public interface ResourcePermissionService {
 
     /**
-     * Verifies whether the user or any of their groups is the owner of the resource and has read
+     * Verifies whether the user or any of its groups is the owner of the resource and has read
      * permissions on it.
      *
-     * <p>Be aware to fetch the user security rules prior to call this method.
+     * <p>Be aware to fetch the resource security rules prior to call this method.
      *
+     * @param resource
      * @param user
-     * @param resourceId
-     * @return <code>true</code> if the user can read the resource, <code>false</code> otherwise
-     * @throws IllegalArgumentException if the user security rules have not been initialized
+     * @return <code>true</code> if the resource can be read by the user, <code>false</code>
+     *     otherwise
+     * @throws IllegalArgumentException if the resource security rules have not been initialized
      *     properly
      */
-    boolean canUserReadResource(User user, Long resourceId);
+    boolean canResourceBeReadByUser(Resource resource, User user);
 
     /**
-     * Verifies whether the user or any of their groups is the owner of the resource and has write
+     * Verifies whether the user or any of its groups is the owner of the resource and has write
      * permissions on it.
      *
      * <p>GUEST users can not access to the delete and edit (resource, data blob is editable)
      * services, so only admins and authenticated users with write permissions can.
      *
-     * <p>Be aware to fetch the user security rules prior to call this method.
+     * <p>Be aware to fetch the resource security rules prior to call this method.
      *
-     * @param user
      * @param resource
-     * @return <code>true</code> if the user can write the resource, <code>false</code> otherwise
-     * @throws IllegalArgumentException if the user security rules have not been initialized
-     *     properly
-     */
-    boolean canUserWriteResource(User user, Resource resource);
-
-    /**
-     * Verifies whether the user or any of their groups is the owner of the resource and has both
-     * read and write permissions on it.
-     *
-     * <p>Be aware to fetch the user security rules prior to call this method.
-     *
      * @param user
-     * @param resource
-     * @return <code>true</code> if the user can read and write the resource, <code>false</code>
+     * @return <code>true</code> if the resource can be written by the user, <code>false</code>
      *     otherwise
-     * @throws IllegalArgumentException if the user security rules have not been initialized
+     * @throws IllegalArgumentException if the resource security rules have not been initialized
      *     properly
      */
-    boolean canUserReadAndWriteResource(User user, Resource resource);
+    boolean canResourceBeWrittenByUser(Resource resource, User user);
 }

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/ResourceService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/ResourceService.java
@@ -253,4 +253,23 @@ public interface ResourceService extends SecurityService {
 
     long insertAttribute(long id, String name, String value, DataType type)
             throws InternalErrorServiceEx;
+
+    /**
+     * Update the resource entity by fetching its security rules from the database.
+     *
+     * @param resource
+     */
+    default void fetchSecurityRules(Resource resource) {
+        /* no-op */
+    }
+
+    /**
+     * Update the resource entity by fetching from the database the users who marked it as a
+     * favorite.
+     *
+     * @param resource
+     */
+    default void fetchFavoritedBy(Resource resource) {
+        /* no-op */
+    }
 }

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
@@ -130,16 +130,6 @@ public interface UserService {
     Collection<User> getByGroup(UserGroup group);
 
     /**
-     * Update the user entity by fetching its security rules and group security rules from the
-     * database.
-     *
-     * @param user
-     */
-    default void fetchSecurityRules(User user) {
-        /* no-op */
-    }
-
-    /**
      * Update the user entity by fetching its favorites resources from the database.
      *
      * @param user

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
@@ -90,8 +90,6 @@ public class ResourceServiceImpl implements ResourceService {
 
     private SecurityDAO securityDAO;
 
-    private UserService userService;
-
     private ResourcePermissionService resourcePermissionService;
 
     public void setUserDAO(UserDAO userDAO) {
@@ -120,10 +118,6 @@ public class ResourceServiceImpl implements ResourceService {
 
     public void setResourceDAO(ResourceDAO resourceDAO) {
         this.resourceDAO = resourceDAO;
-    }
-
-    public void setUserService(UserService userService) {
-        this.userService = userService;
     }
 
     public void setResourcePermissionService(ResourcePermissionService resourcePermissionService) {

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
@@ -472,21 +472,6 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void fetchSecurityRules(User user) {
-        if (user == null || user.getId() == null) {
-            return;
-        }
-
-        user.getGroups()
-                .forEach(
-                        userGroup ->
-                                userGroup.setSecurity(
-                                        securityDAO.findUserGroupSecurityRules(userGroup.getId())));
-
-        user.setSecurity(securityDAO.findUserSecurityRules(user.getId()));
-    }
-
-    @Override
     public void fetchFavorites(User user) {
         if (user == null || user.getId() == null) {
             return;

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
@@ -22,7 +22,6 @@ package it.geosolutions.geostore.services;
 import com.googlecode.genericdao.search.Filter;
 import com.googlecode.genericdao.search.Search;
 import it.geosolutions.geostore.core.dao.ResourceDAO;
-import it.geosolutions.geostore.core.dao.SecurityDAO;
 import it.geosolutions.geostore.core.dao.UserAttributeDAO;
 import it.geosolutions.geostore.core.dao.UserDAO;
 import it.geosolutions.geostore.core.dao.UserGroupDAO;
@@ -59,8 +58,6 @@ public class UserServiceImpl implements UserService {
 
     private UserGroupDAO userGroupDAO;
 
-    private SecurityDAO securityDAO;
-
     private ResourceDAO resourceDAO;
 
     public void setUserDAO(UserDAO userDAO) {
@@ -73,10 +70,6 @@ public class UserServiceImpl implements UserService {
 
     public void setUserGroupDAO(UserGroupDAO userGroupDAO) {
         this.userGroupDAO = userGroupDAO;
-    }
-
-    public void setSecurityDAO(SecurityDAO securityDAO) {
-        this.securityDAO = securityDAO;
     }
 
     public void setResourceDAO(ResourceDAO resourceDAO) {


### PR DESCRIPTION
These changes aim to address the slowness reported on the MapStore main page loading in [issue #10794](https://github.com/geosolutions-it/MapStore2/issues/10794).

Previously, the logic for checking resource permissions was inverted, retrieving permissions from user and user group security rules. This approach led to ORM N+1 issues, significantly impacting performance.

The logic has now been restored to check permissions from the resources themselves, reducing database accesses to a minimum.