### PR TITLE
Added `canCopy` attribute to ShortResource representation.

### DIFF
--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/ShortResource.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/ShortResource.java
@@ -1,7 +1,7 @@
 /*
  * ====================================================================
  *
- * Copyright (C) 2007 - 2016 GeoSolutions S.A.S.
+ * Copyright (C) 2007 - 2025 GeoSolutions S.A.S.
  * http://www.geo-solutions.it
  *
  * GPLv3 + Classpath exception
@@ -57,6 +57,8 @@ public class ShortResource implements Serializable {
     private boolean canEdit = false;
 
     private boolean canDelete = false;
+
+    private boolean canCopy = false;
 
     private String creator;
 
@@ -148,6 +150,14 @@ public class ShortResource implements Serializable {
         this.canDelete = canDelete;
     }
 
+    public boolean isCanCopy() {
+        return canCopy;
+    }
+
+    public void setCanCopy(boolean canCopy) {
+        this.canCopy = canCopy;
+    }
+
     /** @return */
     public String getCreator() {
         return creator;
@@ -199,6 +209,8 @@ public class ShortResource implements Serializable {
         if (canEdit) builder.append("canEdit=").append(true).append(", ");
 
         if (canDelete) builder.append("canDelete=").append(true).append(", ");
+
+        if (canCopy) builder.append("canCopy=").append(true).append(", ");
 
         if (creator != null) builder.append("creator=").append(creator).append(", ");
 

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourceServiceImpl.java
@@ -729,6 +729,7 @@ public class ResourceServiceImpl implements ResourceService {
         if (user != null && resourcePermissionService.canResourceBeWrittenByUser(resource, user)) {
             shortResource.setCanEdit(true);
             shortResource.setCanDelete(true);
+            shortResource.setCanCopy(true);
         }
 
         return shortResource;

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserGroupServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserGroupServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007-2012 GeoSolutions S.A.S.
+ *  Copyright (C) 2007-2025 GeoSolutions S.A.S.
  *  http://www.geo-solutions.it
  *
  *  GPLv3 + Classpath exception
@@ -306,6 +306,7 @@ public class UserGroupServiceImpl implements UserGroupService {
                 // rule updated.
                 out.setCanDelete(canWrite);
                 out.setCanEdit(canWrite);
+                out.setCanCopy(canRead);
                 updated.add(out);
             } else {
                 // Update the existing rule
@@ -320,6 +321,7 @@ public class UserGroupServiceImpl implements UserGroupService {
                 // rule updated.
                 out.setCanDelete(canWrite);
                 out.setCanEdit(canWrite);
+                out.setCanCopy(canRead);
                 updated.add(out);
             }
         }

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserGroupServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserGroupServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007-2012 GeoSolutions S.A.S.
+ *  Copyright (C) 2007-2025 GeoSolutions S.A.S.
  *  http://www.geo-solutions.it
  *
  *  GPLv3 + Classpath exception
@@ -107,13 +107,13 @@ public class UserGroupServiceImplTest extends ServiceTestBase {
         u.setName("u1");
         u.setPassword("password");
         u.setRole(Role.USER);
-        Set<UserGroup> group = new HashSet<UserGroup>();
+        Set<UserGroup> group = new HashSet<>();
         group.add(ug1);
         u.setGroups(group);
         long uid = userService.insert(u);
 
         Resource r = new Resource();
-        List<Attribute> attributeList = new ArrayList<Attribute>();
+        List<Attribute> attributeList = new ArrayList<>();
         Attribute a1 = new Attribute();
         a1.setTextValue("a1");
         a1.setType(DataType.STRING);
@@ -129,13 +129,13 @@ public class UserGroupServiceImplTest extends ServiceTestBase {
         long id = resourceService.insert(r);
         r = resourceService.get(id);
 
-        List<Long> idList = new ArrayList<Long>();
+        List<Long> idList = new ArrayList<>();
         idList.add(id);
         List<Resource> resourcelist = resourceDAO.findResources(idList);
         List<SecurityRule> listSecurity = resourcelist.get(0).getSecurity();
         assertEquals(0, listSecurity.size()); // shouldn't be any rule...
 
-        List<Long> listR = new ArrayList<Long>();
+        List<Long> listR = new ArrayList<>();
         listR.add(r.getId());
 
         List<ShortResource> listsr =
@@ -143,8 +143,9 @@ public class UserGroupServiceImplTest extends ServiceTestBase {
         assertEquals(1, listsr.size());
         assertTrue("Expected TRUE", listsr.get(0).isCanDelete());
         assertTrue("Expected TRUE", listsr.get(0).isCanEdit());
+        assertTrue("Expected TRUE", listsr.get(0).isCanCopy());
 
-        idList = new ArrayList<Long>();
+        idList = new ArrayList<>();
         idList.add(id);
         resourcelist = resourceDAO.findResources(idList);
         listSecurity = resourcelist.get(0).getSecurity();
@@ -152,8 +153,9 @@ public class UserGroupServiceImplTest extends ServiceTestBase {
 
         listsr = userGroupService.updateSecurityRules(ug1.getId(), listR, false, false);
         assertEquals(1, listsr.size());
-        assertTrue("Expected FALSE", !listsr.get(0).isCanDelete());
-        assertTrue("Expected FALSE", !listsr.get(0).isCanEdit());
+        assertFalse("Expected FALSE", listsr.get(0).isCanDelete());
+        assertFalse("Expected FALSE", listsr.get(0).isCanEdit());
+        assertFalse("Expected FALSE", listsr.get(0).isCanCopy());
     }
 
     /**

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/model/ExtShortResource.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/model/ExtShortResource.java
@@ -1,3 +1,30 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
 package it.geosolutions.geostore.services.model;
 
 import it.geosolutions.geostore.services.dto.ShortResource;
@@ -29,6 +56,7 @@ public class ExtShortResource extends ShortResource {
         this.setLastUpdate(builder.shortResource.getLastUpdate());
         this.setCanEdit(builder.shortResource.isCanEdit());
         this.setCanDelete(builder.shortResource.isCanDelete());
+        this.setCanCopy(builder.shortResource.isCanCopy());
         this.setCreator(builder.shortResource.getCreator());
         this.setEditor(builder.shortResource.getEditor());
         this.setAdvertised(builder.shortResource.isAdvertised());

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
@@ -687,11 +687,14 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
         resourceService.fetchSecurityRules(resource);
         resourceService.fetchFavoritedBy(resource);
 
-        if (!resourcePermissionService.canResourceBeReadByUser(resource, user)) {
+        ShortResource shortResource = new ShortResource(resource);
+
+        if (resourcePermissionService.canResourceBeReadByUser(resource, user)) {
+            shortResource.setCanCopy(true);
+        } else {
             throw new ForbiddenErrorWebEx("Resource is protected");
         }
 
-        ShortResource shortResource = new ShortResource(resource);
         if (resourcePermissionService.canResourceBeWrittenByUser(resource, user)) {
             shortResource.setCanEdit(true);
             shortResource.setCanDelete(true);

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 GeoSolutions
+ * Copyright (C) 2016-2025 GeoSolutions
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1757,6 +1757,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                             adminSecurityContext, userOwnedResourceId, true, true, false);
             assertTrue(response.isCanEdit());
             assertTrue(response.isCanDelete());
+            assertTrue(response.isCanCopy());
             List<ShortAttribute> attributes = response.getAttributeList().getList();
             assertEquals(1, attributes.size());
             ShortAttribute attribute = attributes.get(0);
@@ -1779,6 +1780,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                             user0SecurityContext, userOwnedResourceId, true, true, false);
             assertTrue(response.isCanEdit());
             assertTrue(response.isCanDelete());
+            assertTrue(response.isCanCopy());
             List<ShortAttribute> attributes = response.getAttributeList().getList();
             assertEquals(1, attributes.size());
             ShortAttribute attribute = attributes.get(0);
@@ -1793,6 +1795,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                             user0SecurityContext, readOnlyResourceId, true, true, false);
             assertFalse(response.isCanEdit());
             assertFalse(response.isCanDelete());
+            assertTrue(response.isCanCopy());
             List<ShortAttribute> attributes = response.getAttributeList().getList();
             assertEquals(1, attributes.size());
             ShortAttribute attribute = attributes.get(0);
@@ -2027,6 +2030,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                             user0SecurityContext, userOwnedResourceId, true, true, false);
             assertTrue(response.isCanEdit());
             assertTrue(response.isCanDelete());
+            assertTrue(response.isCanCopy());
             List<RESTSecurityRule> securityRules = response.getSecurityRuleList().getList();
             assertEquals(1, securityRules.size());
             RESTSecurityRule securityRule = securityRules.get(0);
@@ -2041,6 +2045,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                             user0SecurityContext, readOnlyResourceId, true, true, false);
             assertFalse(response.isCanEdit());
             assertFalse(response.isCanDelete());
+            assertTrue(response.isCanCopy());
             List<RESTSecurityRule> securityRules = response.getSecurityRuleList().getList();
             assertEquals(1, securityRules.size());
             RESTSecurityRule securityRule = securityRules.get(0);
@@ -2123,6 +2128,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                             adminSecurityContext, groupOwnedResourceId, true, true, false);
             assertTrue(response.isCanEdit());
             assertTrue(response.isCanDelete());
+            assertTrue(response.isCanCopy());
             List<RESTSecurityRule> securityRules = response.getSecurityRuleList().getList();
             assertEquals(1, securityRules.size());
         }
@@ -2133,6 +2139,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                             userSecurityContext, groupOwnedResourceId, true, true, false);
             assertTrue(response.isCanEdit());
             assertTrue(response.isCanDelete());
+            assertTrue(response.isCanCopy());
             List<RESTSecurityRule> securityRules = response.getSecurityRuleList().getList();
             assertEquals(1, securityRules.size());
             RESTSecurityRule securityRule = securityRules.get(0);
@@ -2147,6 +2154,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                             userSecurityContext, readOnlyGroupResourceId, true, true, false);
             assertFalse(response.isCanEdit());
             assertFalse(response.isCanDelete());
+            assertTrue(response.isCanCopy());
             List<RESTSecurityRule> securityRules = response.getSecurityRuleList().getList();
             assertEquals(1, securityRules.size());
             RESTSecurityRule securityRule = securityRules.get(0);
@@ -2224,6 +2232,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
 
             assertTrue(response.isCanEdit());
             assertTrue(response.isCanDelete());
+            assertTrue(response.isCanCopy());
         }
 
         {
@@ -2298,6 +2307,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
 
             assertTrue(response.isCanEdit());
             assertTrue(response.isCanDelete());
+            assertTrue(response.isCanCopy());
         }
 
         {
@@ -2369,6 +2379,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
 
             assertTrue(response.isCanEdit());
             assertTrue(response.isCanDelete());
+            assertTrue(response.isCanCopy());
         }
 
         {


### PR DESCRIPTION
This changes add the attribute `canCopy` to the `ShortResource` resource representation, returned by the endpoint `/extjs/resource`.

Example:
```xml
<ShortResource>
    <advertised>true</advertised>
    <canCopy>true</canCopy>
    <canDelete>true</canDelete>
    <canEdit>true</canEdit>
    <creation>2025-08-20T18:32:11.959+02:00</creation>
    <creator>user</creator>
    <id>624</id>
    <name>rest_test_resource_1755707531574</name>
[...]
```