### PR TITLE
Fixed canwrite check based on dummy ids.

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/ExternalSecurityDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/ExternalSecurityDAOImpl.java
@@ -26,7 +26,6 @@ import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserGroup;
 import it.geosolutions.geostore.core.model.enums.Role;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,9 +89,7 @@ public class ExternalSecurityDAOImpl extends SecurityDAOImpl {
         return fillFromNames(super.search(search));
     }
 
-    /**
-     * Add security filtering in order to filter out resources the user has not read access to
-     */
+    /** Add security filtering in order to filter out resources the user has not read access to */
     @Override
     public void addReadSecurityConstraints(Search searchCriteria, User user) {
         // no further constraints for admin user
@@ -180,7 +177,7 @@ public class ExternalSecurityDAOImpl extends SecurityDAOImpl {
                 filledRule.setUsername(rule.getUsername());
                 if (rule.getUser() == null) {
                     User user = new User();
-                    user.setId(-1L);
+                    user.setId(null);
                     user.setEnabled(true);
                     user.setName(rule.getUsername());
                     filledRule.setUser(user);
@@ -190,7 +187,7 @@ public class ExternalSecurityDAOImpl extends SecurityDAOImpl {
                 filledRule.setGroupname(rule.getGroupname());
                 if (rule.getGroup() == null) {
                     UserGroup group = new UserGroup();
-                    group.setId(-1L);
+                    group.setId(null);
                     group.setEnabled(true);
                     group.setGroupName(rule.getGroupname());
                     filledRule.setGroup(group);

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
@@ -22,12 +22,14 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
             (rule, user) ->
                     rule.getUsername() != null && rule.getUsername().equals(user.getName())
                             || rule.getUser() != null
+                                    && rule.getUser().getId() != null
                                     && rule.getUser().getId().equals(user.getId());
 
     private final BiPredicate<SecurityRule, UserGroup> resourceGroupOwnership =
             (rule, group) ->
                     rule.getGroupname() != null && rule.getGroupname().equals(group.getGroupName())
                             || rule.getGroup() != null
+                                    && rule.getGroup().getId() != null
                                     && rule.getGroup().getId().equals(group.getId());
 
     private final BiPredicate<SecurityRule, User> resourceUserIPAccess =

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourcePermissionServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourcePermissionServiceImplTest.java
@@ -93,6 +93,32 @@ public class ResourcePermissionServiceImplTest {
     }
 
     @Test
+    public void testCannotWriteByRuleFilledUserId() {
+        // LDAP direct user
+        User user = new User();
+        user.setId(-1L);
+        user.setName("alice");
+        user.setRole(Role.USER);
+
+        // with external security, security rules contain a dummy user
+        User filledUser = new User();
+        filledUser.setId(null);
+        filledUser.setName("admin");
+        SecurityRule filledRule = new SecurityRule();
+        filledRule.setCanRead(true);
+        filledRule.setCanWrite(true);
+        filledRule.setUser(filledUser);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(filledRule));
+
+        // Assert that read is NOT allowed
+        assertFalse(
+                "User shouldn't have write access",
+                service.canResourceBeWrittenByUser(resource, filledUser));
+    }
+
+    @Test
     public void testCanReadByGroupNameMatch() {
         // Create a user and assign to a group named "editors"
         UserGroup group = new UserGroup();
@@ -147,6 +173,37 @@ public class ResourcePermissionServiceImplTest {
         assertTrue(
                 "User should have read access via group name match",
                 service.canResourceBeReadByUser(resource, user));
+    }
+
+    @Test
+    public void testCannotWriteByRuleFilledGroupId() {
+        // LDAP direct group
+        UserGroup group = new UserGroup();
+        group.setId(-1L);
+        group.setGroupName("group");
+
+        User user = new User();
+        user.setId(-1L);
+        user.setName("bob");
+        user.setRole(Role.USER);
+        user.setGroups(Collections.singleton(group));
+
+        // with external security, security rules contain a dummy group
+        UserGroup filledGroup = new UserGroup();
+        filledGroup.setId(null);
+        filledGroup.setGroupName("admins");
+        SecurityRule filledRule = new SecurityRule();
+        filledRule.setCanRead(true);
+        filledRule.setCanWrite(true);
+        filledRule.setGroup(filledGroup);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(filledRule));
+
+        // Assert that read is NOT allowed
+        assertFalse(
+                "User shouldn't have write access",
+                service.canResourceBeWrittenByUser(resource, user));
     }
 
     @Test


### PR DESCRIPTION
These changes fix https://github.com/geosolutions-it/geostore/issues/506.

### Situation
With LDAP direct configuration the `ExternalSecutityDAO` was adding to each resource security rule, a placeholder user and group.
These placeholder entities have as names the rule `username` and `groupname`, to reproduce the rules retrieved from the database.
Not only the names were set, but also the ids, with a `-1` value that **_coincidentally_** matches with the id of all users in the LDAP direct context. 
This caused the rules to match by id and therefore having a `canwrite` permission wrongly set to `true` for the resource.

### Solution
The fix consists in replacing `-1` value with `null` as the ids for placeholder user and group in rules, and making the permission check avoids checking ids if they are null.