### PR TITLE
Made group filter match also security rule groupname. (#480)

### DIFF
--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/AssociatedEntityFilter.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/AssociatedEntityFilter.java
@@ -19,6 +19,7 @@
  */
 package it.geosolutions.geostore.services.dto.search;
 
+import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
 import it.geosolutions.geostore.services.exception.InternalErrorServiceEx;
 import java.io.Serializable;
@@ -30,7 +31,7 @@ import javax.xml.bind.annotation.XmlElement;
 
 /**
  * {@link SearchFilter} implementation that represent a filter by name on a {@link
- * it.geosolutions.geostore.core.model.Resource}-associated entity.
+ * Resource}-associated entity.
  */
 public abstract class AssociatedEntityFilter extends SearchFilter implements Serializable {
 
@@ -45,9 +46,9 @@ public abstract class AssociatedEntityFilter extends SearchFilter implements Ser
     private SearchOperator operator;
     private List<String> values;
 
-    public AssociatedEntityFilter() {}
+    protected AssociatedEntityFilter() {}
 
-    public AssociatedEntityFilter(String names, SearchOperator operator) {
+    protected AssociatedEntityFilter(String names, SearchOperator operator) {
         setOperator(operator);
         setNames(names);
     }

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/FilterVisitor.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/FilterVisitor.java
@@ -37,6 +37,8 @@ public interface FilterVisitor {
 
     void visit(AssociatedEntityFilter filter);
 
+    void visit(GroupFilter filter);
+
     void visit(FieldFilter filter) throws InternalErrorServiceEx;
 
     void visit(NotFilter filter) throws BadRequestServiceEx, InternalErrorServiceEx;

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/GroupFilter.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/dto/search/GroupFilter.java
@@ -19,6 +19,8 @@
  */
 package it.geosolutions.geostore.services.dto.search;
 
+import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
+import it.geosolutions.geostore.services.exception.InternalErrorServiceEx;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /** Filter by group name */
@@ -34,5 +36,14 @@ public class GroupFilter extends AssociatedEntityFilter {
     @Override
     public String property() {
         return "security.group.groupName";
+    }
+
+    public String additionalProperty() {
+        return "security.groupname";
+    }
+
+    @Override
+    public void accept(FilterVisitor visitor) throws BadRequestServiceEx, InternalErrorServiceEx {
+        visitor.visit(this);
     }
 }

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/util/SearchConverter.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/util/SearchConverter.java
@@ -28,6 +28,7 @@ import it.geosolutions.geostore.services.dto.search.AttributeFilter;
 import it.geosolutions.geostore.services.dto.search.CategoryFilter;
 import it.geosolutions.geostore.services.dto.search.FieldFilter;
 import it.geosolutions.geostore.services.dto.search.FilterVisitor;
+import it.geosolutions.geostore.services.dto.search.GroupFilter;
 import it.geosolutions.geostore.services.dto.search.NotFilter;
 import it.geosolutions.geostore.services.dto.search.OrFilter;
 import it.geosolutions.geostore.services.dto.search.SearchFilter;
@@ -108,9 +109,6 @@ public class SearchConverter implements FilterVisitor {
 
     private SearchConverter() {}
 
-    /*
-     * (non-Javadoc) @see it.geosolutions.geostore.services.dto.search.FilterVisitor#visit(it.geosolutions.geostore.services.dto.search.AndFilter)
-     */
     @Override
     public void visit(AndFilter filter) throws BadRequestServiceEx, InternalErrorServiceEx {
         trgFilter = Filter.and();
@@ -120,6 +118,27 @@ public class SearchConverter implements FilterVisitor {
             searchFilter.accept(sc);
             trgFilter.add(sc.trgFilter);
         }
+    }
+
+    @Override
+    public void visit(OrFilter filter) throws BadRequestServiceEx, InternalErrorServiceEx {
+        trgFilter = Filter.or();
+
+        for (SearchFilter searchFilter : filter.getFilters()) {
+            SearchConverter sc = new SearchConverter();
+            searchFilter.accept(sc);
+            trgFilter.add(sc.trgFilter);
+        }
+    }
+
+    @Override
+    public void visit(NotFilter filter) throws BadRequestServiceEx, InternalErrorServiceEx {
+        SearchFilter notFilter = filter.getFilter();
+
+        SearchConverter sc = new SearchConverter();
+        notFilter.accept(sc);
+
+        trgFilter = Filter.not(sc.trgFilter);
     }
 
     /**
@@ -136,14 +155,10 @@ public class SearchConverter implements FilterVisitor {
                 && (filter.getOperator() != null)
                 && (filter.getValue() != null)) {
 
-            Integer trg_op = ops_rest_trg.get(filter.getOperator());
-
-            if (trg_op == null) {
-                throw new IllegalStateException("Unknown op " + filter.getOperator());
-            }
+            Integer op = calculateOperator(filter.getOperator());
 
             String fieldValueName;
-            Object value = null;
+            Object value;
 
             switch (filter.getType()) {
                 case DATE:
@@ -182,7 +197,7 @@ public class SearchConverter implements FilterVisitor {
                             "attribute",
                             Filter.and(
                                     Filter.equal("name", filter.getName()),
-                                    new Filter(fieldValueName, value, trg_op)));
+                                    new Filter(fieldValueName, value, op)));
 
         } else {
             throw new BadRequestServiceEx("Bad payload. One or more field are missing");
@@ -202,14 +217,10 @@ public class SearchConverter implements FilterVisitor {
 
         Filter f = new Filter();
 
-        Integer op = ops_rest_trg.get(filter.getOperator());
-
-        if (op == null) {
-            throw new IllegalStateException("Unknown op " + filter.getOperator());
-        }
+        Integer operator = calculateOperator(filter.getOperator());
 
         f.setProperty(property);
-        f.setOperator(op);
+        f.setOperator(operator);
 
         if (type == Date.class) {
             try {
@@ -240,14 +251,10 @@ public class SearchConverter implements FilterVisitor {
     public void visit(CategoryFilter filter) {
         CategoryFilter.checkOperator(filter.getOperator());
 
-        Integer op = ops_rest_trg.get(filter.getOperator());
-
-        if (op == null) {
-            throw new IllegalStateException("Unknown op " + filter.getOperator());
-        }
+        Integer operator = calculateOperator(filter.getOperator());
 
         Filter f = new Filter();
-        f.setOperator(op);
+        f.setOperator(operator);
         f.setProperty("category.name");
         f.setValue(filter.getName());
 
@@ -260,48 +267,52 @@ public class SearchConverter implements FilterVisitor {
         SearchOperator searchOperator = filter.getOperator();
         List<String> values = filter.values();
 
-        Integer operator = ops_rest_trg.get(searchOperator);
-        if (operator == null) {
-            throw new IllegalStateException("Unknown op " + searchOperator);
-        }
+        Integer operator = calculateOperator(searchOperator);
 
         Filter f = new Filter();
         f.setOperator(operator);
         f.setProperty(filter.property());
-
-        if (SearchOperator.IN == searchOperator) {
-            f.setValue(values);
-        } else {
-            f.setValue(values.get(0));
-        }
+        f.setValue(calculateOperatorValue(searchOperator, values));
 
         trgFilter = f;
     }
 
-    /*
-     * (non-Javadoc) @see it.geosolutions.geostore.services.dto.search.FilterVisitor#visit(it.geosolutions.geostore.services.dto.search.NotFilter)
-     */
     @Override
-    public void visit(NotFilter filter) throws BadRequestServiceEx, InternalErrorServiceEx {
-        SearchFilter notFilter = filter.getFilter();
+    public void visit(GroupFilter filter) {
 
-        SearchConverter sc = new SearchConverter();
-        notFilter.accept(sc);
+        SearchOperator searchOperator = filter.getOperator();
+        List<String> values = filter.values();
 
-        trgFilter = Filter.not(sc.trgFilter);
+        int operator = calculateOperator(searchOperator);
+
+        Object value = calculateOperatorValue(searchOperator, values);
+
+        Filter propertyFilter = new Filter();
+        propertyFilter.setOperator(operator);
+        propertyFilter.setProperty(filter.property());
+        propertyFilter.setValue(value);
+
+        Filter additionalPropertyFilter = new Filter();
+        additionalPropertyFilter.setOperator(operator);
+        additionalPropertyFilter.setProperty(filter.additionalProperty());
+        additionalPropertyFilter.setValue(value);
+
+        trgFilter = Filter.or(propertyFilter, additionalPropertyFilter);
     }
 
-    /*
-     * (non-Javadoc) @see it.geosolutions.geostore.services.dto.search.FilterVisitor#visit(it.geosolutions.geostore.services.dto.search.OrFilter)
-     */
-    @Override
-    public void visit(OrFilter filter) throws BadRequestServiceEx, InternalErrorServiceEx {
-        trgFilter = Filter.or();
+    private Integer calculateOperator(SearchOperator filter) {
+        Integer operator = ops_rest_trg.get(filter);
+        if (operator == null) {
+            throw new IllegalStateException("Unknown op " + filter);
+        }
+        return operator;
+    }
 
-        for (SearchFilter searchFilter : filter.getFilters()) {
-            SearchConverter sc = new SearchConverter();
-            searchFilter.accept(sc);
-            trgFilter.add(sc.trgFilter);
+    private Object calculateOperatorValue(SearchOperator searchOperator, List<String> values) {
+        if (SearchOperator.IN == searchOperator) {
+            return values;
+        } else {
+            return values.get(0);
         }
     }
 }

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourceServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourceServiceImplTest.java
@@ -31,6 +31,7 @@ import it.geosolutions.geostore.services.dto.ShortResource;
 import it.geosolutions.geostore.services.dto.search.BaseField;
 import it.geosolutions.geostore.services.dto.search.CategoryFilter;
 import it.geosolutions.geostore.services.dto.search.FieldFilter;
+import it.geosolutions.geostore.services.dto.search.GroupFilter;
 import it.geosolutions.geostore.services.dto.search.SearchFilter;
 import it.geosolutions.geostore.services.dto.search.SearchOperator;
 import it.geosolutions.geostore.services.exception.DuplicatedResourceNameServiceEx;
@@ -326,6 +327,63 @@ public class ResourceServiceImplTest extends ServiceTestBase {
 
         {
             SearchFilter filter = new CategoryFilter("cat%", SearchOperator.LIKE);
+            List<ShortResource> list =
+                    resourceService.getShortResources(
+                            ResourceSearchParameters.builder()
+                                    .filter(filter)
+                                    .authUser(buildFakeAdminUser())
+                                    .build());
+            assertEquals(3, list.size());
+        }
+    }
+
+    public void testGroupFilter() throws Exception {
+
+        String ownerGroupName = "owner_group_name";
+        String groupName = "group_name";
+
+        long groupId = createGroup(ownerGroupName);
+
+        SecurityRule securityRuleGroupOwner = new SecurityRule();
+        securityRuleGroupOwner.setGroup(userGroupService.get(groupId));
+
+        SecurityRule securityRuleGroupName = new SecurityRule();
+        securityRuleGroupName.setGroupname(groupName);
+
+        SecurityRule securityRuleOwnerAndName = new SecurityRule();
+        securityRuleOwnerAndName.setGroup(userGroupService.get(groupId));
+        securityRuleOwnerAndName.setGroupname(groupName);
+
+        createResource("group", "des0", "cat0", List.of(securityRuleGroupOwner));
+        createResource("name", "des1", "cat1", List.of(securityRuleGroupName));
+        createResource("group_and_name", "des2", "cat2", List.of(securityRuleOwnerAndName));
+
+        {
+            SearchFilter filter = new GroupFilter(ownerGroupName, SearchOperator.EQUAL_TO);
+            List<ShortResource> list =
+                    resourceService.getShortResources(
+                            ResourceSearchParameters.builder()
+                                    .filter(filter)
+                                    .authUser(buildFakeAdminUser())
+                                    .build());
+            assertEquals(2, list.size());
+            assertTrue(list.stream().noneMatch(r -> r.getName().equals("name")));
+        }
+
+        {
+            SearchFilter filter = new GroupFilter(groupName, SearchOperator.EQUAL_TO);
+            List<ShortResource> list =
+                    resourceService.getShortResources(
+                            ResourceSearchParameters.builder()
+                                    .filter(filter)
+                                    .authUser(buildFakeAdminUser())
+                                    .build());
+            assertEquals(2, list.size());
+            assertTrue(list.stream().noneMatch(r -> r.getName().equals("group")));
+        }
+
+        {
+            SearchFilter filter = new GroupFilter("%group%", SearchOperator.LIKE);
             List<ShortResource> list =
                     resourceService.getShortResources(
                             ResourceSearchParameters.builder()

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ServiceTestBase.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ServiceTestBase.java
@@ -21,6 +21,7 @@ package it.geosolutions.geostore.services;
 
 import it.geosolutions.geostore.core.dao.IpRangeDAO;
 import it.geosolutions.geostore.core.dao.ResourceDAO;
+import it.geosolutions.geostore.core.dao.SecurityDAO;
 import it.geosolutions.geostore.core.dao.TagDAO;
 import it.geosolutions.geostore.core.model.Category;
 import it.geosolutions.geostore.core.model.IPRange;
@@ -76,6 +77,8 @@ public abstract class ServiceTestBase extends TestCase {
 
     protected static ResourcePermissionService resourcePermissionService;
 
+    protected static SecurityDAO securityDAO;
+
     protected static ResourceDAO resourceDAO;
 
     protected static TagDAO tagDAO;
@@ -104,6 +107,7 @@ public abstract class ServiceTestBase extends TestCase {
                 ipRangeService = (IPRangeService) ctx.getBean("ipRangeService");
                 resourcePermissionService =
                         (ResourcePermissionService) ctx.getBean("resourcePermissionService");
+                securityDAO = (SecurityDAO) ctx.getBean("securityDAO");
                 resourceDAO = (ResourceDAO) ctx.getBean("resourceDAO");
                 tagDAO = (TagDAO) ctx.getBean("tagDAO");
                 ipRangeDAO = (IpRangeDAO) ctx.getBean("ipRangeDAO");


### PR DESCRIPTION
These changes fix https://github.com/geosolutions-it/geostore/issues/480.

Searching for resources with group filter (`<GROUP>`) was only matching the filter name with the resource owner usergroup.
With these changes, group filtering now considers also the name of the group in a OR condition with the actual usergroup that owns the resource.