### PR TITLE
[Backport 2.3.x] Making OAuth2GeoStoreAuthenticationFilter resilient to possible group name duplication

### DIFF
--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/UserGroup.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/UserGroup.java
@@ -196,71 +196,19 @@ public class UserGroup implements Serializable {
         return builder.toString();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = (prime * result) + ((groupName == null) ? 0 : groupName.hashCode());
-        result = (prime * result) + ((id == null) ? 0 : id.hashCode());
-        result = (prime * result) + ((security == null) ? 0 : security.hashCode());
-        result = (prime * result) + ((attributes == null) ? 0 : attributes.hashCode());
-
-        return result;
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
         UserGroup other = (UserGroup) obj;
-        if (groupName == null) {
-            if (other.groupName != null) {
-                return false;
-            }
-        } else if (!groupName.equals(other.groupName)) {
-            return false;
-        }
-        if (id == null) {
-            if (other.id != null) {
-                return false;
-            }
-        } else if (!id.equals(other.id)) {
-            return false;
-        }
-        if (security == null) {
-            if (other.security != null) {
-                return false;
-            }
-        } else if (!security.equals(other.security)) {
-            return false;
-        }
+        if (id != null && other.id != null) return id.equals(other.id);
+        // fallback if id is null (unsaved entities)
+        return groupName != null && groupName.equals(other.groupName);
+    }
 
-        if (attributes == null) {
-            if (other.attributes != null) {
-                return false;
-            }
-        } else if (!attributes.equals(other.attributes)) {
-            return false;
-        }
-
-        return true;
+    @Override
+    public int hashCode() {
+        if (id != null) return id.hashCode();
+        return groupName != null ? groupName.hashCode() : 0;
     }
 }

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
@@ -17,6 +17,7 @@
 
 package it.geosolutions.geostore.services.rest.impl;
 
+import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -447,7 +448,9 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
         createCategory(CAT0_NAME);
 
         restCreateResource(RES_ATTRIBUTE_A, RES_ATTRIBUTE_A, CAT0_NAME, u0, true);
+        sleep(10);
         restCreateResource(RES_ATTRIBUTE_B, RES_ATTRIBUTE_B, CAT0_NAME, u0, true);
+        sleep(10);
         restCreateResource(RES_ATTRIBUTE_C, RES_ATTRIBUTE_C, CAT0_NAME, u0, true);
 
         {
@@ -1041,12 +1044,11 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
         createCategory(CAT0_NAME);
 
         long resourceAId = restCreateResource("name_A", "", CAT0_NAME, u0, true);
+        sleep(1000);
         long resourceBId = restCreateResource("name_B", "", CAT0_NAME, u0, true);
 
         Resource resourceA = resourceService.get(resourceAId);
-
         Resource resourceB = resourceService.get(resourceBId);
-        Thread.sleep(1000);
         resourceB.setDescription("posticipated");
         resourceService.update(resourceB);
 


### PR DESCRIPTION
This small patch ensure the OAuth2 service sanitize the user group names avoiding a DB constraint error.