### PR TITLE
Backport #465 fix: token refresh and cache expiration (2.5.x)

### DIFF
--- a/src/modules/rest/impl/pom.xml
+++ b/src/modules/rest/impl/pom.xml
@@ -154,6 +154,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.9.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         </dependency>

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/TokenAuthenticationCache.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/TokenAuthenticationCache.java
@@ -27,9 +27,10 @@
  */
 package it.geosolutions.geostore.services.rest.security;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
 import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
 import it.geosolutions.geostore.services.rest.security.oauth2.TokenDetails;
@@ -37,6 +38,7 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.index.qual.NonNegative;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -50,29 +52,72 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * A cache for OAuth2 Authentication object. Authentication instances are identified by the
- * corresponding accessToken.
+ * corresponding accessToken. Uses per-entry expiration based on the token's actual expiry time.
  */
 public class TokenAuthenticationCache implements ApplicationContextAware {
 
     private static final Logger LOGGER = LogManager.getLogger(TokenAuthenticationCache.class);
     private final Cache<String, Authentication> cache;
-    private final int cacheSize = 1000;
-    private final int cacheExpirationMinutes = 8;
+    private final long defaultExpirationNanos;
     private ApplicationContext context;
 
     public TokenAuthenticationCache() {
-        CacheBuilder<String, Authentication> cacheBuilder =
-                CacheBuilder.newBuilder()
+        this(1000, 480);
+    }
+
+    public TokenAuthenticationCache(int cacheSize, int cacheExpirationMinutes) {
+        this.defaultExpirationNanos = TimeUnit.MINUTES.toNanos(cacheExpirationMinutes);
+        this.cache =
+                Caffeine.newBuilder()
                         .maximumSize(cacheSize)
-                        .expireAfterWrite(cacheExpirationMinutes, TimeUnit.HOURS)
-                        .removalListener(
-                                notification -> {
-                                    if (notification.getCause().equals(RemovalCause.EXPIRED)) {
-                                        Authentication authentication = notification.getValue();
+                        .expireAfter(
+                                new Expiry<String, Authentication>() {
+                                    @Override
+                                    public long expireAfterCreate(
+                                            String key, Authentication value, long currentTime) {
+                                        return computeExpirationNanos(value);
+                                    }
+
+                                    @Override
+                                    public long expireAfterUpdate(
+                                            String key,
+                                            Authentication value,
+                                            long currentTime,
+                                            @NonNegative long currentDuration) {
+                                        return computeExpirationNanos(value);
+                                    }
+
+                                    @Override
+                                    public long expireAfterRead(
+                                            String key,
+                                            Authentication value,
+                                            long currentTime,
+                                            @NonNegative long currentDuration) {
+                                        return currentDuration;
+                                    }
+                                })
+                        .evictionListener(
+                                (key, authentication, cause) -> {
+                                    if (cause == RemovalCause.EXPIRED && authentication != null) {
                                         revokeAuthIfRefreshExpired(authentication);
                                     }
-                                });
-        this.cache = cacheBuilder.build();
+                                })
+                        .recordStats()
+                        .build();
+    }
+
+    private long computeExpirationNanos(Authentication authentication) {
+        TokenDetails details = OAuth2Utils.getTokenDetails(authentication);
+        if (details != null && details.getAccessToken() != null) {
+            Date exp = details.getAccessToken().getExpiration();
+            if (exp != null) {
+                long remainingMs = exp.getTime() - System.currentTimeMillis();
+                if (remainingMs > 0) {
+                    return TimeUnit.MILLISECONDS.toNanos(remainingMs);
+                }
+            }
+        }
+        return defaultExpirationNanos;
     }
 
     /**
@@ -159,6 +204,10 @@ public class TokenAuthenticationCache implements ApplicationContextAware {
      */
     public void removeEntry(String accessToken) {
         this.cache.invalidate(accessToken);
+    }
+
+    public Cache<String, Authentication> getCache() {
+        return cache;
     }
 
     @Override

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -79,6 +79,10 @@ public class OAuth2Configuration extends IdPConfiguration {
     private String groupsClaim;
     private boolean groupNamesUppercase = false;
 
+    // Cache configuration
+    private int cacheSize = 1000;
+    private int cacheExpirationMinutes = 480;
+
     // Retry and backoff configurations
     private long initialBackoffDelay = 1000; // Default: 1 second
     private double backoffMultiplier = 2.0; // Default multiplier
@@ -584,6 +588,22 @@ public class OAuth2Configuration extends IdPConfiguration {
         this.groupNamesUppercase = groupNamesUppercase;
     }
 
+    public int getCacheSize() {
+        return cacheSize;
+    }
+
+    public void setCacheSize(int cacheSize) {
+        this.cacheSize = cacheSize;
+    }
+
+    public int getCacheExpirationMinutes() {
+        return cacheExpirationMinutes;
+    }
+
+    public void setCacheExpirationMinutes(int cacheExpirationMinutes) {
+        this.cacheExpirationMinutes = cacheExpirationMinutes;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof OAuth2Configuration)) return false;
@@ -591,6 +611,8 @@ public class OAuth2Configuration extends IdPConfiguration {
         return isGlobalLogoutEnabled() == that.isGlobalLogoutEnabled()
                 && isEnableRedirectEntryPoint() == that.isEnableRedirectEntryPoint()
                 && isGroupNamesUppercase() == that.isGroupNamesUppercase()
+                && getCacheSize() == that.getCacheSize()
+                && getCacheExpirationMinutes() == that.getCacheExpirationMinutes()
                 && getInitialBackoffDelay() == that.getInitialBackoffDelay()
                 && Double.compare(getBackoffMultiplier(), that.getBackoffMultiplier()) == 0
                 && getMaxRetries() == that.getMaxRetries()
@@ -630,6 +652,8 @@ public class OAuth2Configuration extends IdPConfiguration {
                 getRolesClaim(),
                 getGroupsClaim(),
                 isGroupNamesUppercase(),
+                getCacheSize(),
+                getCacheExpirationMinutes(),
                 getInitialBackoffDelay(),
                 getBackoffMultiplier(),
                 getMaxRetries());
@@ -686,6 +710,10 @@ public class OAuth2Configuration extends IdPConfiguration {
                 + '\''
                 + ", groupNamesUppercase="
                 + groupNamesUppercase
+                + ", cacheSize="
+                + cacheSize
+                + ", cacheExpirationMinutes="
+                + cacheExpirationMinutes
                 + ", initialBackoffDelay="
                 + initialBackoffDelay
                 + ", backoffMultiplier="

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -83,6 +83,10 @@ public class OAuth2Configuration extends IdPConfiguration {
     private int cacheSize = 1000;
     private int cacheExpirationMinutes = 480;
 
+    // Smart refresh: skip IDP refresh when token is still valid
+    private boolean skipRefreshIfTokenValid = true;
+    private double refreshTokenLifetimeFraction = 0.8;
+
     // Retry and backoff configurations
     private long initialBackoffDelay = 1000; // Default: 1 second
     private double backoffMultiplier = 2.0; // Default multiplier
@@ -140,6 +144,22 @@ public class OAuth2Configuration extends IdPConfiguration {
      */
     public void setBackoffMultiplier(double backoffMultiplier) {
         this.backoffMultiplier = backoffMultiplier;
+    }
+
+    public boolean isSkipRefreshIfTokenValid() {
+        return skipRefreshIfTokenValid;
+    }
+
+    public void setSkipRefreshIfTokenValid(boolean skipRefreshIfTokenValid) {
+        this.skipRefreshIfTokenValid = skipRefreshIfTokenValid;
+    }
+
+    public double getRefreshTokenLifetimeFraction() {
+        return refreshTokenLifetimeFraction;
+    }
+
+    public void setRefreshTokenLifetimeFraction(double refreshTokenLifetimeFraction) {
+        this.refreshTokenLifetimeFraction = refreshTokenLifetimeFraction;
     }
 
     /**
@@ -611,6 +631,11 @@ public class OAuth2Configuration extends IdPConfiguration {
         return isGlobalLogoutEnabled() == that.isGlobalLogoutEnabled()
                 && isEnableRedirectEntryPoint() == that.isEnableRedirectEntryPoint()
                 && isGroupNamesUppercase() == that.isGroupNamesUppercase()
+                && isSkipRefreshIfTokenValid() == that.isSkipRefreshIfTokenValid()
+                && Double.compare(
+                                getRefreshTokenLifetimeFraction(),
+                                that.getRefreshTokenLifetimeFraction())
+                        == 0
                 && getCacheSize() == that.getCacheSize()
                 && getCacheExpirationMinutes() == that.getCacheExpirationMinutes()
                 && getInitialBackoffDelay() == that.getInitialBackoffDelay()
@@ -652,6 +677,8 @@ public class OAuth2Configuration extends IdPConfiguration {
                 getRolesClaim(),
                 getGroupsClaim(),
                 isGroupNamesUppercase(),
+                isSkipRefreshIfTokenValid(),
+                getRefreshTokenLifetimeFraction(),
                 getCacheSize(),
                 getCacheExpirationMinutes(),
                 getInitialBackoffDelay(),
@@ -710,6 +737,10 @@ public class OAuth2Configuration extends IdPConfiguration {
                 + '\''
                 + ", groupNamesUppercase="
                 + groupNamesUppercase
+                + ", skipRefreshIfTokenValid="
+                + skipRefreshIfTokenValid
+                + ", refreshTokenLifetimeFraction="
+                + refreshTokenLifetimeFraction
                 + ", cacheSize="
                 + cacheSize
                 + ", cacheExpirationMinutes="

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -42,7 +42,6 @@ import it.geosolutions.geostore.services.rest.utils.GeoStoreContext;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -81,6 +80,7 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
     private static final long CLOCK_SKEW_ALLOWANCE_MILLIS = 5 * 60 * 1000; // 5 minutes
 
     protected UserService userService;
+    protected final String delegateName;
 
     /**
      * @param restSessionService the session service to which register this delegate?
@@ -89,11 +89,14 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
     public OAuth2SessionServiceDelegate(
             RESTSessionService restSessionService, String delegateName, UserService userService) {
         restSessionService.registerDelegate(delegateName, this);
+        this.delegateName = delegateName;
         this.userService = userService;
     }
 
     public OAuth2SessionServiceDelegate(
-            RestTemplate restTemplate, OAuth2Configuration configuration) {}
+            RestTemplate restTemplate, OAuth2Configuration configuration) {
+        this.delegateName = null;
+    }
 
     @Override
     public SessionToken refresh(String refreshToken, String accessToken) {
@@ -125,7 +128,14 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         SessionToken sessionToken = null;
         OAuth2Configuration configuration = configuration();
 
-        if (configuration != null && configuration.isEnabled()) {
+        if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
+            // No refresh token available (e.g. bearer-token auth without auth code flow,
+            // or IdP did not issue a refresh token because offline_access was not requested).
+            // Skip the refresh attempt and return the current token if still valid.
+            LOGGER.info(
+                    "No refresh token available; skipping token refresh and returning current token.");
+            warningMessage = "No refresh token available; using existing access token.";
+        } else if (configuration != null && configuration.isEnabled()) {
             LOGGER.info("Attempting to refresh the token.");
             try {
                 sessionToken = doRefresh(refreshTokenToUse, accessToken, configuration);
@@ -248,13 +258,18 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         String errorMessage = "";
         String warningMessage = "";
 
-        OAuth2RestTemplate restTemplate = restTemplate();
+        // Use a plain RestTemplate to avoid OAuth2RestTemplate interceptors that may
+        // trigger a UserRedirectRequiredException when the current access token is expired.
+        RestTemplate plainRestTemplate = createRefreshRestTemplate();
         HttpHeaders headers = getHttpHeaders(accessToken, configuration);
         MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
         requestBody.add("grant_type", "refresh_token");
         requestBody.add("refresh_token", refreshToken);
         requestBody.add("client_secret", configuration.getClientSecret());
         requestBody.add("client_id", configuration.getClientId());
+        if (configuration.getScopes() != null && !configuration.getScopes().isEmpty()) {
+            requestBody.add("scope", configuration.getScopes().replace(",", " "));
+        }
         HttpEntity<MultiValueMap<String, String>> requestEntity =
                 new HttpEntity<>(requestBody, headers);
 
@@ -267,8 +282,8 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
 
             try {
                 ResponseEntity<OAuth2AccessToken> response =
-                        restTemplate.exchange(
-                                configuration.buildRefreshTokenURI(),
+                        plainRestTemplate.exchange(
+                                configuration.getAccessTokenUri(),
                                 HttpMethod.POST,
                                 requestEntity,
                                 OAuth2AccessToken.class);
@@ -497,7 +512,9 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         if (token == null) {
             if (restTemplate != null
                     && restTemplate.getOAuth2ClientContext() != null
-                    && restTemplate.getOAuth2ClientContext().getAccessToken() != null) {
+                    && restTemplate.getOAuth2ClientContext().getAccessToken() != null
+                    && restTemplate.getOAuth2ClientContext().getAccessToken().getRefreshToken()
+                            != null) {
                 token =
                         restTemplate
                                 .getOAuth2ClientContext()
@@ -508,10 +525,10 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
             if (token == null) {
                 token = OAuth2Utils.getParameterValue(REFRESH_TOKEN_PARAM, request);
             }
-            if (token == null) {
+            if (token == null && RequestContextHolder.getRequestAttributes() != null) {
                 token =
                         (String)
-                                Objects.requireNonNull(RequestContextHolder.getRequestAttributes())
+                                RequestContextHolder.getRequestAttributes()
                                         .getAttribute(REFRESH_TOKEN_PARAM, 0);
             }
         }
@@ -525,10 +542,10 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
             if (accessToken == null) {
                 accessToken = OAuth2Utils.getParameterValue(ACCESS_TOKEN_PARAM, request);
             }
-            if (accessToken == null) {
+            if (accessToken == null && RequestContextHolder.getRequestAttributes() != null) {
                 accessToken =
                         (String)
-                                Objects.requireNonNull(RequestContextHolder.getRequestAttributes())
+                                RequestContextHolder.getRequestAttributes()
                                         .getAttribute(ACCESS_TOKEN_PARAM, 0);
             }
         }
@@ -542,8 +559,7 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
                     doLogoutInternal(token, configuration, accessToken);
                 if (configuration.getRevokeEndpoint() != null) clearSession(restTemplate, request);
             } else {
-                if (LOGGER.isDebugEnabled())
-                    LOGGER.info("Unable to retrieve access token. Remote logout was not executed.");
+                LOGGER.debug("Unable to retrieve access token. Remote logout was not executed.");
             }
             if (response != null) clearCookies(request, response);
         }
@@ -588,11 +604,17 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         } else if (token instanceof String) {
             tokenValue = (String) token;
         }
-        if (configuration.getRevokeEndpoint() != null && tokenValue != null) {
-            if (LOGGER.isDebugEnabled()) LOGGER.info("Performing remote logout");
+        if (tokenValue == null) return;
+
+        // Revoke the token if a revocation endpoint is available
+        if (configuration.getRevokeEndpoint() != null) {
+            LOGGER.debug("Revoking token at revocation endpoint");
             callRevokeEndpoint(tokenValue, accessToken);
-            callRemoteLogout(tokenValue, accessToken);
         }
+
+        // Call the remote logout endpoint (end_session_endpoint) independently
+        LOGGER.debug("Performing remote logout");
+        callRemoteLogout(tokenValue, accessToken);
     }
 
     protected void callRevokeEndpoint(String token, String accessToken) {
@@ -663,11 +685,23 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
     }
 
     /**
-     * Get the OAuth2Configuration.
+     * Get the OAuth2Configuration. Prefers the provider-specific bean ({delegateName}OAuth2Config)
+     * and falls back to iterating all enabled configurations.
      *
      * @return the OAuth2Configuration.
      */
     protected OAuth2Configuration configuration() {
+        // Try provider-specific bean first
+        if (delegateName != null) {
+            OAuth2Configuration specific =
+                    GeoStoreContext.bean(
+                            delegateName + OAuth2Configuration.CONFIG_NAME_SUFFIX,
+                            OAuth2Configuration.class);
+            if (specific != null && specific.isEnabled()) {
+                return specific;
+            }
+        }
+        // Fallback: iterate all configurations
         Map<String, OAuth2Configuration> configurations =
                 GeoStoreContext.beans(OAuth2Configuration.class);
         if (configurations != null) {
@@ -692,6 +726,15 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
     }
 
     protected abstract OAuth2RestTemplate restTemplate();
+
+    /**
+     * Creates a plain RestTemplate for token refresh requests. Using a plain RestTemplate avoids
+     * OAuth2RestTemplate interceptors that can trigger UserRedirectRequiredException when the
+     * current access token is expired.
+     */
+    protected RestTemplate createRefreshRestTemplate() {
+        return new RestTemplate();
+    }
 
     @Override
     public User getUser(String sessionId, boolean refresh, boolean autorefresh) {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -128,7 +128,10 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         SessionToken sessionToken = null;
         OAuth2Configuration configuration = configuration();
 
-        if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
+        if (configuration != null && shouldSkipRefresh(currentToken, configuration)) {
+            LOGGER.debug("Token still has sufficient validity; skipping IDP refresh.");
+            warningMessage = "Token still valid; refresh skipped.";
+        } else if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
             // No refresh token available (e.g. bearer-token auth without auth code flow,
             // or IdP did not issue a refresh token because offline_access was not requested).
             // Skip the refresh attempt and return the current token if still valid.
@@ -236,6 +239,66 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
             LOGGER.error("Failed to parse JWT token: {}", e.getMessage());
             return null;
         }
+    }
+
+    private Date getIssuedAtFromToken(String token) {
+        try {
+            Jwt decodedToken = JwtHelper.decode(token);
+            String claimsJson = decodedToken.getClaims();
+
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, Object> claims = mapper.readValue(claimsJson, Map.class);
+
+            Object iat = claims.get("iat");
+            if (iat != null) {
+                long iatLong;
+                if (iat instanceof Integer) {
+                    iatLong = ((Integer) iat).longValue();
+                } else if (iat instanceof Long) {
+                    iatLong = (Long) iat;
+                } else if (iat instanceof String) {
+                    iatLong = Long.parseLong((String) iat);
+                } else {
+                    return null;
+                }
+                return new Date(iatLong * 1000);
+            }
+            return null;
+        } catch (Exception e) {
+            LOGGER.debug("Failed to parse 'iat' from JWT token: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    boolean shouldSkipRefresh(OAuth2AccessToken token, OAuth2Configuration config) {
+        if (!config.isSkipRefreshIfTokenValid()) {
+            return false;
+        }
+
+        Date expiration = token.getExpiration();
+        if (expiration == null) {
+            expiration = getExpirationDateFromToken(token.getValue());
+        }
+        if (expiration == null) {
+            return false;
+        }
+
+        long now = System.currentTimeMillis();
+        if (expiration.getTime() <= now) {
+            return false;
+        }
+
+        Date issuedAt = getIssuedAtFromToken(token.getValue());
+        if (issuedAt != null) {
+            long totalLifetime = expiration.getTime() - issuedAt.getTime();
+            long elapsed = now - issuedAt.getTime();
+            double fraction = config.getRefreshTokenLifetimeFraction();
+            return elapsed < totalLifetime * fraction;
+        }
+
+        // Fallback: skip if more than 5 minutes remaining
+        long remaining = expiration.getTime() - now;
+        return remaining > CLOCK_SKEW_ALLOWANCE_MILLIS;
     }
 
     /**

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.security.oauth2.client.resource.UserRedirectRequiredE
 import org.springframework.security.oauth2.common.*;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -35,7 +36,7 @@ class RefreshTokenServiceTest {
 
     private TestOAuth2SessionServiceDelegate serviceDelegate;
     private OAuth2Configuration configuration;
-    private OAuth2RestTemplate restTemplate;
+    private RestTemplate restTemplate;
     private MockHttpServletRequest mockRequest;
     private MockHttpServletResponse mockResponse;
     private DefaultOAuth2AccessToken mockOAuth2AccessToken;
@@ -48,13 +49,13 @@ class RefreshTokenServiceTest {
 
         // Initialize mocks and dependencies
         configuration = mock(OAuth2Configuration.class);
-        restTemplate = mock(OAuth2RestTemplate.class);
+        restTemplate = mock(RestTemplate.class);
         authenticationCache = mock(TokenAuthenticationCache.class);
 
         // Create an instance of the test subclass
         serviceDelegate = spy(new TestOAuth2SessionServiceDelegate());
         // Ensure restTemplate is set correctly
-        serviceDelegate.setRestTemplate(restTemplate);
+        serviceDelegate.setRefreshRestTemplate(restTemplate);
         serviceDelegate.setConfiguration(configuration);
         serviceDelegate.authenticationCache = authenticationCache;
 
@@ -70,7 +71,9 @@ class RefreshTokenServiceTest {
         when(configuration.getMaxRetries()).thenReturn(3);
         when(configuration.getClientId()).thenReturn("testClientId");
         when(configuration.getClientSecret()).thenReturn("testClientSecret");
-        when(configuration.buildRefreshTokenURI()).thenReturn("https://example.com/oauth2/token");
+        when(configuration.getAccessTokenUri()).thenReturn("https://example.com/oauth2/token");
+        when(configuration.getInitialBackoffDelay()).thenReturn(1000L);
+        when(configuration.getBackoffMultiplier()).thenReturn(2.0);
 
         // Mock the existing OAuth2AccessToken with a refresh token
         mockOAuth2AccessToken = new DefaultOAuth2AccessToken("providedAccessToken");
@@ -130,10 +133,6 @@ class RefreshTokenServiceTest {
         when(configuration.isEnabled()).thenReturn(true);
         when(configuration.getClientId()).thenReturn("testClientId");
         when(configuration.getClientSecret()).thenReturn("testClientSecret");
-        when(configuration.buildRefreshTokenURI()).thenReturn("https://example.com/oauth2/token");
-        when(configuration.getInitialBackoffDelay()).thenReturn(1000L);
-        when(configuration.getMaxRetries()).thenReturn(3);
-
         when(restTemplate.exchange(
                         anyString(),
                         eq(HttpMethod.POST),
@@ -229,7 +228,7 @@ class RefreshTokenServiceTest {
         assertEquals(
                 "existingRefreshToken",
                 sessionToken.getRefreshToken(),
-                "Refresh token should remain unchanged after server error");
+                "Refresh token should remain unchanged");
         assertNotNull(sessionToken.getWarning(), "Warning message should be set");
         assertTrue(
                 sessionToken.getWarning().contains("Using existing access token."),
@@ -513,7 +512,7 @@ class RefreshTokenServiceTest {
         String oldAccessToken = "oldAccessToken";
         String refreshToken = "validRefreshToken";
 
-        // We’ll pretend the user originally had "oldAccessToken"
+        // We'll pretend the user originally had "oldAccessToken"
         // and the current OAuth2 token in serviceDelegate is set to the same.
         DefaultOAuth2AccessToken originalAccessToken = new DefaultOAuth2AccessToken(oldAccessToken);
         OAuth2RefreshToken existingRefresh = new DefaultOAuth2RefreshToken(refreshToken);
@@ -546,13 +545,7 @@ class RefreshTokenServiceTest {
                         eq(OAuth2AccessToken.class)))
                 .thenReturn(responseEntity);
 
-        // Mock config so refresh is enabled
-        when(configuration.isEnabled()).thenReturn(true);
-        when(configuration.getClientId()).thenReturn("testClientId");
-        when(configuration.getClientSecret()).thenReturn("testClientSecret");
-        when(configuration.buildRefreshTokenURI()).thenReturn("https://example.com/oauth2/token");
-        when(configuration.getInitialBackoffDelay()).thenReturn(1000L);
-        when(configuration.getMaxRetries()).thenReturn(3);
+        // Mock config so refresh is enabled (most already set in setUp)
 
         // Act
         SessionToken sessionToken = serviceDelegate.refresh(refreshToken, oldAccessToken);
@@ -587,7 +580,7 @@ class RefreshTokenServiceTest {
     /** Test subclass of OAuth2SessionServiceDelegate for testing purposes. */
     class TestOAuth2SessionServiceDelegate extends OAuth2SessionServiceDelegate {
 
-        private OAuth2RestTemplate restTemplate;
+        private RestTemplate refreshRestTemplate;
         private OAuth2Configuration configuration;
         private OAuth2AccessToken currentAccessToken;
         protected TokenAuthenticationCache authenticationCache;
@@ -596,8 +589,8 @@ class RefreshTokenServiceTest {
             super(null, null); // Mocked dependencies
         }
 
-        public void setRestTemplate(OAuth2RestTemplate restTemplate) {
-            this.restTemplate = restTemplate;
+        public void setRefreshRestTemplate(RestTemplate refreshRestTemplate) {
+            this.refreshRestTemplate = refreshRestTemplate;
         }
 
         public void setConfiguration(OAuth2Configuration configuration) {
@@ -606,7 +599,12 @@ class RefreshTokenServiceTest {
 
         @Override
         protected OAuth2RestTemplate restTemplate() {
-            return restTemplate;
+            return null;
+        }
+
+        @Override
+        protected RestTemplate createRefreshRestTemplate() {
+            return refreshRestTemplate;
         }
 
         @Override

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
@@ -9,6 +9,7 @@ import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuratio
 import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2SessionServiceDelegate;
 import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
 import it.geosolutions.geostore.services.rest.security.oauth2.TokenDetails;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -575,6 +576,200 @@ class RefreshTokenServiceTest {
                 "brandNewRefreshToken",
                 serviceDelegate.currentAccessToken.getRefreshToken().getValue(),
                 "Service delegate must store the new refresh token internally.");
+    }
+
+    @Test
+    void testRefreshSkippedWhenTokenStillValid() {
+        // Arrange: token issued 1 minute ago, expires in 9 minutes (10% elapsed of 10-min
+        // lifetime)
+        String accessToken = "providedAccessToken";
+        long now = System.currentTimeMillis();
+        long iat = (now - 60_000) / 1000; // 1 minute ago
+        long exp = (now + 9 * 60_000) / 1000; // 9 minutes from now
+        String jwtToken = buildFakeJwt(iat, exp);
+
+        DefaultOAuth2AccessToken tokenWithJwt = new DefaultOAuth2AccessToken(jwtToken);
+        tokenWithJwt.setExpiration(new Date(exp * 1000));
+        tokenWithJwt.setRefreshToken(new DefaultOAuth2RefreshToken("existingRefreshToken"));
+        serviceDelegate.currentAccessToken = tokenWithJwt;
+
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(true);
+        when(configuration.getRefreshTokenLifetimeFraction()).thenReturn(0.8);
+
+        // Act
+        SessionToken sessionToken = serviceDelegate.refresh(null, jwtToken);
+
+        // Assert: no IDP call, returns current token with skip warning
+        assertNotNull(sessionToken);
+        assertEquals(jwtToken, sessionToken.getAccessToken());
+        assertNotNull(sessionToken.getWarning());
+        assertTrue(sessionToken.getWarning().contains("Token still valid; refresh skipped."));
+
+        // Verify no exchange was attempted
+        verify(restTemplate, never())
+                .exchange(
+                        anyString(),
+                        any(HttpMethod.class),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessToken.class));
+    }
+
+    @Test
+    void testRefreshProceedsWhenTokenNearExpiry() {
+        // Arrange: token issued 9 minutes ago, expires in 1 minute (90% elapsed)
+        String refreshToken = "providedRefreshToken";
+        String accessToken = "providedAccessToken";
+        long now = System.currentTimeMillis();
+        long iat = (now - 9 * 60_000) / 1000; // 9 minutes ago
+        long exp = (now + 60_000) / 1000; // 1 minute from now
+        String jwtToken = buildFakeJwt(iat, exp);
+
+        DefaultOAuth2AccessToken tokenWithJwt = new DefaultOAuth2AccessToken(jwtToken);
+        tokenWithJwt.setExpiration(new Date(exp * 1000));
+        tokenWithJwt.setRefreshToken(new DefaultOAuth2RefreshToken(refreshToken));
+        serviceDelegate.currentAccessToken = tokenWithJwt;
+
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(true);
+        when(configuration.getRefreshTokenLifetimeFraction()).thenReturn(0.8);
+
+        // Mock a successful refresh response
+        DefaultOAuth2AccessToken newAccessToken = new DefaultOAuth2AccessToken("newAccessToken");
+        newAccessToken.setRefreshToken(new DefaultOAuth2RefreshToken("newRefreshToken"));
+        newAccessToken.setExpiration(new Date(System.currentTimeMillis() + 7200_000));
+        ResponseEntity<OAuth2AccessToken> responseEntity =
+                new ResponseEntity<>(newAccessToken, HttpStatus.OK);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessToken.class)))
+                .thenReturn(responseEntity);
+
+        // Act
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, jwtToken);
+
+        // Assert: IDP refresh happened, new token returned
+        assertNotNull(sessionToken);
+        assertEquals("newAccessToken", sessionToken.getAccessToken());
+
+        // Verify exchange was called
+        verify(restTemplate, atLeastOnce())
+                .exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessToken.class));
+    }
+
+    @Test
+    void testRefreshSkipDisabledByConfig() {
+        // Arrange: token with plenty of remaining life, but skip is disabled
+        String refreshToken = "providedRefreshToken";
+        long now = System.currentTimeMillis();
+        long iat = (now - 60_000) / 1000;
+        long exp = (now + 9 * 60_000) / 1000;
+        String jwtToken = buildFakeJwt(iat, exp);
+
+        DefaultOAuth2AccessToken tokenWithJwt = new DefaultOAuth2AccessToken(jwtToken);
+        tokenWithJwt.setExpiration(new Date(exp * 1000));
+        tokenWithJwt.setRefreshToken(new DefaultOAuth2RefreshToken(refreshToken));
+        serviceDelegate.currentAccessToken = tokenWithJwt;
+
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(false);
+
+        // Mock a successful refresh response
+        DefaultOAuth2AccessToken newAccessToken = new DefaultOAuth2AccessToken("newAccessToken");
+        newAccessToken.setRefreshToken(new DefaultOAuth2RefreshToken("newRefreshToken"));
+        newAccessToken.setExpiration(new Date(System.currentTimeMillis() + 7200_000));
+        ResponseEntity<OAuth2AccessToken> responseEntity =
+                new ResponseEntity<>(newAccessToken, HttpStatus.OK);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessToken.class)))
+                .thenReturn(responseEntity);
+
+        // Act
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, jwtToken);
+
+        // Assert: IDP refresh happened even though token has plenty of life
+        assertNotNull(sessionToken);
+        assertEquals("newAccessToken", sessionToken.getAccessToken());
+        verify(restTemplate, atLeastOnce())
+                .exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessToken.class));
+    }
+
+    @Test
+    void testRefreshSkipFallbackWithoutIat() {
+        // Arrange: token without iat claim, but with >5 min remaining → skip
+        String accessToken = "providedAccessToken";
+        long now = System.currentTimeMillis();
+        long exp = (now + 10 * 60_000) / 1000; // 10 minutes from now
+        String jwtToken = buildFakeJwtExpOnly(exp);
+
+        DefaultOAuth2AccessToken tokenWithJwt = new DefaultOAuth2AccessToken(jwtToken);
+        tokenWithJwt.setExpiration(new Date(exp * 1000));
+        tokenWithJwt.setRefreshToken(new DefaultOAuth2RefreshToken("existingRefreshToken"));
+        serviceDelegate.currentAccessToken = tokenWithJwt;
+
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(true);
+        when(configuration.getRefreshTokenLifetimeFraction()).thenReturn(0.8);
+
+        // Act
+        SessionToken sessionToken = serviceDelegate.refresh(null, jwtToken);
+
+        // Assert: skipped because >5 min remaining (fallback threshold)
+        assertNotNull(sessionToken);
+        assertEquals(jwtToken, sessionToken.getAccessToken());
+        assertNotNull(sessionToken.getWarning());
+        assertTrue(sessionToken.getWarning().contains("Token still valid; refresh skipped."));
+        verify(restTemplate, never())
+                .exchange(
+                        anyString(),
+                        any(HttpMethod.class),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessToken.class));
+    }
+
+    /**
+     * Builds a fake unsigned JWT with both iat and exp claims. The format is
+     * base64(header).base64(payload).signature — Spring's JwtHelper.decode() can parse this.
+     */
+    private String buildFakeJwt(long iatEpochSeconds, long expEpochSeconds) {
+        String header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
+        String payload =
+                "{\"sub\":\"testuser\",\"iat\":"
+                        + iatEpochSeconds
+                        + ",\"exp\":"
+                        + expEpochSeconds
+                        + "}";
+        return Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(header.getBytes(StandardCharsets.UTF_8))
+                + "."
+                + Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(payload.getBytes(StandardCharsets.UTF_8))
+                + ".";
+    }
+
+    /** Builds a fake unsigned JWT with only an exp claim (no iat). */
+    private String buildFakeJwtExpOnly(long expEpochSeconds) {
+        String header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
+        String payload = "{\"sub\":\"testuser\",\"exp\":" + expEpochSeconds + "}";
+        return Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(header.getBytes(StandardCharsets.UTF_8))
+                + "."
+                + Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(payload.getBytes(StandardCharsets.UTF_8))
+                + ".";
     }
 
     /** Test subclass of OAuth2SessionServiceDelegate for testing purposes. */


### PR DESCRIPTION
## Summary

Cherry-pick of #485 (backport of #465 fix) to the `2.5.x` release branch.

- Replace Guava cache with Caffeine for per-entry token expiration based on the token's actual `exp` claim
- Use plain `RestTemplate` for token refresh to avoid `UserRedirectRequiredException`

Fixes #465

## Test plan
- [ ] CI build passes
- [ ] Existing `RefreshTokenServiceTest` passes with updated assertions