### PR TITLE
Fixed full resource serialization

### DIFF
--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Resource.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/Resource.java
@@ -272,6 +272,7 @@ public class Resource implements Serializable, CycleRecoverable {
         this.tags = tags;
     }
 
+    @XmlTransient
     public Set<User> getFavoritedBy() {
         return favoritedBy;
     }


### PR DESCRIPTION
Fetching the full resource object was causing serialization errors because of the lazy loading of the `favoritedBy` collection of `User` entities. The attributes of the user were therefore missing, throwing the exception reported in https://github.com/geosolutions-it/MapStore2/issues/10781#issuecomment-2681674492.

These changes fix the problem, avoiding returning the `favoritedBy` collection from the serialized resource.