### PR TITLE
[FIXES #409] Add Username Remapping & Uppercase Group Names Support in OAuth2 Authentication Filter

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -30,6 +30,7 @@ package it.geosolutions.geostore.services.rest.security.oauth2;
 
 import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
 import java.util.Collections;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpEntity;
@@ -73,8 +74,10 @@ public class OAuth2Configuration extends IdPConfiguration {
     private String discoveryUrl;
     private boolean enableRedirectEntryPoint = false;
     private String principalKey;
+    private String uniqueUsername;
     private String rolesClaim;
     private String groupsClaim;
+    private boolean groupNamesUppercase = false;
 
     // Retry and backoff configurations
     private long initialBackoffDelay = 1000; // Default: 1 second
@@ -522,6 +525,25 @@ public class OAuth2Configuration extends IdPConfiguration {
     }
 
     /**
+     * Whether we would like to use another claim to extract the actual "username" from the token
+     * claims.
+     *
+     * @return the unique username claim key.
+     */
+    public String getUniqueUsername() {
+        return uniqueUsername;
+    }
+
+    /**
+     * Set the unique username claim key.
+     *
+     * @param uniqueUsername the unique username claim key.
+     */
+    public void setUniqueUsername(String uniqueUsername) {
+        this.uniqueUsername = uniqueUsername;
+    }
+
+    /**
      * The roles claim name.
      *
      * @return the roles claim name.
@@ -551,6 +573,125 @@ public class OAuth2Configuration extends IdPConfiguration {
      */
     public void setGroupsClaim(String groupsClaim) {
         this.groupsClaim = groupsClaim;
+    }
+
+    public boolean isGroupNamesUppercase() {
+        return groupNamesUppercase;
+    }
+
+    public void setGroupNamesUppercase(boolean groupNamesUppercase) {
+        this.groupNamesUppercase = groupNamesUppercase;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OAuth2Configuration)) return false;
+        OAuth2Configuration that = (OAuth2Configuration) o;
+        return isGlobalLogoutEnabled() == that.isGlobalLogoutEnabled()
+                && isEnableRedirectEntryPoint() == that.isEnableRedirectEntryPoint()
+                && isGroupNamesUppercase() == that.isGroupNamesUppercase()
+                && getInitialBackoffDelay() == that.getInitialBackoffDelay()
+                && Double.compare(getBackoffMultiplier(), that.getBackoffMultiplier()) == 0
+                && getMaxRetries() == that.getMaxRetries()
+                && Objects.equals(getClientId(), that.getClientId())
+                && Objects.equals(getClientSecret(), that.getClientSecret())
+                && Objects.equals(getAccessTokenUri(), that.getAccessTokenUri())
+                && Objects.equals(getAuthorizationUri(), that.getAuthorizationUri())
+                && Objects.equals(getCheckTokenEndpointUrl(), that.getCheckTokenEndpointUrl())
+                && Objects.equals(getLogoutUri(), that.getLogoutUri())
+                && Objects.equals(getRevokeEndpoint(), that.getRevokeEndpoint())
+                && Objects.equals(getScopes(), that.getScopes())
+                && Objects.equals(getIdTokenUri(), that.getIdTokenUri())
+                && Objects.equals(getDiscoveryUrl(), that.getDiscoveryUrl())
+                && Objects.equals(getPrincipalKey(), that.getPrincipalKey())
+                && Objects.equals(getUniqueUsername(), that.getUniqueUsername())
+                && Objects.equals(getRolesClaim(), that.getRolesClaim())
+                && Objects.equals(getGroupsClaim(), that.getGroupsClaim());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                getClientId(),
+                getClientSecret(),
+                getAccessTokenUri(),
+                getAuthorizationUri(),
+                getCheckTokenEndpointUrl(),
+                getLogoutUri(),
+                getRevokeEndpoint(),
+                isGlobalLogoutEnabled(),
+                getScopes(),
+                getIdTokenUri(),
+                getDiscoveryUrl(),
+                isEnableRedirectEntryPoint(),
+                getPrincipalKey(),
+                getUniqueUsername(),
+                getRolesClaim(),
+                getGroupsClaim(),
+                isGroupNamesUppercase(),
+                getInitialBackoffDelay(),
+                getBackoffMultiplier(),
+                getMaxRetries());
+    }
+
+    @Override
+    public String toString() {
+        return "OAuth2Configuration{"
+                + "clientId='"
+                + clientId
+                + '\''
+                + ", clientSecret='"
+                + clientSecret
+                + '\''
+                + ", accessTokenUri='"
+                + accessTokenUri
+                + '\''
+                + ", authorizationUri='"
+                + authorizationUri
+                + '\''
+                + ", checkTokenEndpointUrl='"
+                + checkTokenEndpointUrl
+                + '\''
+                + ", logoutUri='"
+                + logoutUri
+                + '\''
+                + ", revokeEndpoint='"
+                + revokeEndpoint
+                + '\''
+                + ", globalLogoutEnabled="
+                + globalLogoutEnabled
+                + ", scopes='"
+                + scopes
+                + '\''
+                + ", idTokenUri='"
+                + idTokenUri
+                + '\''
+                + ", discoveryUrl='"
+                + discoveryUrl
+                + '\''
+                + ", enableRedirectEntryPoint="
+                + enableRedirectEntryPoint
+                + ", principalKey='"
+                + principalKey
+                + '\''
+                + ", uniqueUsername='"
+                + uniqueUsername
+                + '\''
+                + ", rolesClaim='"
+                + rolesClaim
+                + '\''
+                + ", groupsClaim='"
+                + groupsClaim
+                + '\''
+                + ", groupNamesUppercase="
+                + groupNamesUppercase
+                + ", initialBackoffDelay="
+                + initialBackoffDelay
+                + ", backoffMultiplier="
+                + backoffMultiplier
+                + ", maxRetries="
+                + maxRetries
+                + '}';
     }
 
     /** Represents a configurable HTTP endpoint with method and request entity. */

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/GeoStoreAuthenticationFilterTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/rest/security/GeoStoreAuthenticationFilterTest.java
@@ -23,10 +23,17 @@ import static org.junit.Assert.*;
 
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.UserGroupAttribute;
 import it.geosolutions.geostore.core.model.enums.Role;
 import it.geosolutions.geostore.core.security.MapExpressionUserMapper;
