### PR TITLE
Fix ldap group listing

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/ldap/impl/UserGroupDAOImpl.java
@@ -144,6 +144,9 @@ public class UserGroupDAOImpl extends LdapBaseDAOImpl implements UserGroupDAO {
     /**
      * This search limits the results by the user's groups.
      *
+     * <p>LDAP search is performed only for ADMIN role. USER role gets groups from the user object
+     * only.
+     *
      * <p>This implementation filters user groups only by <code>groupName ILIKE</code> if present in
      * the <code>search</code> parameter.
      */
@@ -162,8 +165,6 @@ public class UserGroupDAOImpl extends LdapBaseDAOImpl implements UserGroupDAO {
         if (userGroups == null) {
             return Set.of();
         }
-
-        userGroups.add(createEveryoneGroup(userGroups.size() + 1));
 
         return applyGroupNameFilter(userGroups, search);
     }

--- a/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/UserGroupDAOTest.java
+++ b/src/core/persistence/src/test/java/it/geosolutions/geostore/core/dao/ldap/UserGroupDAOTest.java
@@ -66,9 +66,6 @@ public class UserGroupDAOTest extends BaseDAOTest {
         UserGroupDAOImpl userGroupDAO =
                 new UserGroupDAOImpl(new MockContextSource(buildContextForGroups()));
 
-        userGroupDAO.setSearchBase("ou=groups");
-        userGroupDAO.setAddEveryOneGroup(true);
-
         Set<String> userRoles = Set.of("USER", "MANAGER", "EDITOR");
 
         User user = new User();
@@ -87,9 +84,7 @@ public class UserGroupDAOTest extends BaseDAOTest {
 
         List<UserGroup> groups = userGroupDAO.searchByUser(user, new Search());
 
-        assertEquals(4, groups.size());
-
-        assertTrue(groups.stream().anyMatch(g -> g.getGroupName().equals("everyone")));
+        assertEquals(3, groups.size());
 
         List<String> groupsNames =
                 groups.stream().map(UserGroup::getGroupName).collect(Collectors.toList());
@@ -133,9 +128,6 @@ public class UserGroupDAOTest extends BaseDAOTest {
         UserGroupDAOImpl userGroupDAO =
                 new UserGroupDAOImpl(new MockContextSource(buildContextForGroups()));
 
-        userGroupDAO.setSearchBase("ou=groups");
-        userGroupDAO.setAddEveryOneGroup(true);
-
         Set<String> userRoles = Set.of("USER", "USERS", "EDITOR");
 
         User user = new User();
@@ -156,9 +148,7 @@ public class UserGroupDAOTest extends BaseDAOTest {
 
         List<UserGroup> groups = userGroupDAO.searchByUser(user, filteredSearch);
 
-        assertEquals(4, groups.size());
-
-        assertTrue(groups.stream().anyMatch(g -> g.getGroupName().equals("everyone")));
+        assertEquals(3, groups.size());
 
         List<String> groupsNames =
                 groups.stream().map(UserGroup::getGroupName).collect(Collectors.toList());


### PR DESCRIPTION
Follow-up on https://github.com/geosolutions-it/geostore/pull/514, #517 

The addition of the everyone group in LDAP direct is made in the authentication filter, so it was not needed from the dao.

Still fixes https://github.com/geosolutions-it/geostore/issues/483 .