### PR TITLE
Fixed resource permission check for guest user. ( #502)

### DIFF
--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
@@ -8,12 +8,11 @@ import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserGroup;
 import it.geosolutions.geostore.core.model.enums.Role;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiPredicate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ResourcePermissionServiceImpl implements ResourcePermissionService {
 
@@ -21,13 +20,15 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
 
     private final BiPredicate<SecurityRule, User> resourceUserOwnership =
             (rule, user) ->
-                    rule.getUser() != null && (user.getId().equals(rule.getUser().getId()))
-                    || user.getName() != null && user.getName().equals(rule.getUsername());
+                    rule.getUsername() != null && rule.getUsername().equals(user.getName())
+                            || rule.getUser() != null
+                                    && rule.getUser().getId().equals(user.getId());
 
     private final BiPredicate<SecurityRule, UserGroup> resourceGroupOwnership =
             (rule, group) ->
-                    rule.getGroup() != null && (group.getId().equals(rule.getGroup().getId()))
-                    || group.getGroupName() != null && group.getGroupName().equals(rule.getGroupname());
+                    rule.getGroupname() != null && rule.getGroupname().equals(group.getGroupName())
+                            || rule.getGroup() != null
+                                    && rule.getGroup().getId().equals(group.getId());
 
     private final BiPredicate<SecurityRule, User> resourceUserIPAccess =
             (rule, user) -> isUserIPAllowed(user, rule.getIpRanges());
@@ -61,8 +62,8 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
 
     private boolean canUserAccessWithReadPermission(Resource resource, User user) {
         return hasUserOwnershipWithReadPermission(user, resource)
-               || haveUserGroupsOwnershipWithReadPermission(user, resource)
-               || hasUserAccessByIpWithReadPermission(user, resource);
+                || haveUserGroupsOwnershipWithReadPermission(user, resource)
+                || hasUserAccessByIpWithReadPermission(user, resource);
     }
 
     private boolean hasUserOwnershipWithReadPermission(User user, Resource resource) {
@@ -83,8 +84,8 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
     @Override
     public boolean canResourceBeWrittenByUser(Resource resource, User user) {
         if (user.getRole() != null
-            && !user.getRole().equals(Role.GUEST)
-            && user.getRole().equals(Role.ADMIN)) {
+                && !user.getRole().equals(Role.GUEST)
+                && user.getRole().equals(Role.ADMIN)) {
             return true;
         }
         checkResourceSecurityRules(resource);
@@ -100,8 +101,8 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
 
     private boolean canUserAccessWithWritePermission(Resource resource, User user) {
         return hasUserOwnershipWithWritePermission(user, resource)
-               || haveUserGroupsOwnershipWithWritePermission(user, resource)
-               || hasUserAccessByIpWithWritePermission(user, resource);
+                || haveUserGroupsOwnershipWithWritePermission(user, resource)
+                || hasUserAccessByIpWithWritePermission(user, resource);
     }
 
     private boolean hasUserOwnershipWithWritePermission(User user, Resource resource) {

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourcePermissionServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourcePermissionServiceImplTest.java
@@ -28,6 +28,7 @@ import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.GroupReservedNames;
 import it.geosolutions.geostore.core.model.enums.Role;
 import java.util.Collections;
 import java.util.List;
@@ -45,14 +46,14 @@ public class ResourcePermissionServiceImplTest {
     }
 
     @Test
-    public void testCanReadByUsernameMatch() {
+    public void testCanReadByUserNameMatch() {
         // Create a user with name "alice" and a dummy ID
         User user = new User();
         user.setId(100L);
         user.setName("alice");
         user.setRole(Role.USER);
 
-        // Create a security rule: mismatch on user ID, but match on username
+        // Create a security rule: mismatch on user ID, but match on user's name
         SecurityRule rule = new SecurityRule();
         User ruleUser = new User();
         ruleUser.setId(999L);
@@ -63,14 +64,36 @@ public class ResourcePermissionServiceImplTest {
         Resource resource = new Resource();
         resource.setSecurity(Collections.singletonList(rule));
 
-        // Assert that read is allowed via username matching
+        // Assert that read is allowed via user's name matching
+        assertTrue(
+                "User should have read access via user's name match",
+                service.canResourceBeReadByUser(resource, user));
+    }
+
+    @Test
+    public void testCanReadByRuleUsernameMatch() {
+        // Create a user with name "alice" and a dummy ID
+        User user = new User();
+        user.setId(-1L);
+        user.setName("alice");
+        user.setRole(Role.USER);
+
+        // Create a security rule: match on rule username
+        SecurityRule rule = new SecurityRule();
+        rule.setUsername("alice");
+        rule.setCanRead(true);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(rule));
+
+        // Assert that read is allowed via rule username matching
         assertTrue(
                 "User should have read access via username match",
                 service.canResourceBeReadByUser(resource, user));
     }
 
     @Test
-    public void testCanReadByGroupnameMatch() {
+    public void testCanReadByGroupNameMatch() {
         // Create a user and assign to a group named "editors"
         UserGroup group = new UserGroup();
         group.setId(10L);
@@ -82,7 +105,7 @@ public class ResourcePermissionServiceImplTest {
         user.setRole(Role.USER);
         user.setGroups(Collections.singleton(group));
 
-        // Create a security rule: mismatch on group ID, but match on groupname
+        // Create a security rule: mismatch on group ID, but match on group's name
         SecurityRule rule = new SecurityRule();
         UserGroup ruleGroup = new UserGroup();
         ruleGroup.setId(888L);
@@ -93,9 +116,62 @@ public class ResourcePermissionServiceImplTest {
         Resource resource = new Resource();
         resource.setSecurity(Collections.singletonList(rule));
 
-        // Assert that read is allowed via groupname matching
+        // Assert that read is allowed via group's name matching
         assertTrue(
-                "User should have read access via groupname match",
+                "User should have read access via group's name match",
+                service.canResourceBeReadByUser(resource, user));
+    }
+
+    @Test
+    public void testCanReadByRuleGroupnameMatch() {
+        // Create a user and assign to a group named "editors"
+        UserGroup group = new UserGroup();
+        group.setId(-1L);
+        group.setGroupName("editors");
+
+        User user = new User();
+        user.setId(-1L);
+        user.setName("bob");
+        user.setRole(Role.USER);
+        user.setGroups(Collections.singleton(group));
+
+        // Create a security rule: match on rule groupname
+        SecurityRule rule = new SecurityRule();
+        rule.setGroupname("editors");
+        rule.setCanRead(true);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(rule));
+
+        // Assert that read is allowed via rule groupname matching
+        assertTrue(
+                "User should have read access via group name match",
+                service.canResourceBeReadByUser(resource, user));
+    }
+
+    @Test
+    public void testGuestCanReadEveryoneResource() {
+        UserGroup group = new UserGroup();
+        group.setId(-1L);
+        group.setGroupName(GroupReservedNames.EVERYONE.groupName());
+
+        User user = new User();
+        user.setId(null);
+        user.setName("guest");
+        user.setRole(Role.GUEST);
+        user.setGroups(Collections.singleton(group));
+
+        // Create a security rule: match on rule groupname
+        SecurityRule rule = new SecurityRule();
+        rule.setGroupname(GroupReservedNames.EVERYONE.groupName());
+        rule.setCanRead(true);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(rule));
+
+        // Assert that read is allowed via rule groupname matching
+        assertTrue(
+                "User should have read access via everyone group match",
                 service.canResourceBeReadByUser(resource, user));
     }
 


### PR DESCRIPTION
These changes fix https://github.com/geosolutions-it/geostore/issues/502.

Since with LDAP direct configuration the guest user is given `null` as id, the resource permission check was failing with a NPE exception.
The fix consist in reordering the validations checks to avoid checking the user ID if rule matching should be done by rule username or groupname.