### PR TITLE
Applied user and groups namelike filter sql normalization only for db searches (#483).

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/UserDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/UserDAOImpl.java
@@ -19,18 +19,20 @@
  */
 package it.geosolutions.geostore.core.dao.impl;
 
+import com.googlecode.genericdao.search.Filter;
 import com.googlecode.genericdao.search.ISearch;
 import it.geosolutions.geostore.core.dao.UserDAO;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
 import it.geosolutions.geostore.core.model.UserGroup;
 import it.geosolutions.geostore.core.security.password.PwEncoder;
-import java.util.List;
-import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.Hibernate;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * Class UserDAOImpl.
@@ -75,15 +77,28 @@ public class UserDAOImpl extends BaseDAO<User, Long> implements UserDAO {
         return super.findAll();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see com.trg.dao.jpa.GenericDAOImpl#search(com.trg.search.ISearch)
-     */
     @SuppressWarnings("unchecked")
     @Override
     public List<User> search(ISearch search) {
+
+        List<Filter> filters = search.getFilters();
+
+        if (filters.stream().anyMatch(this::hasLikeToStringOperator)) {
+            return super.search(createNormalizedSearchForSql(search));
+        }
+
         return super.search(search);
+    }
+
+    @Override
+    public int count(ISearch search) {
+        List<Filter> filters = search.getFilters();
+
+        if (filters.stream().anyMatch(this::hasLikeToStringOperator)) {
+            return super.count(createNormalizedSearchForSql(search));
+        }
+
+        return super.count(search);
     }
 
     /*

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/UserDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/UserDAOImpl.java
@@ -19,7 +19,6 @@
  */
 package it.geosolutions.geostore.core.dao.impl;
 
-import com.googlecode.genericdao.search.Filter;
 import com.googlecode.genericdao.search.ISearch;
 import it.geosolutions.geostore.core.dao.UserDAO;
 import it.geosolutions.geostore.core.model.User;
@@ -80,25 +79,12 @@ public class UserDAOImpl extends BaseDAO<User, Long> implements UserDAO {
     @SuppressWarnings("unchecked")
     @Override
     public List<User> search(ISearch search) {
-
-        List<Filter> filters = search.getFilters();
-
-        if (filters.stream().anyMatch(this::hasLikeToStringOperator)) {
-            return super.search(createNormalizedSearchForSql(search));
-        }
-
-        return super.search(search);
+        return super.search(normalizeSearchForSql(search));
     }
 
     @Override
     public int count(ISearch search) {
-        List<Filter> filters = search.getFilters();
-
-        if (filters.stream().anyMatch(this::hasLikeToStringOperator)) {
-            return super.count(createNormalizedSearchForSql(search));
-        }
-
-        return super.count(search);
+        return super.count(normalizeSearchForSql(search));
     }
 
     /*

--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/UserGroupDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/UserGroupDAOImpl.java
@@ -19,7 +19,6 @@
  */
 package it.geosolutions.geostore.core.dao.impl;
 
-import com.googlecode.genericdao.search.Filter;
 import com.googlecode.genericdao.search.ISearch;
 import com.googlecode.genericdao.search.Search;
 import it.geosolutions.geostore.core.dao.UserGroupDAO;
@@ -107,25 +106,12 @@ public class UserGroupDAOImpl extends BaseDAO<UserGroup, Long> implements UserGr
     @SuppressWarnings("unchecked")
     @Override
     public List<UserGroup> search(ISearch search) {
-
-        List<Filter> filters = search.getFilters();
-
-        if (filters.stream().anyMatch(this::hasLikeToStringOperator)) {
-            return super.search(createNormalizedSearchForSql(search));
-        }
-
-        return super.search(search);
+        return super.search(normalizeSearchForSql(search));
     }
 
     @Override
     public int count(ISearch search) {
-        List<Filter> filters = search.getFilters();
-
-        if (filters.stream().anyMatch(this::hasLikeToStringOperator)) {
-            return super.count(createNormalizedSearchForSql(search));
-        }
-
-        return super.count(search);
+        return super.count(normalizeSearchForSql(search));
     }
 
     /*

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/RESTExtJsService.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/RESTExtJsService.java
@@ -170,7 +170,7 @@ public interface RESTExtJsService {
      * Search for groups by name and return paginated results.
      *
      * @param sc security context
-     * @param nameLike a substring in the name
+     * @param nameLike pattern to match the name. Supports wildcard ('*').
      * @param start the n-th group shown as first in results.
      * @param limit max entries per page
      * @param all if <code>true</code> return also 'everyone' group

--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
@@ -491,12 +491,11 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
         }
 
         try {
-            String sqlNameLike = convertNameLikeToSqlSyntax(nameLike);
-            List<User> users = userService.getAll(page, limit, sqlNameLike, includeAttributes);
+            List<User> users = userService.getAll(page, limit, nameLike, includeAttributes);
 
             long count = 0;
             if (users != null && !users.isEmpty()) {
-                count = userService.getCount(sqlNameLike);
+                count = userService.getCount(nameLike);
             }
 
             return new ExtUserList(count, users);
@@ -538,13 +537,12 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
         }
 
         try {
-            String sqlNameLike = convertNameLikeToSqlSyntax(nameLike);
             List<UserGroup> groups =
-                    groupService.getAllAllowed(authUser, page, limit, sqlNameLike, all);
+                    groupService.getAllAllowed(authUser, page, limit, nameLike, all);
 
             long count = 0;
             if (groups != null && !groups.isEmpty()) {
-                count = groupService.getCount(authUser, sqlNameLike, all);
+                count = groupService.getCount(authUser, nameLike, all);
             }
 
             return new ExtGroupList(count, groups);

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/ServiceTestBase.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/ServiceTestBase.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import it.geosolutions.geostore.core.dao.ResourceDAO;
 import it.geosolutions.geostore.core.dao.UserDAO;
+import it.geosolutions.geostore.core.dao.UserGroupDAO;
 import it.geosolutions.geostore.core.model.Category;
 import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.core.model.SecurityRule;
@@ -94,6 +95,7 @@ public abstract class ServiceTestBase {
 
     protected static ResourceDAO resourceDAO;
     protected static UserDAO userDAO;
+    protected static UserGroupDAO userGroupDAO;
 
     protected static ClassPathXmlApplicationContext ctx = null;
     protected final Logger LOGGER = LogManager.getLogger(getClass());
@@ -124,6 +126,7 @@ public abstract class ServiceTestBase {
 
                 resourceDAO = (ResourceDAO) ctx.getBean("resourceDAO");
                 userDAO = (UserDAO) ctx.getBean("userDAO");
+                userGroupDAO = (UserGroupDAO) ctx.getBean("userGroupDAO");
             }
         }
     }
@@ -156,6 +159,7 @@ public abstract class ServiceTestBase {
 
         assertNotNull(resourceDAO);
         assertNotNull(userDAO);
+        assertNotNull(userGroupDAO);
     }
 
     protected void removeAll()
@@ -233,6 +237,9 @@ public abstract class ServiceTestBase {
     }
 
     private void removeAllUserGroup() throws BadRequestServiceEx, NotFoundServiceEx {
+
+        userGroupService.removeSpecialUsersGroups();
+
         List<UserGroup> list = userGroupService.getAll(null, null);
         for (UserGroup item : list) {
             LOGGER.info("Removing User: " + item.getGroupName());


### PR DESCRIPTION
These changes fix https://github.com/geosolutions-it/geostore/issues/483.

Searching for users or groups with `nameLike` parameter required normalization of the `*` wildcard to `%` while prior searching in the database. This prevented correct group searches in LDAP direct configuration.
With these changes, the normalization has been moved to be applied only in db searches.