### PR TITLE
Set canCopy to false if user is a guest.

### DIFF
--- a/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
+++ b/src/modules/rest/extjs/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImpl.java
@@ -396,12 +396,17 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
 
     private ExtResource convertToExtResource(Resource resource, User user) {
 
-        ExtResource.Builder extResourceBuilder =
-                ExtResource.builder(resource)
-                        /* setting copy permission as in ResourceEnvelop.isCanCopy */
-                        .withCanCopy(user != null);
+        if (user == null) {
+            throw new InternalErrorWebEx("user should not be null");
+        }
 
-        if (user != null && hasUserEditAndDeletePermissionsOnResource(user, resource)) {
+        ExtResource.Builder extResourceBuilder = ExtResource.builder(resource);
+
+        if (isUserNotAGuest(user)) {
+            extResourceBuilder.withCanCopy(true);
+        }
+
+        if (hasUserEditAndDeletePermissionsOnResource(user, resource)) {
             extResourceBuilder.withCanEdit(true).withCanDelete(true);
         }
 
@@ -694,7 +699,7 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
         ShortResource shortResource = new ShortResource(resource);
 
         if (resourcePermissionService.canResourceBeReadByUser(resource, user)) {
-            shortResource.setCanCopy(true);
+            shortResource.setCanCopy(isUserNotAGuest(user));
         } else {
             throw new ForbiddenErrorWebEx("Resource is protected");
         }
@@ -715,6 +720,10 @@ public class RESTExtJsServiceImpl extends RESTServiceImpl implements RESTExtJsSe
                 .withTagList(createTagList(resource.getTags()))
                 .withIsFavorite(isResourceUserFavorite(resource, user))
                 .build();
+    }
+
+    private boolean isUserNotAGuest(User user) {
+        return Role.GUEST != user.getRole();
     }
 
     private ShortAttributeList createShortAttributeList(List<Attribute> attributes) {

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
@@ -1792,6 +1792,70 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
     }
 
     @Test
+    public void testExtResourcesList_canCopyWhenGuest() throws Exception {
+        final String CAT0_NAME = "CAT000";
+
+        long groupId = createGroup("group");
+        UserGroup group = userGroupService.get(groupId);
+
+        long adminId = restCreateUser("admin", Role.ADMIN, null, "admin");
+        SecurityContext adminSecurityContext = new SimpleSecurityContext(adminId);
+
+        long userId = restCreateUser("_guest", Role.GUEST, Collections.singleton(group), "guest");
+        SecurityContext guestSecurityContext = new SimpleSecurityContext(userId);
+
+        createCategory(CAT0_NAME);
+
+        long resourceId = restCreateResource("everyone_resource", "", CAT0_NAME, adminId, true);
+
+        SecurityRule everyoneGroupSecurityRule = new SecurityRule();
+        everyoneGroupSecurityRule.setCanRead(true);
+        everyoneGroupSecurityRule.setCanWrite(true);
+        everyoneGroupSecurityRule.setGroup(group);
+        restResourceService.updateSecurityRules(
+                adminSecurityContext,
+                resourceId,
+                new SecurityRuleList(Collections.singletonList(everyoneGroupSecurityRule)));
+
+        {
+            ExtResourceList response =
+                    restExtJsService.getExtResourcesList(
+                            adminSecurityContext,
+                            0,
+                            100,
+                            new Sort("", ""),
+                            false,
+                            false,
+                            false,
+                            false,
+                            new AndFilter());
+
+            List<ExtResource> resources = response.getList();
+            assertEquals(1, resources.size());
+            ExtResource resource = resources.get(0);
+            assertTrue(resource.isCanCopy());
+        }
+        {
+            ExtResourceList response =
+                    restExtJsService.getExtResourcesList(
+                            guestSecurityContext,
+                            0,
+                            100,
+                            new Sort("", ""),
+                            false,
+                            false,
+                            false,
+                            false,
+                            new AndFilter());
+
+            List<ExtResource> resources = response.getList();
+            assertEquals(1, resources.size());
+            ExtResource resource = resources.get(0);
+            assertFalse(resource.isCanCopy());
+        }
+    }
+
+    @Test
     public void testGetExtResource_withoutSecurityInformation() throws Exception {
         final String CAT0_NAME = "CAT000";
 
@@ -2524,6 +2588,46 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
                     restExtJsService.getExtResource(
                             userSecurityContext, nonFavoriteResourceId, false, false, true);
             assertFalse(response.isFavorite());
+        }
+    }
+
+    @Test
+    public void testGetExtResource_canCopyWhenGuest() throws Exception {
+        final String CAT0_NAME = "CAT000";
+
+        long groupId = createGroup("group");
+        UserGroup group = userGroupService.get(groupId);
+
+        long adminId = restCreateUser("admin", Role.ADMIN, null, "admin");
+        SecurityContext adminSecurityContext = new SimpleSecurityContext(adminId);
+
+        long userId = restCreateUser("_guest", Role.GUEST, Collections.singleton(group), "guest");
+        SecurityContext guestSecurityContext = new SimpleSecurityContext(userId);
+
+        createCategory(CAT0_NAME);
+
+        long resourceId = restCreateResource("everyone_resource", "", CAT0_NAME, adminId, true);
+
+        SecurityRule everyoneGroupSecurityRule = new SecurityRule();
+        everyoneGroupSecurityRule.setCanRead(true);
+        everyoneGroupSecurityRule.setCanWrite(true);
+        everyoneGroupSecurityRule.setGroup(group);
+        restResourceService.updateSecurityRules(
+                adminSecurityContext,
+                resourceId,
+                new SecurityRuleList(Collections.singletonList(everyoneGroupSecurityRule)));
+
+        {
+            ExtShortResource response =
+                    restExtJsService.getExtResource(
+                            adminSecurityContext, resourceId, false, false, true);
+            assertTrue(response.isCanCopy());
+        }
+        {
+            ExtShortResource response =
+                    restExtJsService.getExtResource(
+                            guestSecurityContext, resourceId, false, false, true);
+            assertFalse(response.isCanCopy());
         }
     }
 

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTResourceServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTResourceServiceImpl.java
@@ -581,6 +581,9 @@ public class RESTResourceServiceImpl extends RESTServiceImpl implements RESTReso
 
     @Override
     public SecurityRuleList getSecurityRules(SecurityContext sc, long resourceId) {
+        /* TODO: check if the following checks are really needed to return the security rule list.
+         * Seems that can be avoided with resourcePermissionService.canResourceBeWrittenByUser
+         */
         //
         // Authorization check.
         //


### PR DESCRIPTION
This changes fix #452 .

The `canCopy` flag was set differently whether searching for the list of resources or a single resource.
In the first case it was dependent on the read permission for the resource, while in the second it was just a `user!=null` check to be set to `true`.

Now `canCopy` is set to `true` only if the user is not a guest.