### PR TITLE
Fixed NPE in UserDAO findFavoritedBy default implementation.

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/UserDAO.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/UserDAO.java
@@ -20,6 +20,7 @@
 package it.geosolutions.geostore.core.dao;
 
 import it.geosolutions.geostore.core.model.User;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -29,6 +30,6 @@ import java.util.List;
  */
 public interface UserDAO extends RestrictedGenericDAO<User> {
     default List<User> findFavoritedBy(Long resourceId) {
-        return null;
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
Fix #467 
This change fixes the NPE reported in https://github.com/geosolutions-it/support/issues/5576.

Since the user's favourite resource functionality implementation is not compatible with the geostore LDAP configuration, searching the users from the resource was failing.

This fix could be deployed to allow further testing, while the favourite mechanism for LDAP is being implemented.