### PR TITLE
Fixed admin roles checking when adding favorites with external security.

### DIFF
--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/FavoriteService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/FavoriteService.java
@@ -28,18 +28,14 @@
  */
 package it.geosolutions.geostore.services;
 
+import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.services.exception.DuplicatedFavoriteServiceException;
 import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
 
 public interface FavoriteService {
 
-    void addFavoriteByUserId(long userId, long resourceId)
+    void addFavorite(User user, long resourceId)
             throws NotFoundServiceEx, DuplicatedFavoriteServiceException;
 
-    void removeFavoriteByUserId(long userId, long resourceId) throws NotFoundServiceEx;
-
-    void addFavoriteByUsername(String username, long resourceId)
-            throws NotFoundServiceEx, DuplicatedFavoriteServiceException;
-
-    void removeFavoriteByUsername(String username, long resourceId) throws NotFoundServiceEx;
+    void removeFavorite(User user, long resourceId) throws NotFoundServiceEx;
 }

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/FavoriteServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/FavoriteServiceImpl.java
@@ -44,8 +44,8 @@ public class FavoriteServiceImpl implements FavoriteService {
                     SEARCH_BY_RESOURCE_ID.apply(resourceId).addFilterEqual("user.id", userId);
 
     private static final BiFunction<String, Long, Search> SEARCH_BY_USERNAME =
-            (userId, resourceId) ->
-                    SEARCH_BY_RESOURCE_ID.apply(resourceId).addFilterEqual("username", userId);
+            (username, resourceId) ->
+                    SEARCH_BY_RESOURCE_ID.apply(resourceId).addFilterEqual("username", username);
 
     private final UserFavoriteDAO userFavoriteDAO;
     private final ResourcePermissionService resourcePermissionService;
@@ -65,7 +65,36 @@ public class FavoriteServiceImpl implements FavoriteService {
 
     @Override
     @Transactional(value = "geostoreTransactionManager")
-    public void addFavoriteByUserId(long userId, long resourceId)
+    public void addFavorite(User user, long resourceId)
+            throws NotFoundServiceEx, DuplicatedFavoriteServiceException {
+
+        Resource resource = resourceDAO.find(resourceId);
+        if (resource == null) {
+            throw new NotFoundServiceEx("Resource not found");
+        }
+
+        if (!resourcePermissionService.canResourceBeReadByUser(resource, user)) {
+            throw new ForbiddenException("Resource is protected");
+        }
+
+        if (isUserFromExternalSecurity(user)) {
+            /* external security setup - using username */
+            addFavoriteByUsername(user.getName(), resource);
+            return;
+        }
+
+        addFavoriteByUserId(user.getId(), resource);
+    }
+
+    private void addFavoriteByUsername(String username, Resource resource)
+            throws DuplicatedFavoriteServiceException {
+
+        checkForDuplicates(SEARCH_BY_USERNAME.apply(username, resource.getId()));
+
+        userFavoriteDAO.persist(UserFavorite.withUsername(username, resource));
+    }
+
+    private void addFavoriteByUserId(long userId, Resource resource)
             throws NotFoundServiceEx, DuplicatedFavoriteServiceException {
 
         User user = userDAO.find(userId);
@@ -73,55 +102,15 @@ public class FavoriteServiceImpl implements FavoriteService {
             throw new NotFoundServiceEx("User not found");
         }
 
-        Resource resource = resourceDAO.find(resourceId);
-        if (resource == null) {
-            throw new NotFoundServiceEx("Resource not found");
-        }
-
-        if (!resourcePermissionService.canResourceBeReadByUser(resource, user)) {
-            throw new ForbiddenException("Resource is protected");
-        }
-
-        checkForDuplicates(userId, resource);
+        checkForDuplicates(SEARCH_BY_USER_ID.apply(userId, resource.getId()));
 
         userFavoriteDAO.persist(UserFavorite.withUser(user, resource));
     }
 
-    private void checkForDuplicates(Long userId, Resource resource)
-            throws DuplicatedFavoriteServiceException {
-        checkForDuplicates(SEARCH_BY_USER_ID.apply(userId, resource.getId()));
-    }
-
-    @Override
-    @Transactional(value = "geostoreTransactionManager")
-    public void addFavoriteByUsername(String username, long resourceId)
-            throws NotFoundServiceEx, DuplicatedFavoriteServiceException {
-
-        Resource resource = resourceDAO.find(resourceId);
-        if (resource == null) {
-            throw new NotFoundServiceEx("Resource not found");
-        }
-
-        User user = new User();
-        user.setName(username);
-        if (!resourcePermissionService.canResourceBeReadByUser(resource, user)) {
-            throw new ForbiddenException("Resource is protected");
-        }
-
-        checkForDuplicates(username, resource);
-
-        userFavoriteDAO.persist(UserFavorite.withUsername(username, resource));
-    }
-
-    private void checkForDuplicates(String username, Resource resource)
-            throws DuplicatedFavoriteServiceException {
-        checkForDuplicates(SEARCH_BY_USERNAME.apply(username, resource.getId()));
-    }
-
-    private void checkForDuplicates(Search duplicatedSearch)
+    private void checkForDuplicates(Search duplicateSearch)
             throws DuplicatedFavoriteServiceException {
 
-        Search search = duplicatedSearch.setMaxResults(1);
+        Search search = duplicateSearch.setMaxResults(1);
 
         if (userFavoriteDAO.count(search) > 0) {
             throw new DuplicatedFavoriteServiceException(
@@ -131,9 +120,14 @@ public class FavoriteServiceImpl implements FavoriteService {
 
     @Override
     @Transactional(value = "geostoreTransactionManager")
-    public void removeFavoriteByUserId(long userId, long resourceId) throws NotFoundServiceEx {
+    public void removeFavorite(User user, long resourceId) throws NotFoundServiceEx {
 
-        Search searchCriteria = SEARCH_BY_USER_ID.apply(userId, resourceId);
+        Search searchCriteria = SEARCH_BY_USER_ID.apply(user.getId(), resourceId);
+
+        if (isUserFromExternalSecurity(user)) {
+            /* external security setup - searching by username instead */
+            searchCriteria = SEARCH_BY_USERNAME.apply(user.getName(), resourceId);
+        }
 
         List<UserFavorite> favorites = userFavoriteDAO.search(searchCriteria);
         if (favorites.isEmpty()) {
@@ -143,21 +137,7 @@ public class FavoriteServiceImpl implements FavoriteService {
         userFavoriteDAO.remove(favorites.get(0));
     }
 
-    @Override
-    @Transactional(value = "geostoreTransactionManager")
-    public void removeFavoriteByUsername(String username, long resourceId)
-            throws NotFoundServiceEx {
-
-        Search searchCriteria =
-                new Search(UserFavorite.class)
-                        .addFilterEqual("username", username)
-                        .addFilterEqual("resource.id", resourceId);
-
-        List<UserFavorite> favorites = userFavoriteDAO.search(searchCriteria);
-        if (favorites.isEmpty()) {
-            throw new NotFoundServiceEx("Favorite not found");
-        }
-
-        userFavoriteDAO.remove(favorites.get(0));
+    private static boolean isUserFromExternalSecurity(User user) {
+        return user.getId() == -1;
     }
 }

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
@@ -1593,7 +1593,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                 restCreateResource("favourite_resource", "", CAT0_NAME, userId, true);
         restCreateResource("other_resource", "", CAT0_NAME, userId, true);
 
-        favoriteService.addFavoriteByUserId(userId, favoriteResourceId);
+        favoriteService.addFavorite(userService.get(userId), favoriteResourceId);
 
         {
             ExtResourceList response =
@@ -1648,7 +1648,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
         long nonFavoriteResourceId =
                 restCreateResource("other_resource", "", CAT0_NAME, userId, true);
 
-        favoriteService.addFavoriteByUserId(userId, favoriteResourceId);
+        favoriteService.addFavorite(userService.get(userId), favoriteResourceId);
 
         {
             ExtResourceList response =
@@ -2398,7 +2398,7 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
         long nonFavoriteResourceId =
                 restCreateResource("other_resource", "", CAT0_NAME, userId, true);
 
-        favoriteService.addFavoriteByUserId(userId, favoriteResourceId);
+        favoriteService.addFavorite(userService.get(userId), favoriteResourceId);
 
         {
             ExtShortResource response =

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTFavoriteServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTFavoriteServiceImpl.java
@@ -47,15 +47,7 @@ public class RESTFavoriteServiceImpl extends RESTServiceImpl implements RESTFavo
     public void addFavorite(SecurityContext sc, long resourceId) throws NotFoundWebEx {
         try {
             User authUser = extractAuthUser(sc);
-
-            if (authUser.getId() == -1) {
-                /* user ID is not available due to external security setup - using username instead */
-                favoriteService.addFavoriteByUsername(authUser.getName(), resourceId);
-                return;
-            }
-
-            favoriteService.addFavoriteByUserId(authUser.getId(), resourceId);
-
+            favoriteService.addFavorite(authUser, resourceId);
         } catch (NotFoundServiceEx e) {
             throw new NotFoundWebEx(e.getMessage());
         } catch (DuplicatedFavoriteServiceException e) {
@@ -67,15 +59,7 @@ public class RESTFavoriteServiceImpl extends RESTServiceImpl implements RESTFavo
     public void removeFavorite(SecurityContext sc, long resourceId) throws NotFoundWebEx {
         try {
             User authUser = extractAuthUser(sc);
-
-            if (authUser.getId() == -1) {
-                /* user ID is not available due to external security setup - using username instead */
-                favoriteService.removeFavoriteByUsername(authUser.getName(), resourceId);
-                return;
-            }
-
-            favoriteService.removeFavoriteByUserId(authUser.getId(), resourceId);
-
+            favoriteService.removeFavorite(authUser, resourceId);
         } catch (NotFoundServiceEx e) {
             throw new NotFoundWebEx(e.getMessage());
         }


### PR DESCRIPTION
These changes address the admin permission bug described in https://github.com/geosolutions-it/support/issues/5678, 
where using external security, the admin was not able to create favorites for resources not owned.