### PR TITLE
[Backport 2.4.x] Fixed canwrite check based on dummy ids.

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/ExternalSecurityDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/ExternalSecurityDAOImpl.java
@@ -26,7 +26,6 @@ import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserGroup;
 import it.geosolutions.geostore.core.model.enums.Role;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,9 +89,7 @@ public class ExternalSecurityDAOImpl extends SecurityDAOImpl {
         return fillFromNames(super.search(search));
     }
 
-    /**
-     * Add security filtering in order to filter out resources the user has not read access to
-     */
+    /** Add security filtering in order to filter out resources the user has not read access to */
     @Override
     public void addReadSecurityConstraints(Search searchCriteria, User user) {
         // no further constraints for admin user
@@ -180,7 +177,7 @@ public class ExternalSecurityDAOImpl extends SecurityDAOImpl {
                 filledRule.setUsername(rule.getUsername());
                 if (rule.getUser() == null) {
                     User user = new User();
-                    user.setId(-1L);
+                    user.setId(null);
                     user.setEnabled(true);
                     user.setName(rule.getUsername());
                     filledRule.setUser(user);
@@ -190,7 +187,7 @@ public class ExternalSecurityDAOImpl extends SecurityDAOImpl {
                 filledRule.setGroupname(rule.getGroupname());
                 if (rule.getGroup() == null) {
                     UserGroup group = new UserGroup();
-                    group.setId(-1L);
+                    group.setId(null);
                     group.setEnabled(true);
                     group.setGroupName(rule.getGroupname());
                     filledRule.setGroup(group);

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
@@ -8,12 +8,11 @@ import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserGroup;
 import it.geosolutions.geostore.core.model.enums.Role;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiPredicate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ResourcePermissionServiceImpl implements ResourcePermissionService {
 
@@ -21,15 +20,6 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
 
     private final BiPredicate<SecurityRule, User> resourceUserOwnership =
             (rule, user) ->
-<<<<<<< HEAD
-                    rule.getUser() != null && (user.getId().equals(rule.getUser().getId()))
-                    || user.getName() != null && user.getName().equals(rule.getUsername());
-
-    private final BiPredicate<SecurityRule, UserGroup> resourceGroupOwnership =
-            (rule, group) ->
-                    rule.getGroup() != null && (group.getId().equals(rule.getGroup().getId()))
-                    || group.getGroupName() != null && group.getGroupName().equals(rule.getGroupname());
-=======
                     rule.getUsername() != null && rule.getUsername().equals(user.getName())
                             || rule.getUser() != null
                                     && rule.getUser().getId() != null
@@ -41,7 +31,6 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
                             || rule.getGroup() != null
                                     && rule.getGroup().getId() != null
                                     && rule.getGroup().getId().equals(group.getId());
->>>>>>> 6f5763d (Fixed canwrite check based on dummy ids. (#507))
 
     private final BiPredicate<SecurityRule, User> resourceUserIPAccess =
             (rule, user) -> isUserIPAllowed(user, rule.getIpRanges());

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/ResourcePermissionServiceImpl.java
@@ -21,6 +21,7 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
 
     private final BiPredicate<SecurityRule, User> resourceUserOwnership =
             (rule, user) ->
+<<<<<<< HEAD
                     rule.getUser() != null && (user.getId().equals(rule.getUser().getId()))
                     || user.getName() != null && user.getName().equals(rule.getUsername());
 
@@ -28,6 +29,19 @@ public class ResourcePermissionServiceImpl implements ResourcePermissionService 
             (rule, group) ->
                     rule.getGroup() != null && (group.getId().equals(rule.getGroup().getId()))
                     || group.getGroupName() != null && group.getGroupName().equals(rule.getGroupname());
+=======
+                    rule.getUsername() != null && rule.getUsername().equals(user.getName())
+                            || rule.getUser() != null
+                                    && rule.getUser().getId() != null
+                                    && rule.getUser().getId().equals(user.getId());
+
+    private final BiPredicate<SecurityRule, UserGroup> resourceGroupOwnership =
+            (rule, group) ->
+                    rule.getGroupname() != null && rule.getGroupname().equals(group.getGroupName())
+                            || rule.getGroup() != null
+                                    && rule.getGroup().getId() != null
+                                    && rule.getGroup().getId().equals(group.getId());
+>>>>>>> 6f5763d (Fixed canwrite check based on dummy ids. (#507))
 
     private final BiPredicate<SecurityRule, User> resourceUserIPAccess =
             (rule, user) -> isUserIPAllowed(user, rule.getIpRanges());

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourcePermissionServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourcePermissionServiceImplTest.java
@@ -28,6 +28,7 @@ import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.GroupReservedNames;
 import it.geosolutions.geostore.core.model.enums.Role;
 import java.util.Collections;
 import java.util.List;
@@ -45,14 +46,14 @@ public class ResourcePermissionServiceImplTest {
     }
 
     @Test
-    public void testCanReadByUsernameMatch() {
+    public void testCanReadByUserNameMatch() {
         // Create a user with name "alice" and a dummy ID
         User user = new User();
         user.setId(100L);
         user.setName("alice");
         user.setRole(Role.USER);
 
-        // Create a security rule: mismatch on user ID, but match on username
+        // Create a security rule: mismatch on user ID, but match on user's name
         SecurityRule rule = new SecurityRule();
         User ruleUser = new User();
         ruleUser.setId(999L);
@@ -63,16 +64,35 @@ public class ResourcePermissionServiceImplTest {
         Resource resource = new Resource();
         resource.setSecurity(Collections.singletonList(rule));
 
-        // Assert that read is allowed via username matching
+        // Assert that read is allowed via user's name matching
+        assertTrue(
+                "User should have read access via user's name match",
+                service.canResourceBeReadByUser(resource, user));
+    }
+
+    @Test
+    public void testCanReadByRuleUsernameMatch() {
+        // Create a user with name "alice" and a dummy ID
+        User user = new User();
+        user.setId(-1L);
+        user.setName("alice");
+        user.setRole(Role.USER);
+
+        // Create a security rule: match on rule username
+        SecurityRule rule = new SecurityRule();
+        rule.setUsername("alice");
+        rule.setCanRead(true);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(rule));
+
+        // Assert that read is allowed via rule username matching
         assertTrue(
                 "User should have read access via username match",
                 service.canResourceBeReadByUser(resource, user));
     }
 
     @Test
-<<<<<<< HEAD
-    public void testCanReadByGroupnameMatch() {
-=======
     public void testCannotWriteByRuleFilledUserId() {
         // LDAP direct user
         User user = new User();
@@ -100,7 +120,6 @@ public class ResourcePermissionServiceImplTest {
 
     @Test
     public void testCanReadByGroupNameMatch() {
->>>>>>> 6f5763d (Fixed canwrite check based on dummy ids. (#507))
         // Create a user and assign to a group named "editors"
         UserGroup group = new UserGroup();
         group.setId(10L);
@@ -112,7 +131,7 @@ public class ResourcePermissionServiceImplTest {
         user.setRole(Role.USER);
         user.setGroups(Collections.singleton(group));
 
-        // Create a security rule: mismatch on group ID, but match on groupname
+        // Create a security rule: mismatch on group ID, but match on group's name
         SecurityRule rule = new SecurityRule();
         UserGroup ruleGroup = new UserGroup();
         ruleGroup.setId(888L);
@@ -123,11 +142,8 @@ public class ResourcePermissionServiceImplTest {
         Resource resource = new Resource();
         resource.setSecurity(Collections.singletonList(rule));
 
-        // Assert that read is allowed via groupname matching
+        // Assert that read is allowed via group's name matching
         assertTrue(
-<<<<<<< HEAD
-                "User should have read access via groupname match",
-=======
                 "User should have read access via group's name match",
                 service.canResourceBeReadByUser(resource, user));
     }
@@ -213,7 +229,6 @@ public class ResourcePermissionServiceImplTest {
         // Assert that read is allowed via rule groupname matching
         assertTrue(
                 "User should have read access via everyone group match",
->>>>>>> 6f5763d (Fixed canwrite check based on dummy ids. (#507))
                 service.canResourceBeReadByUser(resource, user));
     }
 

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourcePermissionServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/ResourcePermissionServiceImplTest.java
@@ -70,7 +70,37 @@ public class ResourcePermissionServiceImplTest {
     }
 
     @Test
+<<<<<<< HEAD
     public void testCanReadByGroupnameMatch() {
+=======
+    public void testCannotWriteByRuleFilledUserId() {
+        // LDAP direct user
+        User user = new User();
+        user.setId(-1L);
+        user.setName("alice");
+        user.setRole(Role.USER);
+
+        // with external security, security rules contain a dummy user
+        User filledUser = new User();
+        filledUser.setId(null);
+        filledUser.setName("admin");
+        SecurityRule filledRule = new SecurityRule();
+        filledRule.setCanRead(true);
+        filledRule.setCanWrite(true);
+        filledRule.setUser(filledUser);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(filledRule));
+
+        // Assert that read is NOT allowed
+        assertFalse(
+                "User shouldn't have write access",
+                service.canResourceBeWrittenByUser(resource, filledUser));
+    }
+
+    @Test
+    public void testCanReadByGroupNameMatch() {
+>>>>>>> 6f5763d (Fixed canwrite check based on dummy ids. (#507))
         // Create a user and assign to a group named "editors"
         UserGroup group = new UserGroup();
         group.setId(10L);
@@ -95,7 +125,95 @@ public class ResourcePermissionServiceImplTest {
 
         // Assert that read is allowed via groupname matching
         assertTrue(
+<<<<<<< HEAD
                 "User should have read access via groupname match",
+=======
+                "User should have read access via group's name match",
+                service.canResourceBeReadByUser(resource, user));
+    }
+
+    @Test
+    public void testCanReadByRuleGroupnameMatch() {
+        // Create a user and assign to a group named "editors"
+        UserGroup group = new UserGroup();
+        group.setId(-1L);
+        group.setGroupName("editors");
+
+        User user = new User();
+        user.setId(-1L);
+        user.setName("bob");
+        user.setRole(Role.USER);
+        user.setGroups(Collections.singleton(group));
+
+        // Create a security rule: match on rule groupname
+        SecurityRule rule = new SecurityRule();
+        rule.setGroupname("editors");
+        rule.setCanRead(true);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(rule));
+
+        // Assert that read is allowed via rule groupname matching
+        assertTrue(
+                "User should have read access via group name match",
+                service.canResourceBeReadByUser(resource, user));
+    }
+
+    @Test
+    public void testCannotWriteByRuleFilledGroupId() {
+        // LDAP direct group
+        UserGroup group = new UserGroup();
+        group.setId(-1L);
+        group.setGroupName("group");
+
+        User user = new User();
+        user.setId(-1L);
+        user.setName("bob");
+        user.setRole(Role.USER);
+        user.setGroups(Collections.singleton(group));
+
+        // with external security, security rules contain a dummy group
+        UserGroup filledGroup = new UserGroup();
+        filledGroup.setId(null);
+        filledGroup.setGroupName("admins");
+        SecurityRule filledRule = new SecurityRule();
+        filledRule.setCanRead(true);
+        filledRule.setCanWrite(true);
+        filledRule.setGroup(filledGroup);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(filledRule));
+
+        // Assert that read is NOT allowed
+        assertFalse(
+                "User shouldn't have write access",
+                service.canResourceBeWrittenByUser(resource, user));
+    }
+
+    @Test
+    public void testGuestCanReadEveryoneResource() {
+        UserGroup group = new UserGroup();
+        group.setId(-1L);
+        group.setGroupName(GroupReservedNames.EVERYONE.groupName());
+
+        User user = new User();
+        user.setId(null);
+        user.setName("guest");
+        user.setRole(Role.GUEST);
+        user.setGroups(Collections.singleton(group));
+
+        // Create a security rule: match on rule groupname
+        SecurityRule rule = new SecurityRule();
+        rule.setGroupname(GroupReservedNames.EVERYONE.groupName());
+        rule.setCanRead(true);
+
+        Resource resource = new Resource();
+        resource.setSecurity(Collections.singletonList(rule));
+
+        // Assert that read is allowed via rule groupname matching
+        assertTrue(
+                "User should have read access via everyone group match",
+>>>>>>> 6f5763d (Fixed canwrite check based on dummy ids. (#507))
                 service.canResourceBeReadByUser(resource, user));
     }
 


### PR DESCRIPTION
# Description
Backport of #507 to `2.4.x`.

Fixes #506