### PR TITLE
Align geostore dependencies with the MapStore ones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,13 +89,14 @@
         <jaxws-version>2.3.1</jaxws-version>
 
         <!-- Logging & commons (aligned) -->
-        <log4j-version>2.19.0</log4j-version>
+        <log4j.version>2.19.0</log4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <commons-logging-version>1.2</commons-logging-version>
-        <commons-lang-version>2.3</commons-lang-version>
+        <commons-lang-version>3.17.0</commons-lang-version>
         <commons-collections-version>3.2.2</commons-collections-version>
         <commons-beanutils-version>1.9.4</commons-beanutils-version>
         <commons-dbcp-version>1.2.2</commons-dbcp-version>
-        <commons-codec-version>1.4</commons-codec-version>
+        <commons-codec-version>1.16.0</commons-codec-version>
 
         <!-- JAXB/JPA/Hibernate (kept as GeoStore had) -->
         <geronimo-specs-version>1.1</geronimo-specs-version>

--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>it.geosolutions.geostore</groupId>
         <artifactId>geostore-root</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>geostore-cli</artifactId>
@@ -56,8 +56,8 @@
             <artifactId>picocli</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>

--- a/src/cli/src/main/java/it/geosolutions/geostore/cli/H2ToPgSQLExporter.java
+++ b/src/cli/src/main/java/it/geosolutions/geostore/cli/H2ToPgSQLExporter.java
@@ -45,7 +45,7 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.Script;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;

--- a/src/core/persistence/pom.xml
+++ b/src/core/persistence/pom.xml
@@ -51,8 +51,8 @@
         <!-- APACHE COMMONS -->
         <!-- ================================================================-->
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/LdapBaseDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/LdapBaseDAOImpl.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.naming.directory.DirContext;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;

--- a/src/core/security/pom.xml
+++ b/src/core/security/pom.xml
@@ -37,8 +37,8 @@
         <!-- APACHE COMMONS -->
         <!-- ================================================================-->
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/src/core/services-api/pom.xml
+++ b/src/core/services-api/pom.xml
@@ -76,8 +76,8 @@
        	<!-- APACHE COMMONS -->
         <!-- ================================================================-->
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/src/core/services-impl/pom.xml
+++ b/src/core/services-impl/pom.xml
@@ -57,8 +57,8 @@
 	    <!-- =========================================================== -->
         <!-- APACHE COMMONS -->
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
@@ -171,30 +171,39 @@
     </build>
 
     <profiles>
+        <!-- coverage with JaCoCo instead of Cobertura -->
         <profile>
-            <id>cob</id>
+            <id>coverage</id>
             <build>
                 <plugins>
 
-                    <!-- Instrument classes -->
+                    <!-- ❶ Attach the JaCoCo agent before tests -->
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>${cobertura-maven-plugin.version}</version>
-                        <configuration>
-                            <instrumentation>
-                            </instrumentation>
-                        </configuration>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.13</version>
                         <executions>
+
+                            <!-- instruments classes: equivalent to Cobertura’s “instrument” goal -->
                             <execution>
-                                <id>instrument_ws_impl</id>
-                                <phase>process-classes</phase>
+                                <id>prepare-agent</id>
                                 <goals>
-                                    <goal>instrument</goal>
+                                    <goal>prepare-agent</goal>
                                 </goals>
                             </execution>
+
+                            <!-- generates HTML + XML in target/site/jacoco -->
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+
                         </executions>
                     </plugin>
+
                 </plugins>
             </build>
         </profile>

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserGroupServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserGroupServiceImpl.java
@@ -43,7 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
@@ -1,7 +1,7 @@
 package it.geosolutions.geostore.services.rest.security;
 
 import it.geosolutions.geostore.core.model.enums.Role;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.BeanNameAware;
 
 /**

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/keycloak/KeyCloakConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/keycloak/KeyCloakConfiguration.java
@@ -30,7 +30,7 @@ package it.geosolutions.geostore.services.rest.security.keycloak;
 import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.keycloak.adapters.KeycloakDeploymentBuilder;
 import org.keycloak.enums.TokenStore;
 import org.keycloak.representations.adapters.config.AdapterConfig;

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -52,7 +52,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -208,23 +208,37 @@
             <!-- =========================================================== -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${log4j-version}</version>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
+            <!-- Logging -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>${log4j-version}</version>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <!-- Override SLF4J to your single, newest version -->
+            <!-- 3) Force your single SLF4J -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${log4j-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-1.2-api</artifactId>
-                <version>${log4j-version}</version>
+                <version>${log4j.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- =========================================================== -->
@@ -239,8 +253,8 @@
             <!--     APACHE COMMONS                                          -->
             <!-- =========================================================== -->
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang-version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
- Bumps commons-lang-version to version 3.17.0 in order to be aligned with the MapStore ones
- Bumps commons-codec-version to version 1.16.0 since the 1.4.0 are very old; MapStore does not use those libraries
- SL4J: Adding SLF4J jars does not replace Log4j 2 – it just puts a lightweight, standard façade in front of it and this is what MapStore actually does already; like this geostore is more aligned with MapStore
- Cobertura does not work anymore with Java 8; it has been replaces with JaCoCo which is Java 11+ compatible