### PR TITLE
Fixed missing favorites fetch in full resource loading.

### DIFF
--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
@@ -727,9 +727,10 @@ public class ResourceServiceImpl implements ResourceService {
             throws BadRequestServiceEx, InternalErrorServiceEx {
 
         Search searchCriteria = SearchConverter.convert(resourceSearchParameters.getFilter());
-        searchCriteria.addFetch("security");
         searchCriteria.setDistinct(true);
+        searchCriteria.addFetch("security");
         searchCriteria.addFetch("data");
+        searchCriteria.addFetch("favoritedBy");
 
         securityDAO.addReadSecurityConstraints(
                 searchCriteria, resourceSearchParameters.getAuthUser());


### PR DESCRIPTION
Having added a new `LAZY` fetched association to the resource for favorites, this was not added in the fetch for the full resource loading from the DB, causing an `no Session` error in hibernate.

These changes fixes https://github.com/geosolutions-it/MapStore2/issues/10801.