### PR TITLE
[FIXES #426] Support for direct integration on security settings (#429)

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/SecurityDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/SecurityDAOImpl.java
@@ -157,7 +157,10 @@ public class SecurityDAOImpl extends BaseDAO<SecurityRule, Long> implements Secu
         }
 
         // User filtering based on user and groups
-        Filter userFiltering = Filter.equal("user.name", user.getName());
+        Filter userFiltering =
+                Filter.or(
+                        Filter.equal("username", user.getName()),
+                        Filter.equal("user.name", user.getName()));
 
         if (user.getGroups() != null && !user.getGroups().isEmpty()) {
             List<Long> groupsId = new ArrayList<>();
@@ -182,12 +185,16 @@ public class SecurityDAOImpl extends BaseDAO<SecurityRule, Long> implements Secu
         }
 
         // User filtering based on user and groups
-        Filter userFiltering = Filter.equal("user.name", user.getName());
+        Filter userFiltering =
+                Filter.or(
+                        Filter.equal("username", user.getName()),
+                        Filter.equal("user.name", user.getName()));
 
         // Combine owner and advertisedFilter using OR
         /* The user is the owner of the resource or the resource is advertised. */
         Filter advertisedFiltering =
                 Filter.or(
+                        Filter.equal("username", user.getName()),
                         Filter.equal("user.name", user.getName()),
                         Filter.equal("resource.advertised", true));
 
@@ -219,9 +226,13 @@ public class SecurityDAOImpl extends BaseDAO<SecurityRule, Long> implements Secu
         Search searchCriteria = new Search(SecurityRule.class);
 
         Filter securityFilter =
-                Filter.and(
-                        Filter.equal("resource.id", resourceId),
-                        Filter.equal("user.name", userName));
+                Filter.or(
+                        Filter.and(
+                                Filter.equal("resource.id", resourceId),
+                                Filter.equal("username", userName)),
+                        Filter.and(
+                                Filter.equal("resource.id", resourceId),
+                                Filter.equal("user.name", userName)));
         searchCriteria.addFilter(securityFilter);
         // now rules are not properly filtered.
         // so no user rules have to be removed externally (see RESTServiceImpl >


### PR DESCRIPTION
## 1. Summary of Changes

Enhanced Ownership Checks

Expanded resourceUserOwnership and resourceGroupOwnership predicates to also match on SecurityRule.username and SecurityRule.groupname when IDs differ.

New Test Coverage

Introduced ResourcePermissionServiceImplTest with two positive tests:

testCanReadByUsernameMatch

testCanReadByGroupnameMatch

## 2. Motivation
Prior to this change, a security rule only granted access if the user/group ID matched exactly. In cases where the rule was created with a legacy or external identifier (username or groupname) that didn’t map directly to the internal ID, valid principals were being wrongly denied. Supporting name-based matching closes this gap.

## 3. Behavioral Impact

Backward-compatible: ID-based matching remains unchanged; name-based is only an additional allowance.

Granularity: Exact matching on both identifiers still required for write operations, and canRead/canWrite flags continue to be enforced as before.

## 4. Testing

Two new unit tests validate the new name-based branches without altering any existing test surfaces.

No negative or edge-case tests were modified; existing coverage remains green.

## 5. Performance & Safety

The extra null-checks and string comparisons are negligible in typical security-rule list sizes (usually <10).

No change to external APIs or database schema.