### PR TITLE
Removed editor overwrite at resource permission update.

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/SecurityDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/SecurityDAOImpl.java
@@ -63,7 +63,7 @@ public class SecurityDAOImpl extends BaseDAO<SecurityRule, Long> implements Secu
         }
         for (SecurityRule rule : entities) {
             validateGroup(rule);
-            validateCreatorAndEditor(rule);
+            updateResourceCreatorIfEmpty(rule);
         }
         super.persist(entities);
     }
@@ -78,17 +78,12 @@ public class SecurityDAOImpl extends BaseDAO<SecurityRule, Long> implements Secu
         }
     }
 
-    private void validateCreatorAndEditor(SecurityRule rule) {
+    private void updateResourceCreatorIfEmpty(SecurityRule rule) {
         if (rule.getResource() != null && (rule.getUser() != null || rule.getUsername() != null)) {
             Resource resource = rule.getResource();
             boolean updated = false;
             if (resource.getCreator() == null) {
                 resource.setCreator(
-                        rule.getUser() != null ? rule.getUser().getName() : rule.getUsername());
-                updated = true;
-            }
-            if (rule.getUser() != null || !rule.getUsername().isEmpty()) {
-                resource.setEditor(
                         rule.getUser() != null ? rule.getUser().getName() : rule.getUsername());
                 updated = true;
             }

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/SecurityDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/SecurityDAOTest.java
@@ -228,10 +228,8 @@ public class SecurityDAOTest extends BaseDAOTest {
 
             Resource loaded = resourceDAO.find(resourceId);
             assertNotNull(loaded.getCreator());
-            assertNotNull(loaded.getEditor());
             assertEquals("testuser", loaded.getCreator());
-            assertEquals("testuser", loaded.getEditor());
-
+            assertNull(loaded.getEditor());
             securityDAO.removeById(securityId);
         }
 
@@ -262,9 +260,8 @@ public class SecurityDAOTest extends BaseDAOTest {
 
             loaded = resourceDAO.find(resourceId);
             assertNotNull(loaded.getCreator());
-            assertNotNull(loaded.getEditor());
             assertEquals("testuser", loaded.getCreator());
-            assertEquals(testUser.getName(), loaded.getEditor());
+            assertNull(loaded.getEditor());
 
             securityDAO.removeById(securityId);
         }

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
@@ -300,7 +300,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
             ShortResource resource = restExtJsService.getExtResource(sc, r0Id, false, false, false);
             assertEquals(RES_NAME, resource.getName());
             assertEquals("u0", resource.getCreator());
-            assertEquals("u0", resource.getEditor());
+            assertNull(resource.getEditor());
         }
 
         {
@@ -1053,9 +1053,9 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
         {
             FieldFilter ltDateFilter =
                     new FieldFilter(
-                            BaseField.LASTUPDATE,
+                            BaseField.CREATION,
                             new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
-                                    .format(resourceB.getLastUpdate()),
+                                    .format(resourceB.getCreation()),
                             SearchOperator.LESS_THAN);
 
             ExtResourceList response =

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -262,27 +262,19 @@
 
             <!-- Run the application using "mvn jetty:run" -->
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>maven-jetty-plugin</artifactId>
-                <version>6.1.26</version>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>9.4.57.v20241219</version>
                 <configuration>
-                    <!-- <webAppSourceDirectory>${basedir}/war</webAppSourceDirectory> -->
-                    <webAppConfig>
+                    <webApp>
                         <contextPath>/geostore</contextPath>
-                    </webAppConfig>
-                    <connectors>
-                        <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-                            <port>9191</port>
-                            <maxIdleTime>60000</maxIdleTime>
-                        </connector>
-                    </connectors>
-                    <reload>manual</reload>
+                    </webApp>
+                    <httpConnector>
+                        <port>9191</port>
+                    </httpConnector>
                 </configuration>
             </plugin>
-
         </plugins>
-
     </build>
-
 
 </project>

--- a/src/web/app/src/main/java/it/geosolutions/geostore/init/GeoStoreInit.java
+++ b/src/web/app/src/main/java/it/geosolutions/geostore/init/GeoStoreInit.java
@@ -212,6 +212,7 @@ public class GeoStoreInit implements InitializingBean {
 
         PwEncoder.setEncoder(this.passwordEncoder);
     }
+
     private static JAXBContext getUserContext() {
 
         List<Class> allClasses = GeoStoreJAXBContext.getGeoStoreClasses();


### PR DESCRIPTION
These changes aim to address the issue reported in https://github.com/geosolutions-it/MapStore2/issues/11098.

Previously, when permission were updated for a resource, the user of the permission was erroneously set as the `editor` of the resource, creating inconsistencies at the frontend.
This behavior was not expected, so it has been removed.