+import it.geosolutions.geostore.services.dto.ShortResource;
+import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
 import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
 import it.geosolutions.geostore.services.rest.security.GeoStoreRequestHeadersAuthenticationFilter;
+import it.geosolutions.geostore.services.rest.security.oauth2.JWTHelper;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2GeoStoreAuthenticationFilter;
 import it.geosolutions.geostore.services.rest.utils.MockedUserService;
 import java.io.IOException;
 import java.util.*;
@@ -41,23 +48,33 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
+/**
+ * Test class for GeoStore authentication filters.
+ *
+ * <p>This class contains tests for the header‐based authentication filter and tests for the OAuth2
+ * filter, including verifying the new configuration option to remap the username based on idToken
+ * claims and the new constraint enforcing uppercase group names with users being added to groups.
+ */
 public class GeoStoreAuthenticationFilterTest {
 
     private static final String USERNAME_HEADER = "username";
     private static final String SAMPLE_USER = "myuser";
+
     private MockedUserService userService;
-    private GeoStoreRequestHeadersAuthenticationFilter filter;
+    private GeoStoreRequestHeadersAuthenticationFilter headerFilter;
     private HttpServletRequest req;
     private HttpServletResponse resp;
 
     @Before
     public void setUp() {
+        // Setup for the header-based filter tests.
         userService = new MockedUserService();
-        filter = new GeoStoreRequestHeadersAuthenticationFilter();
-        filter.setUserNameHeader(USERNAME_HEADER);
-        filter.setUserService(userService);
-        filter.setAutoCreateUser(true);
+        headerFilter = new GeoStoreRequestHeadersAuthenticationFilter();
+        headerFilter.setUserNameHeader(USERNAME_HEADER);
+        headerFilter.setUserService(userService);
+        headerFilter.setAutoCreateUser(true);
 
         req = Mockito.mock(HttpServletRequest.class);
         resp = Mockito.mock(HttpServletResponse.class);
@@ -65,7 +82,7 @@ public class GeoStoreAuthenticationFilterTest {
         Mockito.when(req.getHeader(USERNAME_HEADER)).thenReturn(SAMPLE_USER);
         Mockito.when(req.getHeader("header1")).thenReturn("value1");
         Mockito.when(req.getHeaderNames())
-                .thenReturn(new Vector(Arrays.asList(USERNAME_HEADER, "header1")).elements());
+                .thenReturn(new Vector<>(Arrays.asList(USERNAME_HEADER, "header1")).elements());
     }
 
     @After
@@ -76,69 +93,346 @@ public class GeoStoreAuthenticationFilterTest {
     @Test
     public void testAutoCreate() throws IOException, ServletException, NotFoundServiceEx {
 
-        filter.doFilter(
+        headerFilter.doFilter(
                 req,
                 resp,
                 new FilterChain() {
-
                     @Override
                     public void doFilter(ServletRequest arg0, ServletResponse arg1)
-                            throws IOException, ServletException {}
+                            throws IOException, ServletException {
+                        // No-op chain for testing.
+                    }
                 });
 
         User user = userService.get(SAMPLE_USER);
         checkUser(user);
-        assertTrue(user.isEnabled());
+        assertTrue("User should be enabled", user.isEnabled());
     }
 
     @Test
     public void testAutoCreateDisabled() throws IOException, ServletException, NotFoundServiceEx {
 
-        filter.setEnableAutoCreatedUsers(false);
-        filter.doFilter(
+        headerFilter.setEnableAutoCreatedUsers(false);
+        headerFilter.doFilter(
                 req,
                 resp,
                 new FilterChain() {
-
                     @Override
                     public void doFilter(ServletRequest arg0, ServletResponse arg1)
-                            throws IOException, ServletException {}
+                            throws IOException, ServletException {
+                        // No-op chain for testing.
+                    }
                 });
 
         User user = userService.get(SAMPLE_USER);
         checkUser(user);
-        assertFalse(user.isEnabled());
+        assertFalse("User should be disabled", user.isEnabled());
     }
 
     @Test
     public void testAutoCreateAttributesMapping()
             throws IOException, ServletException, NotFoundServiceEx {
 
-        Map<String, String> attributeMappings = new HashMap<String, String>();
-        attributeMappings.put("attr1", "header1");
-        filter.setUserMapper(new MapExpressionUserMapper(attributeMappings));
+        // Map header "header1" to user attribute "attr1".
+        headerFilter.setUserMapper(
+                new MapExpressionUserMapper(Collections.singletonMap("attr1", "header1")));
 
-        filter.doFilter(
+        headerFilter.doFilter(
                 req,
                 resp,
                 new FilterChain() {
-
                     @Override
                     public void doFilter(ServletRequest arg0, ServletResponse arg1)
-                            throws IOException, ServletException {}
+                            throws IOException, ServletException {
+                        // No-op chain for testing.
+                    }
                 });
 
         User user = userService.get(SAMPLE_USER);
         checkUser(user);
-        List<UserAttribute> attributes = user.getAttribute();
-        assertEquals(1, attributes.size());
-        assertEquals("attr1", attributes.get(0).getName());
-        assertEquals("value1", attributes.get(0).getValue());
+        assertNotNull("Attributes should not be null", user.getAttribute());
+        assertEquals("Should have one attribute", 1, user.getAttribute().size());
+        UserAttribute attr = user.getAttribute().get(0);
+        assertEquals("Attribute name should be 'attr1'", "attr1", attr.getName());
+        assertEquals("Attribute value should be 'value1'", "value1", attr.getValue());
+    }
+
+    /**
+     * Test that verifies the new configuration option for username remapping.
+     *
+     * <p>This test creates a dummy OAuth2 filter that overrides the idToken decoding to return a
+     * dummy JWTHelper. The dummy helper returns the original username for the "principal" claim and
+     * a remapped username for the "unique" claim. The filter then should create a user with the
+     * remapped name.
+     */
+    @Test
+    public void testUsernameRemapping() throws Exception {
+        final String ORIGINAL_USERNAME = "myuser";
+        final String REMAPPED_USERNAME = "remappedUser";
+
+        // Create a dummy OAuth2Configuration with the remapping properties.
+        OAuth2Configuration config = new OAuth2Configuration();
+        config.setPrincipalKey("principal");
+        config.setUniqueUsername("unique");
+        config.setBeanName("testBean");
+        config.setAutoCreateUser(true);
+
+        // Create an instance of the OAuth2 filter using an anonymous subclass.
+        OAuth2GeoStoreAuthenticationFilter oauth2Filter =
+                new OAuth2GeoStoreAuthenticationFilter(
+                        /* tokenServices */ null,
+                        /* restTemplate */ null,
+                        config,
+                        /* cache */ null) {
+
+                    @Override
+                    protected JWTHelper decodeAndValidateIdToken(String idToken) {
+                        return new JWTHelper(idToken) {
+                            @Override
+                            public <T> T getClaim(String claimName, Class<T> clazz) {
+                                if ("principal".equals(claimName)) {
+                                    return (T) ORIGINAL_USERNAME;
+                                }
+                                if ("unique".equals(claimName)) {
+                                    return (T) REMAPPED_USERNAME;
+                                }
+                                return null;
+                            }
+                        };
+                    }
+
+                    @Override
+                    protected User retrieveUserWithAuthorities(
+                            String username,
+                            HttpServletRequest request,
+                            HttpServletResponse response) {
+                        User user = new User();
+                        user.setName(username);
+                        user.setRole(Role.USER);
+                        user.setEnabled(true);
+                        user.setAttribute(Collections.emptyList());
+                        user.setGroups(new HashSet<>());
+                        return user;
+                    }
+
+                    @Override
+                    protected void configureRestTemplate() {
+                        // No-op for testing.
+                    }
+                };
+
+        HttpServletRequest req2 = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resp2 = Mockito.mock(HttpServletResponse.class);
+
+        PreAuthenticatedAuthenticationToken authToken =
+                oauth2Filter.createPreAuthentication(ORIGINAL_USERNAME, req2, resp2);
+        assertNotNull("Authentication token should not be null", authToken);
+
+        User user = (User) authToken.getPrincipal();
+        assertNotNull("User should not be null", user);
+        assertEquals(
+                "Username should be remapped to the unique claim value",
+                REMAPPED_USERNAME,
+                user.getName());
+    }
+
+    /**
+     * Test that verifies group names are forced to uppercase and that the user is assigned to the
+     * group.
+     *
+     * <p>This test creates a dummy OAuth2 filter that returns a dummy JWTHelper which, when asked
+     * for the groups claim, returns a list with a single group name ("groupA"). With the
+     * configuration set to force uppercase group names, the filter will use "GROUPA" for
+     * lookup/insertion. We supply a dummy UserGroupService that holds groups in memory. The test
+     * then verifies that the user gets assigned to the uppercase group.
+     */
+    @Test
+    public void testGroupNamesUppercaseAndUserGroupAssignment() throws Exception {
+        final String GROUP_FROM_TOKEN = "groupA";
+        final String EXPECTED_GROUP = "GROUPA";
+
+        // Create a dummy OAuth2Configuration with groupsClaim and groupNamesUppercase enabled.
+        OAuth2Configuration config = new OAuth2Configuration();
+        config.setGroupsClaim("groups");
+        config.setBeanName("testBean");
+        config.setAutoCreateUser(true);
+        config.setGroupNamesUppercase(true);
+
+        // Create a dummy UserGroupService that holds groups in memory.
+        DummyUserGroupService dummyGroupService = new DummyUserGroupService();
+
+        // Create an instance of the OAuth2 filter using an anonymous subclass.
+        OAuth2GeoStoreAuthenticationFilter oauth2Filter =
+                new OAuth2GeoStoreAuthenticationFilter(
+                        /* tokenServices */ null,
+                        /* restTemplate */ null,
+                        config,
+                        /* cache */ null) {
+
+                    @Override
+                    protected JWTHelper decodeAndValidateIdToken(String idToken) {
+                        return new JWTHelper(idToken) {
+                            @Override
+                            public <T> List<T> getClaimAsList(String claimName, Class<T> clazz) {
+                                if ("groups".equals(claimName)) {
+                                    // Return a list containing the group name from the token.
+                                    return (List<T>) Collections.singletonList(GROUP_FROM_TOKEN);
+                                }
+                                return Collections.emptyList();
+                            }
+                        };
+                    }
+
+                    @Override
+                    protected User retrieveUserWithAuthorities(
+                            String username,
+                            HttpServletRequest request,
+                            HttpServletResponse response) {
+                        User user = new User();
+                        user.setName(username);
+                        user.setRole(Role.USER);
+                        user.setEnabled(true);
+                        user.setAttribute(Collections.emptyList());
+                        user.setGroups(new HashSet<>());
+                        return user;
+                    }
+
+                    @Override
+                    protected void configureRestTemplate() {
+                        // No-op for testing.
+                    }
+                };
+
+        // Inject the dummy group service.
+        oauth2Filter.setUserGroupService(dummyGroupService);
+
+        // Create dummy HTTP request/response.
+        HttpServletRequest req2 = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resp2 = Mockito.mock(HttpServletResponse.class);
+
+        // Call createPreAuthentication (which will invoke addAuthoritiesFromToken).
+        PreAuthenticatedAuthenticationToken authToken =
+                oauth2Filter.createPreAuthentication("anyuser", req2, resp2);
+        assertNotNull("Authentication token should not be null", authToken);
+
+        User user = (User) authToken.getPrincipal();
+        assertNotNull("User should not be null", user);
+
+        // Verify that the user has been assigned to the group with uppercase name.
+        boolean found =
+                user.getGroups().stream()
+                        .anyMatch(group -> EXPECTED_GROUP.equals(group.getGroupName()));
+        assertTrue("User should be assigned to group " + EXPECTED_GROUP, found);
+
+        // Also verify that the dummy service holds the group under the uppercase key.
+        UserGroup groupFromService = dummyGroupService.get(EXPECTED_GROUP);
+        assertNotNull(
+                "Dummy group service should contain group " + EXPECTED_GROUP, groupFromService);
     }
 
     private void checkUser(User user) {
-        assertNotNull(user);
-        assertEquals(Role.USER, user.getRole());
-        assertTrue(user.getGroups().isEmpty());
+        assertNotNull("User should not be null", user);
+        assertEquals("User role should be USER", Role.USER, user.getRole());
+        assertTrue("User groups should be empty", user.getGroups().isEmpty());
+    }
+
+    /** Dummy implementation of UserGroupService for testing purposes. */
+    private static class DummyUserGroupService
+            implements it.geosolutions.geostore.services.UserGroupService {
+        private final Map<String, UserGroup> groupsByName = new HashMap<>();
+        private final Map<Long, UserGroup> groupsById = new HashMap<>();
+        private long nextId = 1;
+
+        @Override
+        public UserGroup get(String groupName) {
+            return groupsByName.get(groupName);
+        }
+
+        @Override
+        public long getCount(String nameLike, boolean all) throws BadRequestServiceEx {
+            return 0;
+        }
+
+        @Override
+        public long getCount(User authUser, String nameLike, boolean all)
+                throws BadRequestServiceEx {
+            return 0;
+        }
+
+        @Override
+        public void updateAttributes(long id, List<UserGroupAttribute> attributes)
+                throws NotFoundServiceEx {}
+
+        @Override
+        public long update(UserGroup group) throws NotFoundServiceEx, BadRequestServiceEx {
+            return 0;
+        }
+
+        @Override
+        public Collection<UserGroup> findByAttribute(
+                String name, List<String> values, boolean ignoreCase) {
+            return List.of();
+        }
+
+        @Override
+        public UserGroup get(long id) {
+            return groupsById.get(id);
+        }
+
+        @Override
+        public List<ShortResource> updateSecurityRules(
+                Long groupId, List<Long> resourcesToSet, boolean canRead, boolean canWrite)
+                throws NotFoundServiceEx, BadRequestServiceEx {
+            return List.of();
+        }
+
+        @Override
+        public boolean insertSpecialUsersGroups() {
+            return false;
+        }
+
+        @Override
+        public boolean removeSpecialUsersGroups() {
+            return false;
+        }
+
+        @Override
+        public long insert(UserGroup group) throws BadRequestServiceEx {
+            group.setId(nextId);
+            groupsById.put(nextId, group);
+            groupsByName.put(group.getGroupName(), group);
+            return nextId++;
+        }
+
+        @Override
+        public boolean delete(long id) throws NotFoundServiceEx, BadRequestServiceEx {
+            return false;
+        }
+
+        @Override
+        public void assignUserGroup(long userId, long groupId) throws NotFoundServiceEx {
+            // For testing, we assume the assignment is always successful.
+        }
+
+        @Override
+        public void deassignUserGroup(long userId, long groupId) throws NotFoundServiceEx {}
+
+        @Override
+        public List<UserGroup> getAllAllowed(
+                User user, Integer page, Integer entries, String nameLike, boolean all)
+                throws BadRequestServiceEx {
+            return List.of();
+        }
+
+        @Override
+        public List<UserGroup> getAll(Integer page, Integer entries) throws BadRequestServiceEx {
+            return List.of();
+        }
+
+        @Override
+        public List<UserGroup> getAll(Integer page, Integer entries, String nameLike, boolean all)
+                throws BadRequestServiceEx {
+            return List.of();
+        }
     }
 }


### PR DESCRIPTION
References: https://github.com/geosolutions-it/geostore/issues/409

This pull request introduces two new features and some refactoring improvements in the OAuth2 authentication filter:

**New Features**

1. Username Remapping from idToken Claims:

    - The filter now decodes the `idToken` only once using a helper (`JWTHelper`).
    - If the configuration provides non-blank values for both `principalKey` and `uniqueUsername`, and the incoming username (from the principal claim) matches the expected value, it is remapped to the value found in the unique username claim.
    - This ensures that the system always works with a consistent unique identifier for user lookup and creation.

2. Enforce Uppercase Group Names:

    - A new configuration parameter `groupNamesUppercase` has been added.
    - When enabled, groups retrieved from token claims (via the groupsClaim configuration) are normalized to uppercase during lookup and creation.
    - This change avoids mismatches due to case sensitivity, ensuring that users are assigned to the correct groups regardless of the token’s letter case.

**Changes in Code and Tests**
1. Refactoring:
    The code has been refactored so that idToken decoding/validation is done only once, and the result is reused for username remapping.

2. Updated addAuthoritiesFromToken:
    This method now checks the configuration for groupNamesUppercase and uses uppercase for group lookup/insertion if enabled. Users are correctly assigned to these groups.

3. Unit Tests:
    - Existing tests for auto-creation and attribute mapping remain unchanged.
    - A new test (testUsernameRemapping()) validates that the incoming username is replaced by the unique claim value.
    - Another test (testGroupNamesUppercaseAndUserGroupAssignment()) verifies that groups are looked up/created in uppercase and that the user is correctly assigned to these groups.

**Documentation**
New configuration parameters have been introduced and should be documented in our developer guide or configuration reference:

* `principalKey`:
    The name of the claim in the idToken that represents the principal (original username).

* `uniqueUsername`:
    The name of the claim in the idToken that contains the unique username. If the incoming username matches the value from principalKey, it will be replaced with this unique username.

* `groupNamesUppercase`:
    A boolean flag that, when enabled, forces the filter to convert group names from token claims to uppercase before lookup or creation. This parameter helps maintain consistency in group names and prevents issues related to case sensitivity.

Please review the changes and tests, and let me know if further modifications are needed.