### PR TITLE
Fixed group permissions checking to include security rule groupname.

### DIFF
--- a/src/core/model/src/main/java/it/geosolutions/geostore/core/model/SecurityRule.java
+++ b/src/core/model/src/main/java/it/geosolutions/geostore/core/model/SecurityRule.java
@@ -116,9 +116,21 @@ public class SecurityRule implements Serializable {
     @Column(nullable = false, updatable = true)
     private boolean canWrite;
 
+    /**
+     * This field is used in LDAP direct configuration, where the users are not handled by GeoStore.
+     * <p>
+     * Permission on resources are then managed by matching the current user username with this field value.
+     * </p>
+     */
     @Column(nullable = true, updatable = true)
     private String username;
 
+    /**
+     * This field is used in LDAP direct configuration, where the users are not handled by GeoStore.
+     * <p>
+     * Permission on resources are then managed by matching the current user groups names with this field value.
+     * </p>
+     */
     @Column(nullable = true, updatable = true)
     private String groupname;
 


### PR DESCRIPTION
These changes fix #479, allowing resource retrieval by group/role ownership in LDAP direct mode.
The resource check now considers also the name of the group in a `OR` condition with the actual usergroup that owns the resource.