### PR TITLE
Restore OAuth2 / OIDC / LDAP security layer on Spring Security 7

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,10 @@
 name: Integration tests
 
 # Runs the REST integration suite (.github/scripts/run-integration-tests.ps1)
-# against a standalone jetty:run backend on port 9191. OIDC/OAuth2 paths are
-# intentionally NOT exercised — that stack was removed in PR #529 and will be
-# reintroduced via Spring Security 7 oauth2-client in a follow-up.
+# against a standalone jetty:run backend on port 9191. This suite covers the
+# non-OIDC REST API surface. The OIDC/OAuth2 stack (restored on Spring Security 7)
+# is exercised end-to-end against a real Keycloak by KeycloakLifecycleTest
+# (Testcontainers) in the main CI build (CI.yml).
 
 on:
   push:

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
@@ -21,6 +21,8 @@ public abstract class IdPConfiguration implements BeanNameAware {
 
     protected Role authenticatedDefaultRole;
 
+    protected String authenticatedDefaultGroup;
+
     /**
      * @return true if the filter to which this configuration object refers is enabled. False
      *     otherwise.
@@ -112,5 +114,20 @@ public abstract class IdPConfiguration implements BeanNameAware {
     public void setAuthenticatedDefaultRole(String authenticatedDefaultRole) {
         if (StringUtils.isNotBlank(authenticatedDefaultRole))
             this.authenticatedDefaultRole = Role.valueOf(authenticatedDefaultRole);
+    }
+
+    /**
+     * Optional group assigned when no group could be derived from the IdP claims (the groups claim
+     * is missing, or every value was dropped by groupMappings/dropUnmapped). Created on the fly
+     * when it does not exist. Blank or unset disables the fallback.
+     *
+     * @return the fallback group name, or null when not configured.
+     */
+    public String getAuthenticatedDefaultGroup() {
+        return authenticatedDefaultGroup;
+    }
+
+    public void setAuthenticatedDefaultGroup(String authenticatedDefaultGroup) {
+        this.authenticatedDefaultGroup = authenticatedDefaultGroup;
     }
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
@@ -1,6 +1,9 @@
 package it.geosolutions.geostore.services.rest.security;
 
 import it.geosolutions.geostore.core.model.enums.Role;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.BeanNameAware;
 
@@ -21,7 +24,7 @@ public abstract class IdPConfiguration implements BeanNameAware {
 
     protected Role authenticatedDefaultRole;
 
-    protected String authenticatedDefaultGroup;
+    protected List<String> defaultGroups = Collections.emptyList();
 
     /**
      * @return true if the filter to which this configuration object refers is enabled. False
@@ -117,17 +120,29 @@ public abstract class IdPConfiguration implements BeanNameAware {
     }
 
     /**
-     * Optional group assigned when no group could be derived from the IdP claims (the groups claim
-     * is missing, or every value was dropped by groupMappings/dropUnmapped). Created on the fly
-     * when it does not exist. Blank or unset disables the fallback.
+     * Optional groups always assigned to the authenticated user, in addition to the ones derived
+     * from the IdP claims. They are not subject to groupMappings/dropUnmapped and are created on
+     * the fly when they do not exist.
      *
-     * @return the fallback group name, or null when not configured.
+     * @return the configured default group names; never null, empty when not configured.
      */
-    public String getAuthenticatedDefaultGroup() {
-        return authenticatedDefaultGroup;
+    public List<String> getDefaultGroups() {
+        return defaultGroups;
     }
 
-    public void setAuthenticatedDefaultGroup(String authenticatedDefaultGroup) {
-        this.authenticatedDefaultGroup = authenticatedDefaultGroup;
+    /** @param defaultGroups comma-separated list of group names; blank entries are discarded. */
+    public void setDefaultGroups(String defaultGroups) {
+        if (StringUtils.isBlank(defaultGroups)) {
+            this.defaultGroups = Collections.emptyList();
+            return;
+        }
+        List<String> parsed = new ArrayList<>();
+        for (String name : defaultGroups.split(",")) {
+            String trimmed = name.trim();
+            if (!trimmed.isEmpty()) {
+                parsed.add(trimmed);
+            }
+        }
+        this.defaultGroups = parsed;
     }
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/TokenAuthenticationCache.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/TokenAuthenticationCache.java
@@ -1,0 +1,216 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2022 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
+import it.geosolutions.geostore.services.rest.security.oauth2.TokenDetails;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * A cache for OAuth2 Authentication object. Authentication instances are identified by the
+ * corresponding accessToken. Uses per-entry expiration based on the token's actual expiry time.
+ */
+public class TokenAuthenticationCache implements ApplicationContextAware {
+
+    private static final Logger LOGGER = LogManager.getLogger(TokenAuthenticationCache.class);
+    private final Cache<String, Authentication> cache;
+    private final long defaultExpirationNanos;
+    private ApplicationContext context;
+
+    public TokenAuthenticationCache() {
+        this(1000, 480);
+    }
+
+    public TokenAuthenticationCache(int cacheSize, int cacheExpirationMinutes) {
+        this.defaultExpirationNanos = TimeUnit.MINUTES.toNanos(cacheExpirationMinutes);
+        this.cache =
+                Caffeine.newBuilder()
+                        .maximumSize(cacheSize)
+                        .expireAfter(
+                                new Expiry<String, Authentication>() {
+                                    @Override
+                                    public long expireAfterCreate(
+                                            String key, Authentication value, long currentTime) {
+                                        return computeExpirationNanos(value);
+                                    }
+
+                                    @Override
+                                    public long expireAfterUpdate(
+                                            String key,
+                                            Authentication value,
+                                            long currentTime,
+                                            @NonNegative long currentDuration) {
+                                        return computeExpirationNanos(value);
+                                    }
+
+                                    @Override
+                                    public long expireAfterRead(
+                                            String key,
+                                            Authentication value,
+                                            long currentTime,
+                                            @NonNegative long currentDuration) {
+                                        return currentDuration;
+                                    }
+                                })
+                        .evictionListener(
+                                (key, authentication, cause) -> {
+                                    if (cause == RemovalCause.EXPIRED && authentication != null) {
+                                        revokeAuthIfRefreshExpired(authentication);
+                                    }
+                                })
+                        .recordStats()
+                        .build();
+    }
+
+    private long computeExpirationNanos(Authentication authentication) {
+        TokenDetails details = OAuth2Utils.getTokenDetails(authentication);
+        if (details != null && details.getAccessToken() != null) {
+            Instant exp = details.getAccessToken().getExpiresAt();
+            if (exp != null) {
+                long remainingMs = exp.toEpochMilli() - System.currentTimeMillis();
+                if (remainingMs > 0) {
+                    return TimeUnit.MILLISECONDS.toNanos(remainingMs);
+                }
+            }
+        }
+        return defaultExpirationNanos;
+    }
+
+    /**
+     * Perform a revoke authorization when the cache entry expires.
+     *
+     * @param authentication the authentication object.
+     */
+    protected void revokeAuthIfRefreshExpired(Authentication authentication) {
+        TokenDetails tokenDetails = OAuth2Utils.getTokenDetails(authentication);
+        if (tokenDetails != null && tokenDetails.getAccessToken() != null) {
+            OAuth2AccessToken accessToken = tokenDetails.getAccessToken();
+            OAuth2RefreshToken refreshToken = tokenDetails.getRefreshToken();
+            // Only expiring refresh tokens trigger a remote revoke (mirrors the legacy
+            // ExpiringOAuth2RefreshToken instanceof check: a refresh token without an expiry was a
+            // plain DefaultOAuth2RefreshToken and was never revoked here).
+            if (refreshToken != null && refreshToken.getExpiresAt() != null) {
+                OAuth2Configuration configuration =
+                        (OAuth2Configuration) context.getBean(tokenDetails.getProvider());
+                if (configuration != null && configuration.isEnabled()) {
+                    if (refreshToken.getExpiresAt().isAfter(Instant.now())) {
+                        OAuth2Configuration.Endpoint revokeEndpoint =
+                                configuration.buildRevokeEndpoint(
+                                        refreshToken.getTokenValue(),
+                                        accessToken.getTokenValue(),
+                                        configuration);
+                        if (revokeEndpoint != null) {
+                            RestTemplate template = new RestTemplate();
+                            ResponseEntity<String> responseEntity =
+                                    template.exchange(
+                                            revokeEndpoint.getUrl(),
+                                            revokeEndpoint.getMethod(),
+                                            null,
+                                            String.class);
+                            if (responseEntity.getStatusCode().value() != 200) {
+                                LOGGER.error(
+                                        "Error while revoking authorization. Error is: {}",
+                                        responseEntity.getBody());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieve the authentication by its accessToken value.
+     *
+     * @param accessToken the accessToken.
+     * @return the Authentication identified by the token if present. Null otherwise.
+     */
+    public Authentication get(String accessToken) {
+        return cache.asMap().get(accessToken);
+    }
+
+    /**
+     * Put an Authentication instance identified by an accessToken value. If the passed
+     * Authentication instance does not have a refresh token, and we have an old one that has, the
+     * refresh Token is set to the new instance.
+     *
+     * @param accessToken the access token identifying the instance to update
+     * @param authentication the Authentication to cache.
+     * @return the Authentication cached.
+     */
+    public Authentication putCacheEntry(String accessToken, Authentication authentication) {
+        Authentication old = get(accessToken);
+        TokenDetails oldDetails = OAuth2Utils.getTokenDetails(old);
+        if (oldDetails != null) {
+            TokenDetails newDetails = OAuth2Utils.getTokenDetails(authentication);
+            if (newDetails != null
+                    && newDetails.getRefreshToken() == null
+                    && oldDetails.getRefreshToken() != null) {
+                newDetails.setRefreshToken(oldDetails.getRefreshToken());
+            }
+        }
+
+        this.cache.put(accessToken, authentication);
+        return authentication;
+    }
+
+    /**
+     * Remove an authentication from the cache.
+     *
+     * @param accessToken the accessToken identifying the authentication to remove.
+     */
+    public void removeEntry(String accessToken) {
+        this.cache.invalidate(accessToken);
+    }
+
+    public Cache<String, Authentication> getCache() {
+        return cache;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.context = applicationContext;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2-group-role-sync.md
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2-group-role-sync.md
@@ -1,0 +1,209 @@
+# OAuth2 / OIDC — User, Role and Group Synchronization
+
+This document describes how GeoStore synchronizes the authenticated user's role and group
+memberships from OAuth2/OIDC token claims on every login.
+
+The behavior is implemented in `OAuth2GeoStoreAuthenticationService` and applies to **all
+OAuth2/OIDC providers** (Keycloak, Azure AD, Google, etc.).
+
+---
+
+## Overview
+
+After a successful token exchange, GeoStore:
+
+1. Resolves the **principal** (username) from the token.
+2. Looks up or auto-creates the **user** in the local DB.
+3. Reads **role** and **group** claims from the token.
+4. Synchronizes the user's DB role and group memberships to match the claims.
+5. Persists the updated user.
+
+---
+
+## Configuration properties (`geostore-ovr.properties`)
+
+| Property | Default | Description |
+|---|---|---|
+| `rolesClaim` | _(none)_ | JWT claim name that contains the user's roles (e.g. `roles`, `realm_access.roles`) |
+| `groupsClaim` | _(none)_ | JWT claim name that contains the user's groups (e.g. `groups`) |
+| `roleMappings` | _(none)_ | Comma-separated `TOKENROLE=GEOSTOREROLE` pairs to rename roles |
+| `dropUnmapped` | `false` | If `true`, roles/groups not present in the mapping are discarded |
+| `defaultGroups` | _(none)_ | Comma-separated group names always assigned on login, regardless of token claims |
+| `authenticatedDefaultRole` | `USER` | Role assigned when `rolesClaim` is configured but missing from the token |
+| `autoCreateUser` | `true` | Whether to auto-create a DB user on first login |
+| `groupNamesUppercase` | `false` | Normalize group names to uppercase before DB lookup/creation |
+
+---
+
+## Role synchronization
+
+### Claim resolution order
+
+`syncRoleFromClaims` tries to read `rolesClaim` from:
+
+1. Primary token (ID token for OIDC, access token for plain OAuth2)
+2. Access token (fallback — Keycloak puts `realm_access.roles` here)
+3. Userinfo map (response from `/userinfo` endpoint)
+
+### Role mapping
+
+If `roleMappings` is configured, each role string from the token is looked up in the map
+(case-insensitive key). If found, the mapped name replaces the original.
+
+If `dropUnmapped=true`, roles not in the mapping are silently discarded before comparison.
+If `dropUnmapped=false` (default), unmapped roles are kept as-is.
+
+### Role resolution (`computeRole`)
+
+After mapping, GeoStore compares each role string against its own `Role` enum:
+
+- matches `ADMIN` (case-insensitive) → role is **ADMIN** (returned immediately)
+- matches `USER` → role is at least **USER**
+- matches `GUEST` → role is at least **GUEST**
+- no match → falls through to default
+
+The highest role wins. If no roles match, `authenticatedDefaultRole` is used (default: `USER`).
+
+### Edge cases
+
+| Situation | Result |
+|---|---|
+| `rolesClaim` not configured | Current DB role preserved |
+| `rolesClaim` configured, claim missing from token | `authenticatedDefaultRole` applied |
+| Token contains `ADMIN` | User gets `ADMIN` immediately |
+
+---
+
+## Group synchronization
+
+### Claim resolution order
+
+`resolveStringListClaimWithFallback` tries to read `groupsClaim` from:
+
+1. Primary token
+2. Access token (fallback)
+3. Userinfo map
+
+### Group mapping
+
+Same `groupMappings` / `dropUnmapped` logic as roles.
+
+### Default groups
+
+Groups listed in `defaultGroups` are processed **after** `reconcileRemoteGroups`, in a
+separate step. They are not subject to `groupMappings` or `dropUnmapped`, and are created
+and assigned even when the token carries no groups at all.
+
+### Reconciliation with DB (`reconcileRemoteGroups`)
+
+GeoStore tracks which groups belong to each OAuth2 provider via the `sourceService` group
+attribute. On every login it reconciles only groups tagged with the current provider:
+
+| Situation | Action |
+|---|---|
+| Group in token, exists in DB, already assigned | No-op |
+| Group in token, exists in DB, not yet assigned | Assign to user |
+| Group in token, **not** in DB | Create group (with `sourceService=<provider>`) then assign |
+| Group **not** in token, assigned, tagged for this provider | Deassign from user |
+| Group not in token, assigned, tagged for a **different** provider | Left untouched |
+| Group not in token, assigned manually (no `sourceService`) | Left untouched |
+
+> Group creation and assignment only happen when `autoCreateUser=true` and
+> `userGroupService` is available.
+
+---
+
+## Examples
+
+### Example 1 — First login, no claims configured
+
+**Setup:** `rolesClaim` and `groupsClaim` not set.
+
+**Result:** User created with role `USER`, no groups assigned.
+
+---
+
+### Example 2 — Role from token
+
+**Setup:**
+```properties
+rolesClaim=roles
+```
+Token contains `"roles": ["ADMIN"]`.
+
+**Result:** User role set to `ADMIN`.
+
+---
+
+### Example 3 — Role missing from token
+
+**Setup:**
+```properties
+rolesClaim=roles
+authenticatedDefaultRole=GUEST
+```
+Token does **not** contain `roles`.
+
+**Result:** User role set to `GUEST`.
+
+---
+
+### Example 4 — Groups from token, first login
+
+**Setup:**
+```properties
+groupsClaim=groups
+```
+Token contains `"groups": ["developers", "testers"]`.
+
+**Result:** Groups `developers` and `testers` created in DB (tagged `sourceService=oidc`),
+assigned to user.
+
+---
+
+### Example 5 — Group removed from token
+
+**Setup:** Same as Example 4, but on second login token contains only `"groups": ["developers"]`.
+
+**Result:** `testers` deassigned from user (group record in DB is kept).
+
+> **Note:** Deassignment only works from the **second login onwards**. On the very first login
+> the user object is freshly created in memory and its group set is empty, so `reconcileRemoteGroups`
+> sees `currentGroups=[]` and cannot compute removals. From the second login the user is loaded
+> from DB with groups populated, and the reconciliation works correctly.
+
+---
+
+### Example 6 — Group mapping
+
+**Setup:**
+```properties
+groupsClaim=groups
+groupMappings=DEVS:developers,QA:testers
+dropUnmapped=true
+```
+Token contains `"groups": ["DEVS", "QA", "ops"]`.
+
+**Result:** `developers` and `testers` assigned; `ops` dropped (unmapped + `dropUnmapped=true`).
+
+---
+
+### Example 7 — Default groups
+
+**Setup:**
+```properties
+groupsClaim=groups
+defaultGroups=everyone
+```
+Token contains `"groups": ["developers"]`.
+
+**Result:** Both `developers` and `everyone` assigned (regardless of token content).
+
+---
+
+### Example 8 — Manually assigned group preserved
+
+**Setup:** User has group `admins` assigned manually in DB (no `sourceService` attribute).
+Token contains `"groups": []`.
+
+**Result:** `admins` is **not** removed (not tagged for this provider).

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/AccessCookie.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/AccessCookie.java
@@ -1,0 +1,63 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2022 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.NewCookie;
+import java.util.Date;
+
+/** Cookie class to allow an easy setting of the SameSite cookie part. */
+public class AccessCookie extends NewCookie {
+
+    private final String sameSite;
+
+    public AccessCookie(
+            Cookie cookie, String comment, int maxAge, boolean secure, String sameSite) {
+        super(cookie, comment, maxAge, secure);
+        this.sameSite = sameSite;
+    }
+
+    public AccessCookie(
+            Cookie cookie,
+            String comment,
+            int maxAge,
+            Date expiry,
+            boolean secure,
+            boolean httpOnly,
+            String sameSite) {
+        super(cookie, comment, maxAge, expiry, secure, httpOnly);
+        this.sameSite = sameSite;
+    }
+
+    @Override
+    public String toString() {
+        String cookie = super.toString();
+        if (sameSite != null) cookie = cookie.concat(";").concat("SameSite=").concat(sameSite);
+        return cookie;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/ClaimPathResolver.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/ClaimPathResolver.java
@@ -1,0 +1,175 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Utility class for resolving claim values from Maps using Jayway JsonPath. Supports both legacy
+ * dot-notation paths (e.g. {@code realm_access.roles}) and full JsonPath expressions (e.g. {@code
+ * $.realm_access.roles}, {@code $.resource_access.*.roles}).
+ *
+ * <p>Legacy dot-notation paths are automatically converted to JsonPath by prepending {@code $.}.
+ * Paths that already start with {@code $} are passed through as-is.
+ */
+public final class ClaimPathResolver {
+
+    private static final Configuration JSON_PATH_CONFIG =
+            Configuration.defaultConfiguration()
+                    .addOptions(Option.SUPPRESS_EXCEPTIONS, Option.DEFAULT_PATH_LEAF_TO_NULL);
+
+    private ClaimPathResolver() {}
+
+    /**
+     * Converts a claim path to a JsonPath expression. Paths starting with {@code $} are returned
+     * as-is; otherwise {@code $.} is prepended to treat them as dot-notation.
+     */
+    public static String toJsonPath(String path) {
+        if (path == null) return null;
+        if (path.startsWith("$")) return path;
+        return "$." + path;
+    }
+
+    /**
+     * Resolves a claim path against a Map document.
+     *
+     * @param document the claims map (e.g. JWT payload or userinfo response)
+     * @param path the claim path (dot-notation or JsonPath)
+     * @return the resolved value, or {@code null} if not found
+     */
+    public static Object resolve(Map<String, Object> document, String path) {
+        if (document == null || path == null || path.isEmpty()) return null;
+        String jsonPath = toJsonPath(path);
+        try {
+            return JsonPath.using(JSON_PATH_CONFIG).parse(document).read(jsonPath);
+        } catch (PathNotFoundException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolves a claim path and coerces the result to a list of strings.
+     *
+     * @param document the claims map
+     * @param path the claim path (dot-notation or JsonPath)
+     * @return the resolved value as a list of strings, or {@code null} if not found
+     */
+    public static List<String> resolveAsList(Map<String, Object> document, String path) {
+        Object value = resolve(document, path);
+        return toStringList(value);
+    }
+
+    /**
+     * Case-insensitive variant of {@link #resolve}. Recursively lowercases all map keys before
+     * resolving, and lowercases the path for matching.
+     *
+     * @param document the claims map
+     * @param path the claim path (dot-notation or JsonPath)
+     * @return the resolved value, or {@code null} if not found
+     */
+    public static Object resolveIgnoreCase(Map<String, Object> document, String path) {
+        if (document == null || path == null || path.isEmpty()) return null;
+        Map<String, Object> lowered = lowercaseKeys(document);
+        String loweredPath = lowercasePath(path);
+        return resolve(lowered, loweredPath);
+    }
+
+    /**
+     * Case-insensitive variant of {@link #resolveAsList}.
+     *
+     * @param document the claims map
+     * @param path the claim path (dot-notation or JsonPath)
+     * @return the resolved value as a list of strings, or {@code null} if not found
+     */
+    public static List<String> resolveAsListIgnoreCase(Map<String, Object> document, String path) {
+        Object value = resolveIgnoreCase(document, path);
+        return toStringList(value);
+    }
+
+    /** Converts a value (single, List, Collection) to a List of Strings. */
+    @SuppressWarnings("unchecked")
+    static List<String> toStringList(Object value) {
+        if (value == null) return null;
+        if (value instanceof List) {
+            List<?> raw = (List<?>) value;
+            if (raw.isEmpty()) return new ArrayList<>();
+            List<String> result = new ArrayList<>(raw.size());
+            for (Object item : raw) {
+                if (item instanceof List) {
+                    // Flatten nested lists (e.g. from wildcard queries)
+                    for (Object nested : (List<?>) item) {
+                        if (nested != null) result.add(String.valueOf(nested));
+                    }
+                } else if (item != null) {
+                    result.add(String.valueOf(item));
+                }
+            }
+            return result.isEmpty() ? null : result;
+        }
+        if (value instanceof Collection) {
+            return toStringList(new ArrayList<>((Collection<?>) value));
+        }
+        // Single value -> wrap in list
+        List<String> result = new ArrayList<>(1);
+        result.add(String.valueOf(value));
+        return result;
+    }
+
+    /** Recursively lowercases all map keys. */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> lowercaseKeys(Map<String, Object> map) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey().toLowerCase(Locale.ROOT);
+            Object val = entry.getValue();
+            if (val instanceof Map) {
+                val = lowercaseKeys((Map<String, Object>) val);
+            }
+            result.put(key, val);
+        }
+        return result;
+    }
+
+    /** Lowercases the path segments (not JsonPath operators). */
+    private static String lowercasePath(String path) {
+        if (path == null) return null;
+        // For JsonPath expressions, lowercase the field names but preserve operators
+        // Simple approach: lowercase the entire path, which works for dot-notation and
+        // simple JsonPath. JsonPath operators ($, ., *, [, ]) are unaffected by lowercase.
+        return path.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/DiscoveryClient.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/DiscoveryClient.java
@@ -1,0 +1,215 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2022 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import java.util.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * DiscoveryClient to perform a discovery request and set the value to the OAuth2Configuration
+ * instance.
+ */
+public class DiscoveryClient {
+    private static final Logger LOGGER = LogManager.getLogger(DiscoveryClient.class);
+    private static final String PROVIDER_END_PATH = "/.well-known/openid-configuration";
+    private static final String AUTHORIZATION_ENDPOINT_ATTR_NAME = "authorization_endpoint";
+    private static final String TOKEN_ENDPOINT_ATTR_NAME = "token_endpoint";
+    private static final String USERINFO_ENDPOINT_ATTR_NAME = "userinfo_endpoint";
+    private static final String END_SESSION_ENDPOINT = "end_session_endpoint";
+    private static final String JWK_SET_URI_ATTR_NAME = "jwks_uri";
+    private static final String SCOPES_SUPPORTED = "scopes_supported";
+    private static final String REVOCATION_ENDPOINT = "revocation_endpoint";
+    private static final String INTROSPECTION_ENDPOINT = "introspection_endpoint";
+
+    private final RestTemplate restTemplate;
+    private String location;
+
+    public DiscoveryClient(String location) {
+        setLocation(location);
+        this.restTemplate = new RestTemplate();
+    }
+
+    public DiscoveryClient(String location, RestTemplate restTemplate) {
+        setLocation(location);
+        this.restTemplate = restTemplate;
+    }
+
+    private static String appendPath(String... pathComponents) {
+        StringBuilder result = new StringBuilder(pathComponents[0]);
+        for (int i = 1; i < pathComponents.length; i++) {
+            String component = pathComponents[i];
+            boolean endsWithSlash = result.charAt(result.length() - 1) == '/';
+            boolean startsWithSlash = component.startsWith("/");
+            if (endsWithSlash && startsWithSlash) {
+                result.setLength(result.length() - 1);
+            } else if (!endsWithSlash && !startsWithSlash) {
+                result.append("/");
+            }
+            result.append(component);
+        }
+
+        return result.toString();
+    }
+
+    private void setLocation(String location) {
+        if (!location.endsWith(PROVIDER_END_PATH)) {
+            location = appendPath(location, PROVIDER_END_PATH);
+        }
+        this.location = location;
+    }
+
+    /**
+     * Fill the OAuth2Configuration instance with the values found in the discovery response.
+     *
+     * @param conf the OAuth2Configuration.
+     */
+    public void autofill(OAuth2Configuration conf) {
+        if (location == null) {
+            LOGGER.warn("Discovery location is null; skipping autofill");
+            return;
+        }
+        try {
+            LOGGER.info("Fetching OIDC discovery document from {}", location);
+            Map response = restTemplate.getForObject(this.location, Map.class);
+            if (response == null) {
+                LOGGER.error(
+                        "OIDC discovery returned null from {}. Endpoints will not be auto-configured.",
+                        location);
+                return;
+            }
+            LOGGER.info(
+                    "Discovery document received from {} with {} keys: {}",
+                    location,
+                    response.size(),
+                    response.keySet());
+            Optional.ofNullable(response.get(getAuthorizationEndpointAttrName()))
+                    .ifPresent(
+                            uri -> {
+                                LOGGER.info("  authorization_endpoint = {}", uri);
+                                conf.setAuthorizationUri((String) uri);
+                            });
+            Optional.ofNullable(response.get(getTokenEndpointAttrName()))
+                    .ifPresent(
+                            uri -> {
+                                LOGGER.info("  token_endpoint = {}", uri);
+                                conf.setAccessTokenUri((String) uri);
+                            });
+            Optional.ofNullable(response.get(getUserinfoEndpointAttrName()))
+                    .ifPresent(
+                            uri -> {
+                                LOGGER.info("  userinfo_endpoint = {}", uri);
+                                conf.setCheckTokenEndpointUrl((String) uri);
+                            });
+            Optional.ofNullable(response.get(getJwkSetUriAttrName()))
+                    .ifPresent(
+                            uri -> {
+                                LOGGER.info("  jwks_uri = {}", uri);
+                                conf.setIdTokenUri((String) uri);
+                            });
+            Optional.ofNullable(response.get(getEndSessionEndpoint()))
+                    .ifPresent(
+                            uri -> {
+                                LOGGER.info("  end_session_endpoint = {}", uri);
+                                conf.setLogoutUri((String) uri);
+                            });
+            Optional.ofNullable(response.get(getRevocationEndpoint()))
+                    .ifPresent(
+                            s -> {
+                                LOGGER.info("  revocation_endpoint = {}", s);
+                                conf.setRevokeEndpoint((String) s);
+                            });
+            Optional.ofNullable(response.get(getIntrospectionEndpoint()))
+                    .ifPresent(
+                            s -> {
+                                LOGGER.info("  introspection_endpoint = {}", s);
+                                conf.setIntrospectionEndpoint((String) s);
+                            });
+            if (conf.getScopes() == null || conf.getScopes().isEmpty()) {
+                Optional.ofNullable(response.get(getScopesSupported()))
+                        .ifPresent(
+                                s -> {
+                                    @SuppressWarnings("unchecked")
+                                    List<String> scopes = (List<String>) s;
+                                    conf.setScopes(collectScopes(scopes));
+                                    LOGGER.info("  scopes_supported = {}", scopes);
+                                });
+            }
+            LOGGER.info("OIDC discovery successful from {}", location);
+        } catch (Exception e) {
+            LOGGER.error(
+                    "Failed to fetch OIDC discovery document from {}: {}. "
+                            + "Endpoints (authorizationUri, accessTokenUri, etc.) will remain null. "
+                            + "Login will fail with NullPointerException.",
+                    location,
+                    e.getMessage(),
+                    e);
+        }
+    }
+
+    private String collectScopes(List<String> scopes) {
+        return String.join(",", scopes);
+    }
+
+    protected String getUserinfoEndpointAttrName() {
+        return USERINFO_ENDPOINT_ATTR_NAME;
+    }
+
+    protected String getEndSessionEndpoint() {
+        return END_SESSION_ENDPOINT;
+    }
+
+    protected String getJwkSetUriAttrName() {
+        return JWK_SET_URI_ATTR_NAME;
+    }
+
+    protected String getProviderEndPath() {
+        return PROVIDER_END_PATH;
+    }
+
+    protected String getAuthorizationEndpointAttrName() {
+        return AUTHORIZATION_ENDPOINT_ATTR_NAME;
+    }
+
+    protected String getTokenEndpointAttrName() {
+        return TOKEN_ENDPOINT_ATTR_NAME;
+    }
+
+    protected String getScopesSupported() {
+        return SCOPES_SUPPORTED;
+    }
+
+    protected String getRevocationEndpoint() {
+        return REVOCATION_ENDPOINT;
+    }
+
+    protected String getIntrospectionEndpoint() {
+        return INTROSPECTION_ENDPOINT;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/GeoStoreOAuth2SuccessHandler.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/GeoStoreOAuth2SuccessHandler.java
@@ -1,0 +1,71 @@
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2GeoStoreAuthenticationFilter.OAUTH2_AUTHENTICATION_TYPE_KEY;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.ACCESS_TOKEN_PARAM;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.REFRESH_TOKEN_PARAM;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+public class GeoStoreOAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final OAuth2AuthorizedClientService authorizedClientService;
+    private final OAuth2GeoStoreAuthenticationService authenticationService;
+
+    public GeoStoreOAuth2SuccessHandler(
+            OAuth2AuthorizedClientService authorizedClientService,
+            OAuth2GeoStoreAuthenticationService authenticationService) {
+        this.authorizedClientService = authorizedClientService;
+        this.authenticationService = authenticationService;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
+
+        if (!(authentication instanceof OAuth2AuthenticationToken)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unsupported authentication");
+            return;
+        }
+        OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
+
+        OAuth2AuthorizedClient authorizedClient =
+                authorizedClientService.loadAuthorizedClient(
+                        oauthToken.getAuthorizedClientRegistrationId(), oauthToken.getName());
+
+        OAuth2AccessToken accessToken =
+                authorizedClient != null ? authorizedClient.getAccessToken() : null;
+
+        OAuth2RefreshToken refreshToken =
+                authorizedClient != null ? authorizedClient.getRefreshToken() : null;
+
+        request.setAttribute(
+                OAUTH2_AUTHENTICATION_TYPE_KEY,
+                OAuth2GeoStoreAuthenticationFilter.OAuth2AuthenticationType.USER);
+
+        if (accessToken != null) {
+            request.setAttribute(ACCESS_TOKEN_PARAM, accessToken.getTokenValue());
+        }
+        if (refreshToken != null) {
+            request.setAttribute(REFRESH_TOKEN_PARAM, refreshToken.getTokenValue());
+        }
+
+        Authentication finalAuthentication =
+                authenticationService.completeInteractiveAuthentication(
+                        request, response, accessToken, refreshToken);
+
+        SecurityContextHolder.getContext().setAuthentication(finalAuthentication);
+
+        response.sendRedirect("/");
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/GeoStoreRemoteTokenServices.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/GeoStoreRemoteTokenServices.java
@@ -1,0 +1,171 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2022 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.server.resource.introspection.BadOpaqueTokenException;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Provides an additional method to be able to deal with not fully standardized/check_token endpoint
+ * responses.
+ */
+public class GeoStoreRemoteTokenServices {
+
+    protected static final Logger LOGGER =
+            LogManager.getLogger(GeoStoreRemoteTokenServices.class.getName());
+
+    protected RestOperations restTemplate;
+
+    protected String checkTokenEndpointUrl;
+
+    protected String clientId;
+
+    protected String clientSecret;
+
+    protected GeoStoreRemoteTokenServices() {
+        // constructor for subclasses that want to configure everything
+    }
+
+    protected GeoStoreRemoteTokenServices(RestOperations restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public void setRestTemplate(RestOperations restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public void setCheckTokenEndpointUrl(String checkTokenEndpointUrl) {
+        this.checkTokenEndpointUrl = checkTokenEndpointUrl;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+
+    public Map<String, Object> loadAuthentication(String accessToken)
+            throws AuthenticationException, BadOpaqueTokenException {
+        Map<String, Object> checkTokenResponse = checkToken(accessToken);
+        verifyTokenResponse(accessToken, checkTokenResponse);
+        transformNonStandardValuesToStandardValues(checkTokenResponse);
+        return checkTokenResponse;
+    }
+
+    protected void verifyTokenResponse(String accessToken, Map<String, Object> checkTokenResponse) {
+        if (checkTokenResponse == null || checkTokenResponse.isEmpty()) {
+            LOGGER.warn("check_token returned empty response");
+            throw new BadOpaqueTokenException(accessToken);
+        }
+        if (checkTokenResponse.containsKey("error")) {
+            LOGGER.warn("check_token returned error: {}", checkTokenResponse.get("error"));
+            throw new BadOpaqueTokenException(accessToken);
+        }
+    }
+
+    /**
+     * Subclass must override this method if values are not standardized.
+     *
+     * @param map the map of values to be transformed.
+     */
+    protected void transformNonStandardValuesToStandardValues(Map<String, Object> map) {
+        // nothing to do if everything is standardized
+    }
+
+    protected Map<String, Object> checkToken(String accessToken) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("token", accessToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", getAuthorizationHeader(accessToken));
+
+        String accessTokenUrl = checkTokenEndpointUrl + "?access_token=" + accessToken;
+        return sendRequestForMap(accessTokenUrl, formData, headers, HttpMethod.POST);
+    }
+
+    protected String getAuthorizationHeader(String accessToken) {
+        return "Bearer " + accessToken;
+    }
+
+    protected Map<String, Object> sendRequestForMap(
+            String path,
+            MultiValueMap<String, String> formData,
+            HttpHeaders headers,
+            HttpMethod method) {
+        if (headers.getContentType() == null) {
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        }
+
+        ParameterizedTypeReference<Map<String, Object>> map = new ParameterizedTypeReference<>() {};
+
+        LOGGER.debug("Executing request {} form data are {}", path, formData);
+        LOGGER.debug("Headers are {}", headers);
+
+        ResponseEntity<Map<String, Object>> response =
+                restTemplate.exchange(path, method, new HttpEntity<>(formData, headers), map);
+
+        return response.getBody();
+    }
+
+    public static GeoStoreRemoteTokenServices defaultInstance() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(
+                new DefaultResponseErrorHandler() {
+                    @Override
+                    public boolean hasError(ClientHttpResponse response) throws IOException {
+                        return response.getStatusCode().value() != 400 && super.hasError(response);
+                    }
+
+                    @Override
+                    public void handleError(URI url, HttpMethod method, ClientHttpResponse response)
+                            throws IOException {
+                        super.handleError(url, method, response);
+                    }
+                });
+        return new GeoStoreRemoteTokenServices(restTemplate);
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/IdPLoginRestImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/IdPLoginRestImpl.java
@@ -121,12 +121,12 @@ public class IdPLoginRestImpl implements IdPLoginRest {
 
     @Override
     public void registerService(String providerName, IdPLoginService service) {
+        this.services.put(providerName, service);
         LOGGER.info(
                 "Registering login service for provider '{}' (class: {}). "
                         + "Providers after registration: {}",
                 providerName,
                 service.getClass().getSimpleName(),
                 services.keySet());
-        this.services.put(providerName, service);
     }
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/JWTHelper.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/JWTHelper.java
@@ -1,0 +1,174 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2022 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/** A class holding utilities method for handling JWT tokens. */
+public class JWTHelper {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final DecodedJWT decodedJWT;
+    private volatile Map<String, Object> payloadMap;
+
+    public JWTHelper(String jwtToken) {
+        this.decodedJWT = JWT.decode(jwtToken);
+    }
+
+    /**
+     * Get a claim by name from the idToken. Supports dot-notation and full JsonPath expressions for
+     * nested claims (e.g. "realm_access.roles", "$.resource_access.*.roles").
+     *
+     * @param claimName the name of the claim to retrieve, may use dot-notation or JsonPath.
+     * @param binding the Class to which convert the claim value.
+     * @param <T> the type of the claim value.
+     * @return the claim value.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getClaim(String claimName, Class<T> binding) {
+        if (decodedJWT == null || claimName == null) return null;
+
+        // For path expressions (dot-notation or JsonPath), use ClaimPathResolver
+        if (claimName.contains(".") || claimName.startsWith("$")) {
+            Object resolved = ClaimPathResolver.resolve(getPayloadAsMap(), claimName);
+            if (resolved == null) return null;
+            if (binding.isInstance(resolved)) return (T) resolved;
+            if (binding == String.class) return (T) String.valueOf(resolved);
+            return null;
+        }
+
+        Claim claim = decodedJWT.getClaim(claimName);
+        if (nonNullClaim(claim)) return claim.as(binding);
+        return null;
+    }
+
+    /**
+     * Get a claim values as List by its name. Supports dot-notation and full JsonPath expressions
+     * for nested claims (e.g. "realm_access.roles", "$.resource_access.*.roles").
+     *
+     * @param claimName the name of the claim to retrieve, may use dot-notation or JsonPath.
+     * @param binding the Class to which convert the claim value.
+     * @param <T> the type of the claim value.
+     * @return the claim value.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> List<T> getClaimAsList(String claimName, Class<T> binding) {
+        if (decodedJWT == null || claimName == null) return null;
+
+        // For path expressions (dot-notation or JsonPath), use ClaimPathResolver
+        if (claimName.contains(".") || claimName.startsWith("$")) {
+            List<String> resolved = ClaimPathResolver.resolveAsList(getPayloadAsMap(), claimName);
+            if (resolved == null) return null;
+            if (binding == String.class) return (List<T>) resolved;
+            return extractListFromValue(resolved, binding);
+        }
+
+        Claim claim = decodedJWT.getClaim(claimName);
+        if (nonNullClaim(claim)) {
+            List<T> result = claim.asList(binding);
+            if (result == null) {
+                result = new ArrayList<>();
+                T singleValue = claim.as(binding);
+                if (singleValue != null) result.add(singleValue);
+            }
+            return result;
+        }
+        return null;
+    }
+
+    /**
+     * Lazily decodes the JWT payload into a Map. The payload is Base64URL-decoded and parsed via
+     * Jackson.
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getPayloadAsMap() {
+        if (payloadMap == null) {
+            synchronized (this) {
+                if (payloadMap == null) {
+                    try {
+                        String payload = decodedJWT.getPayload();
+                        byte[] decoded = Base64.getUrlDecoder().decode(payload);
+                        payloadMap =
+                                OBJECT_MAPPER.readValue(
+                                        decoded, new TypeReference<Map<String, Object>>() {});
+                    } catch (Exception e) {
+                        payloadMap = java.util.Collections.emptyMap();
+                    }
+                }
+            }
+        }
+        return payloadMap;
+    }
+
+    /** Extracts a List from a value that may be a List, a Collection, or a single value. */
+    @SuppressWarnings("unchecked")
+    private <T> List<T> extractListFromValue(Object value, Class<T> binding) {
+        if (value == null) return null;
+        if (value instanceof List) {
+            List<?> raw = (List<?>) value;
+            List<T> result = new ArrayList<>(raw.size());
+            for (Object item : raw) {
+                if (binding.isInstance(item)) {
+                    result.add((T) item);
+                } else if (binding == String.class && item != null) {
+                    result.add((T) String.valueOf(item));
+                }
+            }
+            return result;
+        }
+        if (value instanceof Collection) {
+            return extractListFromValue(new ArrayList<>((Collection<?>) value), binding);
+        }
+        // Single value -> wrap in list
+        List<T> result = new ArrayList<>(1);
+        if (binding.isInstance(value)) {
+            result.add((T) value);
+        } else if (binding == String.class && value != null) {
+            result.add((T) String.valueOf(value));
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    private boolean nonNullClaim(Claim claim) {
+        // java-jwt 4.x removed the public NullClaim sentinel used by 3.x to signal an absent claim.
+        // In 4.x getClaim() never returns Java null; an absent claim reports isMissing(), and a
+        // claim present with a JSON null value reports isNull(). The 3.x NullClaim covered both
+        // cases, so the faithful equivalent excludes both.
+        return claim != null && !claim.isMissing() && !claim.isNull();
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -167,7 +167,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter extends GenericFilterBe
     private void addRequestAttributes(HttpServletRequest request, Authentication authentication) {
         if (authentication != null) {
 
-            TokenDetails tokenDetails = tokenDetails(authentication);
+            TokenDetails tokenDetails = OAuth2Utils.getTokenDetails(authentication);
 
             if (tokenDetails != null && tokenDetails.getAccessToken() != null) {
 
@@ -187,10 +187,5 @@ public abstract class OAuth2GeoStoreAuthenticationFilter extends GenericFilterBe
                 request.setAttribute(PROVIDER_KEY, configuration.getProvider());
             }
         }
-    }
-
-    private TokenDetails tokenDetails(Authentication authentication) {
-        Object details = authentication != null ? authentication.getDetails() : null;
-        return (details instanceof TokenDetails) ? (TokenDetails) details : null;
     }
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -1,0 +1,196 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2022-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static it.geosolutions.geostore.services.rest.SessionServiceDelegate.PROVIDER_KEY;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.ACCESS_TOKEN_PARAM;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.ID_TOKEN_PARAM;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.REFRESH_TOKEN_PARAM;
+
+import it.geosolutions.geostore.services.UserGroupService;
+import it.geosolutions.geostore.services.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.web.filter.GenericFilterBean;
+
+/** GeoStore OAuth2 authentication filter. */
+public abstract class OAuth2GeoStoreAuthenticationFilter extends GenericFilterBean {
+
+    private static final Logger LOGGER =
+            LogManager.getLogger(OAuth2GeoStoreAuthenticationFilter.class);
+
+    public static final String OAUTH2_AUTHENTICATION_TYPE_KEY = "oauth2.authenticationType";
+
+    /** Enum representing the type of OAuth2 authentication. */
+    public enum OAuth2AuthenticationType {
+        /** Bearer token authentication (existing access token in request headers) */
+        BEARER,
+        /** Interactive OAuth2 login authentication */
+        USER;
+    }
+
+    private static final String SECURITY_LOGGER_NAME =
+            "it.geosolutions.geostore.services.rest.security";
+
+    private final OAuth2GeoStoreAuthenticationService authenticationService;
+    private volatile boolean sensitiveLoggingConfigured = false;
+
+    @Autowired protected UserService userService;
+    @Autowired protected UserGroupService userGroupService;
+    protected OAuth2Configuration configuration;
+
+    protected OAuth2GeoStoreAuthenticationFilter(
+            OAuth2Configuration configuration,
+            OAuth2GeoStoreAuthenticationService authenticationService) {
+        this.configuration = configuration;
+        this.authenticationService = authenticationService;
+    }
+
+    public UserService getUserService() {
+        return userService;
+    }
+
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    public UserGroupService getUserGroupService() {
+        return userGroupService;
+    }
+
+    public void setUserGroupService(UserGroupService userGroupService) {
+        this.userGroupService = userGroupService;
+    }
+
+    public OAuth2Configuration getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(OAuth2Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        configureSensitiveLogging();
+
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (configuration.isEnabled() && !configuration.isInvalid() && authentication == null) {
+
+            String token = OAuth2Utils.tokenFromParamsOrBearer(ACCESS_TOKEN_PARAM, request);
+
+            if (token != null) {
+                request.setAttribute(
+                        OAUTH2_AUTHENTICATION_TYPE_KEY, OAuth2AuthenticationType.BEARER);
+
+                Authentication oauth2Authentication =
+                        authenticationService.authenticate(token, request, response);
+
+                if (oauth2Authentication != null) {
+                    SecurityContextHolder.getContext().setAuthentication(oauth2Authentication);
+                    authentication = oauth2Authentication;
+                }
+            } else {
+                request.setAttribute(OAUTH2_AUTHENTICATION_TYPE_KEY, OAuth2AuthenticationType.USER);
+                LOGGER.debug("No bearer token found in request; skipping bearer authentication");
+            }
+        }
+
+        if (request != null) {
+            addRequestAttributes(request, authentication);
+        }
+
+        if (configuration.isEnabled() && configuration.isInvalid()) {
+            LOGGER.info(
+                    "Skipping configured OAuth2 authentication. One or more mandatory properties are missing (clientId, clientSecret, authorizationUri, tokenUri).");
+        }
+        chain.doFilter(req, res);
+    }
+
+    private void configureSensitiveLogging() {
+        if (!sensitiveLoggingConfigured && configuration.isLogSensitiveInfo()) {
+            sensitiveLoggingConfigured = true;
+            Configurator.setLevel(SECURITY_LOGGER_NAME, Level.DEBUG);
+            LOGGER.warn(
+                    "logSensitiveInfo is ENABLED for provider '{}'. "
+                            + "Security logger '{}' set to DEBUG. "
+                            + "Token contents and credentials may appear in logs. "
+                            + "Do NOT use in production.",
+                    configuration.getProvider(),
+                    SECURITY_LOGGER_NAME);
+        }
+    }
+
+    private void addRequestAttributes(HttpServletRequest request, Authentication authentication) {
+        if (authentication != null) {
+
+            TokenDetails tokenDetails = tokenDetails(authentication);
+
+            if (tokenDetails != null && tokenDetails.getAccessToken() != null) {
+
+                OAuth2AccessToken accessToken = tokenDetails.getAccessToken();
+
+                request.setAttribute(ACCESS_TOKEN_PARAM, accessToken.getTokenValue());
+
+                if (tokenDetails.getIdToken() != null) {
+                    request.setAttribute(ID_TOKEN_PARAM, tokenDetails.getIdToken());
+                }
+
+                if (tokenDetails.getRefreshToken() != null) {
+                    request.setAttribute(
+                            REFRESH_TOKEN_PARAM, tokenDetails.getRefreshToken().getTokenValue());
+                }
+
+                request.setAttribute(PROVIDER_KEY, configuration.getProvider());
+            }
+        }
+    }
+
+    private TokenDetails tokenDetails(Authentication authentication) {
+        Object details = authentication != null ? authentication.getDetails() : null;
+        return (details instanceof TokenDetails) ? (TokenDetails) details : null;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
@@ -847,6 +847,18 @@ public class OAuth2GeoStoreAuthenticationService {
 
         oidcGroups = applyGroupMappings(oidcGroups);
 
+        // Optional fallback: when nothing could be derived from the claims (claim missing, or
+        // every value dropped by the mappings), assign the configured default group. It flows
+        // through the normal reconciliation, so it is created on the fly, tagged with this
+        // provider as sourceService, and removed again on a later login carrying real groups.
+        String defaultGroup = configuration.getAuthenticatedDefaultGroup();
+        if (oidcGroups.isEmpty() && StringUtils.isNotBlank(defaultGroup)) {
+            oidcGroups = Collections.singletonList(defaultGroup.trim());
+            LOGGER.info(
+                    "No groups resolved from claims; assigning authenticatedDefaultGroup '{}'",
+                    defaultGroup.trim());
+        }
+
         LOGGER.info(
                 "Final groups to reconcile: {} (user.role={}, user.id={})",
                 oidcGroups,

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
@@ -1,0 +1,1182 @@
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static it.geosolutions.geostore.core.security.password.SecurityUtils.getUsername;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.ACCESS_TOKEN_PARAM;
+
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserAttribute;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.UserGroupAttribute;
+import it.geosolutions.geostore.core.model.enums.Role;
+import it.geosolutions.geostore.services.UserGroupService;
+import it.geosolutions.geostore.services.UserService;
+import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
+import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.server.resource.introspection.BadOpaqueTokenException;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.client.ResourceAccessException;
+
+/**
+ * GeoStore OAuth2 authentication service.
+ *
+ * <p>This class handles OAuth2 authentication including user auto-creation, token caching, and
+ * robust principal resolution (security principal -> introspection map -> JWT claims). It can
+ * augment user role/groups from token claims.
+ */
+public class OAuth2GeoStoreAuthenticationService {
+
+    private static final Logger LOGGER =
+            LogManager.getLogger(OAuth2GeoStoreAuthenticationService.class);
+
+    private static final String SOURCE_SERVICE_USER_GROUP_ATTRIBUTE_NAME = "sourceService";
+
+    public static final String OAUTH2_ACCESS_TOKEN_CHECK_KEY = "oauth2.AccessTokenCheckResponse";
+
+    // protected so the OpenIdConnect subclass can reuse them when overriding principal/authority
+    // resolution.
+    protected final TokenAuthenticationCache cache;
+    protected final UserService userService;
+    protected final UserGroupService userGroupService;
+    protected final OAuth2Configuration configuration;
+
+    public OAuth2GeoStoreAuthenticationService(
+            TokenAuthenticationCache cache,
+            UserService userService,
+            UserGroupService userGroupService,
+            OAuth2Configuration configuration) {
+        this.cache = cache;
+        this.userService = userService;
+        this.userGroupService = userGroupService;
+        this.configuration = configuration;
+    }
+
+    public Authentication authenticate(
+            String token, HttpServletRequest request, HttpServletResponse response) {
+
+        Authentication authentication = cache.get(token);
+
+        if (authentication == null) {
+            // Bearer path: no refresh token is available with an incoming bearer token.
+            return authenticateAndUpdateCache(request, response, token, null, null);
+        }
+
+        TokenDetails tokenDetails = extractTokenDetails(authentication);
+        if (tokenDetails != null) {
+            OAuth2AccessToken accessToken = tokenDetails.getAccessToken();
+            if (accessToken != null
+                    && accessToken.getExpiresAt() != null
+                    && accessToken.getExpiresAt().isBefore(Instant.now())) {
+                return authenticateAndUpdateCache(
+                        request, response, token, accessToken, tokenDetails.getRefreshToken());
+            }
+        }
+
+        return refreshCachedUserRole(authentication, token);
+    }
+
+    private Authentication authenticateAndUpdateCache(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String token,
+            OAuth2AccessToken accessToken,
+            OAuth2RefreshToken refreshToken) {
+
+        Authentication authentication =
+                performOAuthAuthentication(request, response, accessToken, refreshToken);
+
+        if (authentication != null) {
+
+            TokenDetails tokenDetails = extractTokenDetails(authentication);
+            if (tokenDetails != null) {
+                OAuth2AccessToken accessTokenDetails = tokenDetails.getAccessToken();
+                if (accessTokenDetails != null) {
+                    token = accessTokenDetails.getTokenValue();
+                }
+            }
+
+            if (token != null) {
+                cache.putCacheEntry(token, authentication);
+            }
+        }
+
+        return authentication;
+    }
+
+    private Authentication performOAuthAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            OAuth2AccessToken accessToken,
+            OAuth2RefreshToken refreshToken) {
+
+        LOGGER.info("About to perform remote authentication.");
+        LOGGER.info("Access Token: {}", accessToken);
+
+        String principal = null;
+
+        try {
+            LOGGER.info("Trying to get the pre-authenticated principal.");
+            principal = getPreAuthenticatedPrincipal(request, response, accessToken);
+        } catch (Exception e) {
+            LOGGER.error("Error obtaining pre-authenticated principal: {}", e.getMessage(), e);
+        }
+
+        LOGGER.info("Pre-authenticated principal = {}, trying to authenticate", principal);
+
+        PreAuthenticatedAuthenticationToken result = null;
+        if (StringUtils.isNotBlank(principal)) {
+            result =
+                    createPreAuthentication(
+                            principal, request, response, accessToken, refreshToken);
+        }
+        return result;
+    }
+
+    /**
+     * Resolve the principal exactly as the 2.6.x filter did (it never consulted the Spring Security
+     * context): 1) introspection / user-info call (also stashed as a request attribute so authority
+     * sync can reuse it), 2) principal from the introspection/extension map (configured
+     * uniqueUsername/principalKey, then common claim names), 3) JWT claims (ID Token preferred,
+     * else Access Token, else bearer/param).
+     */
+    protected String getPreAuthenticatedPrincipal(
+            HttpServletRequest req, HttpServletResponse resp, OAuth2AccessToken accessToken) {
+
+        Map<String, Object> tokenAttributes = null;
+
+        // 1) Introspection
+        try {
+            tokenAttributes = performIntrospectionOrUserInfo(accessToken);
+            if (tokenAttributes != null && !tokenAttributes.isEmpty()) {
+                req.setAttribute(OAUTH2_ACCESS_TOKEN_CHECK_KEY, tokenAttributes);
+                LOGGER.info("Stored OAuth2 token check attributes in request");
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Unable to introspect token or retrieve user-info", e);
+        }
+
+        // 2) Principal from the introspection/extension map (the 2.6.x primary lookup, which
+        //    extracted the principal from the check_token response via principalKey/uniqueUsername)
+        try {
+            String principal = extractPrincipalFromAttributes(tokenAttributes);
+            if (StringUtils.isNotBlank(principal)) {
+                LOGGER.info(
+                        "Resolved pre-authenticated principal from token attributes: {}",
+                        principal);
+                return principal;
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Unable to resolve principal from token attributes", e);
+        }
+
+        // 4) Fallback #2: JWT claims (ID Token preferred, else Access Token, else bearer/param)
+        try {
+            String principal = extractPrincipalFromFallbacks(accessToken, req);
+            if (StringUtils.isNotBlank(principal)) {
+                LOGGER.info(
+                        "Resolved pre-authenticated principal from fallback strategy: {}",
+                        principal);
+                return principal;
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Unable to resolve principal from fallback strategy", e);
+        }
+
+        // 5) Nothing worked
+        LOGGER.warn(
+                "Principal could not be resolved from security principal, introspection, or JWT claims.");
+        return null;
+    }
+
+    private Map<String, Object> performIntrospectionOrUserInfo(OAuth2AccessToken accessToken) {
+        if (accessToken == null || StringUtils.isBlank(accessToken.getTokenValue())) {
+            LOGGER.debug("Skipping introspection/user-info because access token is missing");
+            return null;
+        }
+
+        try {
+            LOGGER.info("Attempting token introspection/user-info lookup");
+
+            Map<String, Object> tokenAttributes = doIntrospectionOrUserInfoRequest(accessToken);
+
+            if (tokenAttributes == null || tokenAttributes.isEmpty()) {
+                LOGGER.warn("Introspection/user-info returned no attributes");
+                return null;
+            }
+
+            Object active = tokenAttributes.get("active");
+            if (active instanceof Boolean && !((Boolean) active)) {
+                LOGGER.warn("Token introspection returned active=false");
+                return null;
+            }
+
+            if (active instanceof String && !"true".equalsIgnoreCase((String) active)) {
+                LOGGER.warn("Token introspection returned non-active token");
+                return null;
+            }
+
+            LOGGER.info("Successfully retrieved token attributes from introspection/user-info");
+            return tokenAttributes;
+        } catch (ResourceAccessException e) {
+            LOGGER.error(
+                    "OAuth2 provider unreachable during introspection/user-info: {}",
+                    e.getMessage(),
+                    e);
+            return null;
+        } catch (Exception e) {
+            LOGGER.warn("OAuth2 introspection/user-info failed: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    protected Map<String, Object> doIntrospectionOrUserInfoRequest(OAuth2AccessToken accessToken) {
+        if (accessToken == null || StringUtils.isBlank(accessToken.getTokenValue())) {
+            LOGGER.debug(
+                    "Cannot perform introspection/user-info request because access token is missing");
+            return null;
+        }
+
+        String introspectionUri =
+                StringUtils.firstNonBlank(
+                        configuration.getIntrospectionEndpoint(),
+                        configuration.getCheckTokenEndpointUrl());
+
+        if (StringUtils.isNotBlank(introspectionUri)) {
+            LOGGER.debug("Using OAuth2 introspection endpoint [{}]", introspectionUri);
+            return doIntrospectionRequest(accessToken, introspectionUri);
+        }
+
+        LOGGER.debug("No introspection endpoint configured; user-info fallback not available yet");
+        return null;
+    }
+
+    protected Map<String, Object> doIntrospectionRequest(
+            OAuth2AccessToken accessToken, String introspectionUri) {
+        if (accessToken == null
+                || StringUtils.isBlank(accessToken.getTokenValue())
+                || StringUtils.isBlank(introspectionUri)) {
+            return null;
+        }
+
+        try {
+            LOGGER.info("Calling introspection endpoint [{}] for token", introspectionUri);
+
+            GeoStoreRemoteTokenServices tokenServices =
+                    GeoStoreRemoteTokenServices.defaultInstance();
+            tokenServices.setCheckTokenEndpointUrl(introspectionUri);
+            tokenServices.setClientId(configuration.getClientId());
+            tokenServices.setClientSecret(configuration.getClientSecret());
+
+            Map<String, Object> result =
+                    tokenServices.loadAuthentication(accessToken.getTokenValue());
+
+            if (result == null || result.isEmpty()) {
+                LOGGER.warn("Introspection endpoint returned empty response for token");
+                return null;
+            }
+
+            LOGGER.debug("Introspection returned attributes for token: {}", result);
+            return result;
+        } catch (BadOpaqueTokenException e) {
+            LOGGER.warn("Introspection response indicates invalid token: {}", e.getMessage());
+            return null;
+        } catch (Exception e) {
+            LOGGER.warn("Introspection request failed with general error: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    protected String extractPrincipalFromSecurityContext() {
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication == null) {
+                LOGGER.debug("No Authentication found in Spring Security context");
+                return null;
+            }
+
+            String username = getUsername(authentication.getPrincipal());
+            if (StringUtils.isNotBlank(username)) {
+                LOGGER.debug("Resolved username from Spring Security principal");
+                return username;
+            }
+
+            if (StringUtils.isNotBlank(authentication.getName())) {
+                LOGGER.debug("Resolved username from Spring Security authentication name");
+                return authentication.getName();
+            }
+
+            LOGGER.debug("Spring Security context did not provide a usable principal");
+            return null;
+        } catch (Exception e) {
+            LOGGER.warn("Unable to resolve principal from Spring Security context", e);
+            return null;
+        }
+    }
+
+    protected String extractPrincipalFromAttributes(Map<String, Object> attributes) {
+        try {
+            if (attributes == null || attributes.isEmpty()) {
+                LOGGER.debug("No token attributes available to resolve principal");
+                return null;
+            }
+
+            String fromAttributes =
+                    coalesce(
+                            findFirstIgnoreCase(attributes, configuration.getUniqueUsername()),
+                            findFirstIgnoreCase(attributes, configuration.getPrincipalKey()));
+
+            if (StringUtils.isBlank(fromAttributes)) {
+                fromAttributes =
+                        coalesce(
+                                findFirstIgnoreCase(attributes, "upn"),
+                                findFirstIgnoreCase(attributes, "preferred_username"),
+                                findFirstIgnoreCase(attributes, "unique_name"),
+                                findFirstIgnoreCase(attributes, "user_name"),
+                                findFirstIgnoreCase(attributes, "username"),
+                                findFirstIgnoreCase(attributes, "email"),
+                                findFirstIgnoreCase(attributes, "sub"),
+                                findFirstIgnoreCase(attributes, "oid"));
+            }
+
+            if (StringUtils.isNotBlank(fromAttributes)) {
+                LOGGER.debug(
+                        "Authenticated OAuth request with user (introspection) {}", fromAttributes);
+                return fromAttributes;
+            }
+
+            LOGGER.debug("No supported principal attribute found in token attributes");
+            return null;
+        } catch (Exception e) {
+            LOGGER.warn("Unable to resolve principal from token attributes", e);
+            return null;
+        }
+    }
+
+    private String coalesce(String... values) {
+        if (values == null) return null;
+        for (String v : values) {
+            if (StringUtils.isNotBlank(v)) return v;
+        }
+        return null;
+    }
+
+    /** Case-insensitive, searches also one nested level if the map contains sub-maps. */
+    @SuppressWarnings("unchecked")
+    private String findFirstIgnoreCase(Map<String, Object> map, String key) {
+        if (map == null || StringUtils.isBlank(key)) return null;
+        for (Map.Entry<String, Object> e : map.entrySet()) {
+            if (key.equalsIgnoreCase(String.valueOf(e.getKey()))) {
+                return e.getValue() != null ? String.valueOf(e.getValue()) : null;
+            }
+        }
+        for (Object v : map.values()) {
+            if (v instanceof Map) {
+                String found = findFirstIgnoreCase((Map<String, Object>) v, key);
+                if (StringUtils.isNotBlank(found)) return found;
+            }
+        }
+        return null;
+    }
+
+    protected String extractPrincipalFromFallbacks(
+            OAuth2AccessToken accessToken, HttpServletRequest req) {
+        try {
+            String idToken = OAuth2Utils.getIdToken();
+            String jwtForClaims = idToken;
+
+            if (jwtForClaims == null && accessToken != null) {
+                jwtForClaims = accessToken.getTokenValue();
+            }
+
+            if (jwtForClaims == null) {
+                jwtForClaims = OAuth2Utils.tokenFromParamsOrBearer(ACCESS_TOKEN_PARAM, req);
+            }
+
+            if (StringUtils.isBlank(jwtForClaims)) {
+                LOGGER.debug("No JWT available for fallback principal extraction");
+                return null;
+            }
+
+            JWTHelper helper = decodeAndValidateJwt(jwtForClaims);
+            if (helper == null) {
+                LOGGER.debug("Unable to decode or validate JWT for fallback principal extraction");
+                return null;
+            }
+
+            String fromJwt =
+                    coalesce(
+                            getClaim(helper, configuration.getUniqueUsername()),
+                            getClaim(helper, configuration.getPrincipalKey()));
+
+            if (StringUtils.isBlank(fromJwt)) {
+                fromJwt =
+                        coalesce(
+                                getClaim(helper, "upn"),
+                                getClaim(helper, "preferred_username"),
+                                getClaim(helper, "unique_name"),
+                                getClaim(helper, "email"),
+                                getClaim(helper, "sub"),
+                                getClaim(helper, "oid"));
+            }
+
+            if (StringUtils.isNotBlank(fromJwt)) {
+                LOGGER.info("Authenticated OAuth request with user (JWT claims) {}", fromJwt);
+                return fromJwt;
+            }
+
+            LOGGER.debug("No supported principal claim found in JWT fallback");
+            return null;
+        } catch (Exception e) {
+            LOGGER.warn("Unable to resolve principal from JWT fallback", e);
+            return null;
+        }
+    }
+
+    /**
+     * Decode and validate a JWT (ID token or access token). Returns null if the token is null or
+     * cannot be decoded. (Kept protected for potential subclass use.)
+     */
+    protected JWTHelper decodeAndValidateJwt(String jwt) {
+        if (jwt == null) {
+            LOGGER.warn("No JWT provided for decoding.");
+            return null;
+        }
+        try {
+            return new JWTHelper(jwt);
+        } catch (Exception e) {
+            LOGGER.error("Failed to decode or validate JWT", e);
+            return null;
+        }
+    }
+
+    private String getClaim(JWTHelper helper, String key) {
+        if (helper == null || StringUtils.isBlank(key)) return null;
+        try {
+            return helper.getClaim(key, String.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public PreAuthenticatedAuthenticationToken createPreAuthentication(
+            String username,
+            HttpServletRequest request,
+            HttpServletResponse response,
+            @Nullable OAuth2AccessToken accessToken,
+            @Nullable OAuth2RefreshToken refreshToken) {
+
+        if (StringUtils.isBlank(username)) {
+            LOGGER.error("Cannot create authentication: empty username");
+            return null;
+        }
+
+        LOGGER.info("Retrieving user with authorities for username: {}", username);
+        User user = retrieveUserWithAuthorities(username, request, response);
+        if (user == null) {
+            LOGGER.error("User retrieval failed for username: {}", username);
+            return null;
+        }
+
+        user.setTrusted(true);
+
+        String idToken = OAuth2Utils.getIdToken();
+        String accessTokenValue = accessToken != null ? accessToken.getTokenValue() : null;
+        String tokenForClaims = StringUtils.isNotBlank(idToken) ? idToken : accessTokenValue;
+
+        LOGGER.info(
+                "Token selection for claims: idToken={}, accessToken={}, using={}",
+                StringUtils.isNotBlank(idToken) ? "present" : "null",
+                StringUtils.isNotBlank(accessTokenValue) ? "present" : "null",
+                tokenForClaims != null
+                        ? (tokenForClaims.equals(idToken) ? "ID_TOKEN" : "ACCESS_TOKEN")
+                        : "NONE");
+
+        if (StringUtils.isNotBlank(tokenForClaims)
+                && (StringUtils.isNotBlank(configuration.getGroupsClaim())
+                        || StringUtils.isNotBlank(configuration.getRolesClaim()))) {
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> tokenAttributes =
+                    (Map<String, Object>) request.getAttribute(OAUTH2_ACCESS_TOKEN_CHECK_KEY);
+
+            addAuthoritiesFromToken(user, tokenForClaims, accessTokenValue, tokenAttributes);
+        }
+
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + user.getRole());
+
+        PreAuthenticatedAuthenticationToken authenticationToken =
+                new PreAuthenticatedAuthenticationToken(
+                        user, null, Collections.singletonList(authority));
+
+        authenticationToken.setDetails(
+                new TokenDetails(accessToken, idToken, configuration.getBeanName(), refreshToken));
+
+        return authenticationToken;
+    }
+
+    protected User retrieveUserWithAuthorities(
+            String username, HttpServletRequest request, HttpServletResponse response) {
+        User user = null;
+        if (StringUtils.isNotBlank(username) && userService != null) {
+            try {
+                user = userService.get(username);
+                LOGGER.info(
+                        "Found existing user '{}' in DB: id={}, role={}",
+                        username,
+                        user.getId(),
+                        user.getRole());
+            } catch (NotFoundServiceEx notFoundServiceEx) {
+                LOGGER.info("User '{}' not found in DB, will attempt creation.", username);
+            }
+        }
+        if (user == null) {
+            try {
+                user = createUser(username, "", "");
+            } catch (BadRequestServiceEx | NotFoundServiceEx e) {
+                LOGGER.error("Error while auto-creating the user: '{}'", username, e);
+            }
+        }
+        return user;
+    }
+
+    protected User createUser(String userName, String credentials, Object rawUser)
+            throws BadRequestServiceEx, NotFoundServiceEx {
+        User user = new User();
+        user.setName(userName);
+        user.setNewPassword(credentials != null ? credentials : "");
+        user.setEnabled(true);
+        UserAttribute userAttribute = new UserAttribute();
+        userAttribute.setName(OAuth2Configuration.CONFIGURATION_NAME);
+        userAttribute.setValue(configuration.getBeanName());
+        user.setAttribute(Collections.singletonList(userAttribute));
+        Set<UserGroup> groups = new HashSet<>();
+        user.setGroups(groups);
+        user.setRole(Role.USER);
+        LOGGER.info(
+                "createUser called for '{}': autoCreateUser={}, userService={}",
+                userName,
+                configuration.isAutoCreateUser(),
+                userService != null ? "available" : "null");
+        if (userService != null && configuration.isAutoCreateUser()) {
+            long id = userService.insert(user);
+            user = new User(user);
+            user.setId(id);
+            LOGGER.info("Persisted OIDC user '{}' with id {}", userName, id);
+        } else if (userService == null) {
+            LOGGER.warn("Cannot persist user '{}': userService is null", userName);
+        } else {
+            LOGGER.warn(
+                    "User '{}' will NOT be persisted (autoCreateUser=false). "
+                            + "Group assignments and role sync will not work.",
+                    userName);
+        }
+        return user;
+    }
+
+    /**
+     * Add authorities from token claims with optional access token and userinfo fallback. Tries the
+     * primary token (usually ID token) first; if a claim is not found, falls back to the access
+     * token (which in Keycloak contains realm_access, resource_access, groups, etc.), and finally
+     * to the userinfo map.
+     */
+    @SuppressWarnings("unchecked")
+    protected void addAuthoritiesFromToken(
+            User user,
+            String tokenString,
+            String accessTokenString,
+            Map<String, Object> userinfoMap) {
+        LOGGER.info(
+                "Syncing authorities from token claims for user '{}' (id={}, currentRole={}).",
+                user.getName(),
+                user.getId(),
+                user.getRole());
+
+        JWTHelper primaryHelper = null;
+        try {
+            primaryHelper = new JWTHelper(tokenString);
+        } catch (Exception e) {
+            LOGGER.warn("Primary token is not a valid JWT; will try fallbacks.", e);
+        }
+
+        // Build a separate helper for the access token (if different from the primary).
+        // In Keycloak, claims like realm_access, resource_access, and groups are typically
+        // only present in the access token, not in the ID token.
+        JWTHelper accessHelper = buildAccessTokenHelper(tokenString, accessTokenString);
+
+        // ----- Roles -----
+        syncRoleFromClaims(user, primaryHelper, accessHelper, userinfoMap);
+
+        // ----- Groups -----
+        syncGroupsFromClaims(user, primaryHelper, accessHelper, userinfoMap);
+
+        // ----- Persist user after role & group sync -----
+        persistSynchronizedUser(user);
+    }
+
+    protected JWTHelper buildAccessTokenHelper(String tokenString, String accessTokenString) {
+        if (accessTokenString == null || accessTokenString.equals(tokenString)) {
+            return null;
+        }
+
+        try {
+            JWTHelper accessHelper = new JWTHelper(accessTokenString);
+            LOGGER.info("Access token available as fallback for claim resolution.");
+            return accessHelper;
+        } catch (Exception e) {
+            LOGGER.warn("Access token is not a valid JWT; skipping as fallback.", e);
+            return null;
+        }
+    }
+
+    protected void syncRoleFromClaims(
+            User user,
+            JWTHelper primaryHelper,
+            JWTHelper accessHelper,
+            Map<String, Object> userinfoMap) {
+
+        Role currentRole = user.getRole();
+        String rolesClaimName = configuration.getRolesClaim();
+        Object rawRoles = null;
+
+        if (StringUtils.isNotBlank(rolesClaimName)) {
+            rawRoles =
+                    resolveClaimWithFallback(
+                            primaryHelper, accessHelper, userinfoMap, rolesClaimName);
+        } else {
+            LOGGER.info("No rolesClaim configured.");
+        }
+
+        if (rawRoles != null) {
+            List<String> oidcRoles = ClaimPathResolver.toStringList(rawRoles);
+            if (oidcRoles == null) {
+                oidcRoles = Collections.emptyList();
+            }
+            LOGGER.info(
+                    "Resolved role strings from token: {} (roleMappings={})",
+                    oidcRoles,
+                    configuration.getRoleMappings());
+            Role defaultRole = configuration.getAuthenticatedDefaultRole();
+            Role newRole = computeRole(oidcRoles, defaultRole);
+            user.setRole(newRole);
+            LOGGER.info("User role set from token. {} -> {}", currentRole, newRole);
+        } else if (StringUtils.isNotBlank(rolesClaimName)) {
+            // rolesClaim is configured but missing from the token — the IdP is the
+            // source of truth.  Fall back to authenticatedDefaultRole (USER by default)
+            // instead of preserving whatever is in the database.
+            Role defaultRole =
+                    configuration.getAuthenticatedDefaultRole() != null
+                            ? configuration.getAuthenticatedDefaultRole()
+                            : Role.USER;
+            user.setRole(defaultRole);
+            LOGGER.info(
+                    "Roles claim '{}' missing in token and userinfo -> "
+                            + "falling back to authenticatedDefaultRole: {} (was: {})",
+                    rolesClaimName,
+                    defaultRole,
+                    currentRole);
+        } else {
+            LOGGER.info("No rolesClaim configured -> preserving current role: {}", currentRole);
+        }
+    }
+
+    protected Object resolveClaimWithFallback(
+            JWTHelper primaryHelper,
+            JWTHelper accessHelper,
+            Map<String, Object> userinfoMap,
+            String claimName) {
+
+        Object value = null;
+
+        // 1) Try primary token (usually ID token)
+        if (primaryHelper != null) {
+            value = primaryHelper.getClaim(claimName, Object.class);
+            LOGGER.info(
+                    "Roles claim '{}' from primary token: {} (type={})",
+                    claimName,
+                    value,
+                    value != null ? value.getClass().getSimpleName() : "null");
+        }
+
+        // 2) Fallback: access token (Keycloak puts realm_access here)
+        if (value == null && accessHelper != null) {
+            value = accessHelper.getClaim(claimName, Object.class);
+            LOGGER.info(
+                    "Roles claim '{}' from access token (fallback): {} (type={})",
+                    claimName,
+                    value,
+                    value != null ? value.getClass().getSimpleName() : "null");
+        }
+
+        // 3) Fallback: userinfo map
+        if (value == null && userinfoMap != null) {
+            value = ClaimPathResolver.resolveIgnoreCase(userinfoMap, claimName);
+            LOGGER.info(
+                    "Roles claim '{}' from userinfo: {} (type={})",
+                    claimName,
+                    value,
+                    value != null ? value.getClass().getSimpleName() : "null");
+        }
+
+        return value;
+    }
+
+    private Role computeRole(List<String> rolesFromToken, Role defaultRole) {
+        LOGGER.info(
+                "computeRole: rolesFromToken={}, defaultRole={}, roleMappings={}, dropUnmapped={}",
+                rolesFromToken,
+                defaultRole,
+                configuration.getRoleMappings(),
+                configuration.isDropUnmapped());
+        if (rolesFromToken == null || rolesFromToken.isEmpty()) {
+            Role result = (defaultRole != null) ? defaultRole : Role.USER;
+            LOGGER.info("computeRole: no roles in token -> returning {}", result);
+            return result;
+        }
+        Map<String, String> roleMappings = configuration.getRoleMappings();
+        boolean dropUnmapped = configuration.isDropUnmapped();
+        Role resolved = (defaultRole != null) ? defaultRole : Role.USER;
+        for (String r : rolesFromToken) {
+            if (r == null) continue;
+            String rr = r.trim();
+            boolean wasMapped = false;
+            if (roleMappings != null) {
+                String mapped = roleMappings.get(rr.toUpperCase(Locale.ROOT));
+                if (mapped != null) {
+                    LOGGER.info("computeRole: '{}' mapped to '{}' via roleMappings", rr, mapped);
+                    rr = mapped;
+                    wasMapped = true;
+                } else if (dropUnmapped) {
+                    LOGGER.info(
+                            "computeRole: '{}' not in roleMappings, dropping (dropUnmapped)", rr);
+                    continue;
+                } else {
+                    LOGGER.info(
+                            "computeRole: '{}' not in roleMappings, keeping (dropUnmapped=false)",
+                            rr);
+                }
+            }
+            // Only compare against GeoStore role names if the value was explicitly mapped
+            // or if there are no roleMappings configured.  Unmapped IdP role names
+            // (e.g. "guest", "admin") should not accidentally match GeoStore roles.
+            if (wasMapped || roleMappings == null || roleMappings.isEmpty()) {
+                if (rr.equalsIgnoreCase(Role.ADMIN.name())) {
+                    LOGGER.info("computeRole: '{}' matches ADMIN -> returning ADMIN", rr);
+                    return Role.ADMIN;
+                }
+                if (rr.equalsIgnoreCase(Role.USER.name())) {
+                    LOGGER.info("computeRole: '{}' matches USER", rr);
+                    resolved = Role.USER;
+                    continue;
+                }
+                if (rr.equalsIgnoreCase(Role.GUEST.name())) {
+                    LOGGER.info("computeRole: '{}' matches GUEST", rr);
+                    resolved = Role.GUEST;
+                }
+            }
+        }
+        LOGGER.info("computeRole: final resolved role = {}", resolved);
+        return resolved;
+    }
+
+    protected void syncGroupsFromClaims(
+            User user,
+            JWTHelper primaryHelper,
+            JWTHelper accessHelper,
+            Map<String, Object> userinfoMap) {
+
+        List<String> oidcGroups = Collections.emptyList();
+        String groupsClaimName = configuration.getGroupsClaim();
+
+        if (groupsClaimName != null) {
+            LOGGER.info("Resolving groups from claim '{}'", groupsClaimName);
+
+            List<String> fromClaims =
+                    resolveStringListClaimWithFallback(
+                            primaryHelper, accessHelper, userinfoMap, groupsClaimName);
+
+            if (fromClaims != null && !fromClaims.isEmpty()) {
+                oidcGroups = fromClaims;
+            }
+
+            LOGGER.info("Groups resolved from token/userinfo: {}", oidcGroups);
+        } else {
+            LOGGER.info("No groupsClaim configured -> skipping group sync.");
+        }
+
+        oidcGroups = applyGroupMappings(oidcGroups);
+
+        LOGGER.info(
+                "Final groups to reconcile: {} (user.role={}, user.id={})",
+                oidcGroups,
+                user.getRole(),
+                user.getId());
+        reconcileRemoteGroups(user, new LinkedHashSet<>(oidcGroups));
+    }
+
+    protected List<String> resolveStringListClaimWithFallback(
+            JWTHelper primaryHelper,
+            JWTHelper accessHelper,
+            Map<String, Object> userinfoMap,
+            String claimName) {
+
+        List<String> values = null;
+
+        // 1) Try primary token
+        if (primaryHelper != null) {
+            values = primaryHelper.getClaimAsList(claimName, String.class);
+            LOGGER.info("Groups from primary token claim '{}': {}", claimName, values);
+        }
+
+        // 2) Fallback: access token
+        if ((values == null || values.isEmpty()) && accessHelper != null) {
+            values = accessHelper.getClaimAsList(claimName, String.class);
+            LOGGER.info("Groups from access token claim '{}' (fallback): {}", claimName, values);
+        }
+
+        if (values != null && !values.isEmpty()) {
+            return values;
+        }
+
+        // 3) Fallback: userinfo map
+        if (userinfoMap != null) {
+            List<String> fromUserinfo =
+                    ClaimPathResolver.resolveAsListIgnoreCase(userinfoMap, claimName);
+            LOGGER.info("Groups from userinfo claim '{}': {}", claimName, fromUserinfo);
+            if (fromUserinfo != null) {
+                return fromUserinfo;
+            }
+        }
+
+        return values;
+    }
+
+    protected List<String> applyGroupMappings(List<String> oidcGroups) {
+        Map<String, String> groupMappings = configuration.getGroupMappings();
+        boolean dropUnmapped = configuration.isDropUnmapped();
+
+        if (groupMappings != null && !oidcGroups.isEmpty()) {
+            List<String> mapped = new ArrayList<>();
+            for (String g : oidcGroups) {
+                if (g == null) {
+                    continue;
+                }
+                String m = groupMappings.get(g.toUpperCase(Locale.ROOT));
+                if (m != null) {
+                    mapped.add(m);
+                    LOGGER.info("Group '{}' mapped to '{}'", g, m);
+                } else if (!dropUnmapped) {
+                    mapped.add(g);
+                } else {
+                    LOGGER.info("Group '{}' dropped (unmapped, dropUnmapped=true)", g);
+                }
+            }
+            return mapped;
+        }
+
+        return oidcGroups;
+    }
+
+    private void reconcileRemoteGroups(User user, Set<String> newGroupNamesRaw) {
+        final String provider = configuration.getProvider();
+        if (StringUtils.isBlank(provider)) {
+            LOGGER.warn("Provider name is empty; skipping remote group reconciliation.");
+            return;
+        }
+
+        LOGGER.info(
+                "reconcileRemoteGroups: user='{}' (id={}, role={}), "
+                        + "provider='{}', newGroupNames={}, "
+                        + "currentGroups={} (type={})",
+                user.getName(),
+                user.getId(),
+                user.getRole(),
+                provider,
+                newGroupNamesRaw,
+                user.getGroups(),
+                user.getGroups() != null ? user.getGroups().getClass().getSimpleName() : "null");
+
+        if (user.getGroups() == null) {
+            LOGGER.info("User groups is null, initializing empty set.");
+            user.setGroups(new LinkedHashSet<>());
+        }
+
+        Set<String> newGroupNames =
+                newGroupNamesRaw.stream()
+                        .filter(Objects::nonNull)
+                        .map(this::normalizeGroupName)
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        Set<Long> providerRemoteIds = remoteGroupIdsForCurrentProvider();
+
+        // 1) remove old remote groups for THIS provider that are not in the new set
+        Set<UserGroup> toRemove =
+                user.getGroups().stream()
+                        .filter(
+                                g ->
+                                        g != null
+                                                && g.getId() != null
+                                                && providerRemoteIds.contains(g.getId()))
+                        .filter(g -> !newGroupNames.contains(normalizeGroupName(g.getGroupName())))
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        for (UserGroup g : toRemove) {
+            try {
+                userGroupService.deassignUserGroup(user.getId(), g.getId());
+                LOGGER.info(
+                        "Removed remote group '{}' for provider '{}' from user {}",
+                        g.getGroupName(),
+                        provider,
+                        user.getId());
+            } catch (NotFoundServiceEx e) {
+                LOGGER.warn(
+                        "Deassign failed for group '{}' from user {}: {}",
+                        g.getGroupName(),
+                        user.getId(),
+                        e.getMessage());
+            }
+        }
+        user.getGroups().removeAll(toRemove);
+
+        // 2) ensure each new token group exists, is marked for this provider, and is assigned
+        for (String groupName : newGroupNames) {
+            UserGroup group = searchGroup(groupName);
+            if (group == null) {
+                group = createUserGroup(groupName); // sets sourceService=provider
+                LOGGER.info("Created remote group '{}' (provider={})", groupName, provider);
+            } else {
+                updateGroupSourceServiceAttributes(group); // backfill provider tag
+            }
+
+            UserGroup finalGroup = group;
+            boolean alreadyAssigned =
+                    user.getGroups().stream()
+                            .anyMatch(
+                                    g -> {
+                                        if (g == null) return false;
+                                        if (finalGroup.getId() != null && g.getId() != null) {
+                                            return Objects.equals(g.getId(), finalGroup.getId());
+                                        }
+                                        return Objects.equals(
+                                                normalizeGroupName(g.getGroupName()),
+                                                normalizeGroupName(finalGroup.getGroupName()));
+                                    });
+            if (!alreadyAssigned) {
+                if (userGroupService != null && user.getId() != null && group.getId() != null) {
+                    try {
+                        userGroupService.assignUserGroup(user.getId(), group.getId());
+                        LOGGER.info("Assigned user {} to group '{}'", user.getId(), groupName);
+                    } catch (NotFoundServiceEx e) {
+                        LOGGER.error(
+                                "Assignment of user {} to group '{}' failed: {}",
+                                user.getId(),
+                                groupName,
+                                e.getMessage());
+                    }
+                }
+                user.getGroups().add(group);
+            }
+        }
+
+        Map<String, UserGroup> byName = new LinkedHashMap<>();
+        for (UserGroup g : user.getGroups()) {
+            byName.put(normalizeGroupName(g.getGroupName()), g);
+        }
+        user.setGroups(new LinkedHashSet<>(byName.values()));
+    }
+
+    private String normalizeGroupName(String name) {
+        if (name == null) return null;
+        return configuration.isGroupNamesUppercase() ? name.toUpperCase(Locale.ROOT) : name;
+    }
+
+    private Set<Long> remoteGroupIdsForCurrentProvider() {
+        if (userGroupService == null || configuration == null) return Collections.emptySet();
+        final String provider = configuration.getProvider();
+        Set<Long> ids = new LinkedHashSet<>();
+        try {
+            Collection<UserGroup> groups =
+                    userGroupService.findByAttribute(
+                            SOURCE_SERVICE_USER_GROUP_ATTRIBUTE_NAME,
+                            Collections.singletonList(provider),
+                            true);
+            if (groups != null) {
+                for (UserGroup g : groups) {
+                    if (g != null && g.getId() != null) ids.add(g.getId());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "Unable to resolve remote groups for provider '{}': {}",
+                    provider,
+                    e.getMessage());
+        }
+        return ids;
+    }
+
+    private UserGroup searchGroup(String groupName) {
+        if (userGroupService == null) return null;
+        if (configuration.isGroupNamesUppercase()) {
+            UserGroup ug = userGroupService.get(groupName.toUpperCase());
+            if (ug != null) return ug;
+        }
+        return userGroupService.get(groupName);
+    }
+
+    private UserGroup createUserGroup(String groupName) {
+        UserGroup group = new UserGroup();
+        group.setGroupName(
+                configuration.isGroupNamesUppercase() ? groupName.toUpperCase() : groupName);
+        group.setAttributes(
+                List.of(createUserGroupSourceServiceAttribute(configuration.getProvider())));
+        if (userGroupService != null) {
+            try {
+                long groupId = userGroupService.insert(group);
+                group = userGroupService.get(groupId);
+                LOGGER.info("inserted group id: {}", group.getGroupName());
+            } catch (BadRequestServiceEx e) {
+                LOGGER.error("Saving new group found in claims failed");
+            }
+        }
+        return group;
+    }
+
+    private UserGroupAttribute createUserGroupSourceServiceAttribute(String remoteService) {
+        UserGroupAttribute userGroupAttribute = new UserGroupAttribute();
+        userGroupAttribute.setName(SOURCE_SERVICE_USER_GROUP_ATTRIBUTE_NAME);
+        userGroupAttribute.setValue(remoteService);
+        return userGroupAttribute;
+    }
+
+    private void updateGroupSourceServiceAttributes(UserGroup group) {
+        if (group == null || group.getId() == null) return;
+        try {
+            userGroupService.upsertAttribute(
+                    group.getId(),
+                    SOURCE_SERVICE_USER_GROUP_ATTRIBUTE_NAME,
+                    configuration.getProvider());
+        } catch (NotFoundServiceEx | BadRequestServiceEx e) {
+            LOGGER.warn(
+                    "Could not upsert sourceService for group '{}': {}",
+                    group.getGroupName(),
+                    e.getMessage());
+        }
+    }
+
+    /** Persist user after role & group sync. */
+    protected void persistSynchronizedUser(User user) {
+        try {
+            if (userService != null) {
+                LOGGER.info(
+                        "Persisting user '{}' (id={}, role={}, groups={})",
+                        user.getName(),
+                        user.getId(),
+                        user.getRole(),
+                        user.getGroups());
+                userService.update(user);
+            }
+        } catch (BadRequestServiceEx | NotFoundServiceEx e) {
+            LOGGER.error(
+                    "Updating user with synchronized groups found in claims failed: {}",
+                    e.getMessage(),
+                    e);
+        } catch (DataIntegrityViolationException e) {
+            LOGGER.error(
+                    "Updating user with synchronized groups data integrity violation: {}",
+                    e.getMessage(),
+                    e);
+        } catch (RuntimeException e) {
+            LOGGER.error(
+                    "Unexpected error persisting user '{}' with groups: {}",
+                    user.getName(),
+                    e.getMessage(),
+                    e);
+        } finally {
+            LOGGER.info(
+                    "User '{}' after sync: role={}, groups={}",
+                    user.getName(),
+                    user.getRole(),
+                    user.getGroups());
+        }
+    }
+
+    private TokenDetails extractTokenDetails(Authentication authentication) {
+        Object details = authentication != null ? authentication.getDetails() : null;
+        return (details instanceof TokenDetails) ? (TokenDetails) details : null;
+    }
+
+    /**
+     * Re-reads the user's current role from the database and, if it has changed since the
+     * authentication was cached, rebuilds the authentication with the updated authority. This
+     * ensures that role changes (promotions/demotions via admin UI or DB) take effect immediately
+     * without waiting for token expiry or cache eviction.
+     */
+    private Authentication refreshCachedUserRole(Authentication authentication, String token) {
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof User)) {
+            return authentication;
+        }
+        User cachedUser = (User) principal;
+        String username = cachedUser.getName();
+        if (username == null || userService == null) {
+            return authentication;
+        }
+        try {
+            User dbUser = userService.get(username);
+            if (dbUser != null && dbUser.getRole() != cachedUser.getRole()) {
+                LOGGER.info(
+                        "Role changed in DB for user '{}': {} -> {}. Updating cached authentication.",
+                        username,
+                        cachedUser.getRole(),
+                        dbUser.getRole());
+                cachedUser.setRole(dbUser.getRole());
+                SimpleGrantedAuthority authority =
+                        new SimpleGrantedAuthority("ROLE_" + dbUser.getRole().toString());
+                PreAuthenticatedAuthenticationToken updated =
+                        new PreAuthenticatedAuthenticationToken(
+                                cachedUser,
+                                authentication.getCredentials(),
+                                Collections.singletonList(authority));
+                updated.setDetails(authentication.getDetails());
+                cache.putCacheEntry(token, updated);
+                return updated;
+            }
+        } catch (NotFoundServiceEx e) {
+            LOGGER.debug("User '{}' not found in DB during role refresh.", username);
+        }
+        return authentication;
+    }
+
+    public Authentication completeInteractiveAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            OAuth2AccessToken accessToken,
+            OAuth2RefreshToken refreshToken) {
+        String token = accessToken != null ? accessToken.getTokenValue() : null;
+        return authenticateAndUpdateCache(request, response, token, accessToken, refreshToken);
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
@@ -1,6 +1,5 @@
 package it.geosolutions.geostore.services.rest.security.oauth2;
 
-import static it.geosolutions.geostore.core.security.password.SecurityUtils.getUsername;
 import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.ACCESS_TOKEN_PARAM;
 
 import it.geosolutions.geostore.core.model.User;
@@ -35,7 +34,6 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.server.resource.introspection.BadOpaqueTokenException;
@@ -103,7 +101,7 @@ public class OAuth2GeoStoreAuthenticationService {
             return authenticateAndUpdateCache(request, response, token, bearerAccessToken, null);
         }
 
-        TokenDetails tokenDetails = extractTokenDetails(authentication);
+        TokenDetails tokenDetails = OAuth2Utils.getTokenDetails(authentication);
         if (tokenDetails != null) {
             OAuth2AccessToken accessToken = tokenDetails.getAccessToken();
             if (accessToken != null
@@ -129,7 +127,7 @@ public class OAuth2GeoStoreAuthenticationService {
 
         if (authentication != null) {
 
-            TokenDetails tokenDetails = extractTokenDetails(authentication);
+            TokenDetails tokenDetails = OAuth2Utils.getTokenDetails(authentication);
             if (tokenDetails != null) {
                 OAuth2AccessToken accessTokenDetails = tokenDetails.getAccessToken();
                 if (accessTokenDetails != null) {
@@ -152,7 +150,10 @@ public class OAuth2GeoStoreAuthenticationService {
             OAuth2RefreshToken refreshToken) {
 
         LOGGER.info("About to perform remote authentication.");
-        LOGGER.debug("Access token received (type={}, scopes={})", accessToken.getTokenType().getValue(), accessToken.getScopes());
+        LOGGER.debug(
+                "Access token received (type={}, scopes={})",
+                accessToken.getTokenType().getValue(),
+                accessToken.getScopes());
 
         String principal = null;
 
@@ -328,33 +329,6 @@ public class OAuth2GeoStoreAuthenticationService {
         }
     }
 
-    protected String extractPrincipalFromSecurityContext() {
-        try {
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (authentication == null) {
-                LOGGER.debug("No Authentication found in Spring Security context");
-                return null;
-            }
-
-            String username = getUsername(authentication.getPrincipal());
-            if (StringUtils.isNotBlank(username)) {
-                LOGGER.debug("Resolved username from Spring Security principal");
-                return username;
-            }
-
-            if (StringUtils.isNotBlank(authentication.getName())) {
-                LOGGER.debug("Resolved username from Spring Security authentication name");
-                return authentication.getName();
-            }
-
-            LOGGER.debug("Spring Security context did not provide a usable principal");
-            return null;
-        } catch (Exception e) {
-            LOGGER.warn("Unable to resolve principal from Spring Security context", e);
-            return null;
-        }
-    }
-
     protected String extractPrincipalFromAttributes(Map<String, Object> attributes) {
         try {
             if (attributes == null || attributes.isEmpty()) {
@@ -512,7 +486,7 @@ public class OAuth2GeoStoreAuthenticationService {
         }
 
         LOGGER.info("Retrieving user with authorities for username: {}", username);
-        User user = retrieveUserWithAuthorities(username, request, response);
+        User user = retrieveUserWithAuthorities(username);
         if (user == null) {
             LOGGER.error("User retrieval failed for username: {}", username);
             return null;
@@ -555,8 +529,7 @@ public class OAuth2GeoStoreAuthenticationService {
         return authenticationToken;
     }
 
-    protected User retrieveUserWithAuthorities(
-            String username, HttpServletRequest request, HttpServletResponse response) {
+    protected User retrieveUserWithAuthorities(String username) {
         User user = null;
         if (StringUtils.isNotBlank(username) && userService != null) {
             try {
@@ -572,7 +545,7 @@ public class OAuth2GeoStoreAuthenticationService {
         }
         if (user == null) {
             try {
-                user = createUser(username, "", "");
+                user = createUser(username, "");
             } catch (BadRequestServiceEx | NotFoundServiceEx e) {
                 LOGGER.error("Error while auto-creating the user: '{}'", username, e);
             }
@@ -580,7 +553,7 @@ public class OAuth2GeoStoreAuthenticationService {
         return user;
     }
 
-    protected User createUser(String userName, String credentials, Object rawUser)
+    protected User createUser(String userName, String credentials)
             throws BadRequestServiceEx, NotFoundServiceEx {
         User user = new User();
         user.setName(userName);
@@ -1155,11 +1128,6 @@ public class OAuth2GeoStoreAuthenticationService {
                     user.getRole(),
                     user.getGroups());
         }
-    }
-
-    private TokenDetails extractTokenDetails(Authentication authentication) {
-        Object details = authentication != null ? authentication.getDetails() : null;
-        return (details instanceof TokenDetails) ? (TokenDetails) details : null;
     }
 
     /**

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
@@ -152,7 +152,7 @@ public class OAuth2GeoStoreAuthenticationService {
             OAuth2RefreshToken refreshToken) {
 
         LOGGER.info("About to perform remote authentication.");
-        LOGGER.info("Access Token: {}", accessToken);
+        LOGGER.debug("Access token received (type={}, scopes={})", accessToken.getTokenType().getValue(), accessToken.getScopes());
 
         String principal = null;
 
@@ -424,22 +424,21 @@ public class OAuth2GeoStoreAuthenticationService {
             OAuth2AccessToken accessToken, HttpServletRequest req) {
         try {
             String idToken = OAuth2Utils.getIdToken();
-            String jwtForClaims = idToken;
 
-            if (jwtForClaims == null && accessToken != null) {
-                jwtForClaims = accessToken.getTokenValue();
+            if (idToken == null && accessToken != null) {
+                idToken = accessToken.getTokenValue();
             }
 
-            if (jwtForClaims == null) {
-                jwtForClaims = OAuth2Utils.tokenFromParamsOrBearer(ACCESS_TOKEN_PARAM, req);
+            if (idToken == null) {
+                idToken = OAuth2Utils.tokenFromParamsOrBearer(ACCESS_TOKEN_PARAM, req);
             }
 
-            if (StringUtils.isBlank(jwtForClaims)) {
+            if (StringUtils.isBlank(idToken)) {
                 LOGGER.debug("No JWT available for fallback principal extraction");
                 return null;
             }
 
-            JWTHelper helper = decodeAndValidateJwt(jwtForClaims);
+            JWTHelper helper = decodeAndValidateJwt(idToken);
             if (helper == null) {
                 LOGGER.debug("Unable to decode or validate JWT for fallback principal extraction");
                 return null;

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
@@ -847,16 +847,21 @@ public class OAuth2GeoStoreAuthenticationService {
 
         oidcGroups = applyGroupMappings(oidcGroups);
 
-        // Optional fallback: when nothing could be derived from the claims (claim missing, or
-        // every value dropped by the mappings), assign the configured default group. It flows
-        // through the normal reconciliation, so it is created on the fly, tagged with this
-        // provider as sourceService, and removed again on a later login carrying real groups.
-        String defaultGroup = configuration.getAuthenticatedDefaultGroup();
-        if (oidcGroups.isEmpty() && StringUtils.isNotBlank(defaultGroup)) {
-            oidcGroups = Collections.singletonList(defaultGroup.trim());
+        // Always-assigned default groups: appended to the claim-derived ones, not subject to
+        // groupMappings/dropUnmapped. They flow through the normal reconciliation, so they are
+        // created on the fly when missing, tagged with this provider as sourceService, and
+        // assigned through the user-group service like any claim-derived group.
+        List<String> defaultGroups = configuration.getDefaultGroups();
+        if (defaultGroups != null && !defaultGroups.isEmpty()) {
+            List<String> withDefaults = new ArrayList<>(oidcGroups);
+            for (String defaultGroup : defaultGroups) {
+                if (!withDefaults.contains(defaultGroup)) {
+                    withDefaults.add(defaultGroup);
+                }
+            }
+            oidcGroups = withDefaults;
             LOGGER.info(
-                    "No groups resolved from claims; assigning authenticatedDefaultGroup '{}'",
-                    defaultGroup.trim());
+                    "Adding configured defaultGroups {} to the groups to assign.", defaultGroups);
         }
 
         LOGGER.info(

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
@@ -82,8 +82,15 @@ public class OAuth2GeoStoreAuthenticationService {
         Authentication authentication = cache.get(token);
 
         if (authentication == null) {
-            // Bearer path: no refresh token is available with an incoming bearer token.
-            return authenticateAndUpdateCache(request, response, token, null, null);
+            // Bearer path: wrap the incoming bearer token as an OAuth2AccessToken so its claims
+            // (roles/groups) are available to authority synchronization in createPreAuthentication.
+            // The 2.6.x filter always authenticated bearer tokens with the access token in hand,
+            // and
+            // no refresh token accompanies an incoming bearer token.
+            OAuth2AccessToken bearerAccessToken =
+                    new OAuth2AccessToken(
+                            OAuth2AccessToken.TokenType.BEARER, token, Instant.now(), null);
+            return authenticateAndUpdateCache(request, response, token, bearerAccessToken, null);
         }
 
         TokenDetails tokenDetails = extractTokenDetails(authentication);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationService.java
@@ -61,8 +61,8 @@ public class OAuth2GeoStoreAuthenticationService {
     // protected so the OpenIdConnect subclass can reuse them when overriding principal/authority
     // resolution.
     protected final TokenAuthenticationCache cache;
-    protected final UserService userService;
-    protected final UserGroupService userGroupService;
+    protected UserService userService;
+    protected UserGroupService userGroupService;
     protected final OAuth2Configuration configuration;
 
     public OAuth2GeoStoreAuthenticationService(
@@ -74,6 +74,16 @@ public class OAuth2GeoStoreAuthenticationService {
         this.userService = userService;
         this.userGroupService = userGroupService;
         this.configuration = configuration;
+    }
+
+    /** Allows the owning filter (or tests) to wire the user service after construction. */
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    /** Allows the owning filter (or tests) to wire the user-group service after construction. */
+    public void setUserGroupService(UserGroupService userGroupService) {
+        this.userGroupService = userGroupService;
     }
 
     public Authentication authenticate(

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -557,7 +557,7 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
 
         LOGGER.info("Updating the cache and the SecurityContext with new Auth details");
         if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
-            TokenDetails details = getTokenDetails(authentication);
+            TokenDetails details = OAuth2Utils.getTokenDetails(authentication);
             String idToken = details != null ? details.getIdToken() : null;
             cache().removeEntry(oldToken);
             PreAuthenticatedAuthenticationToken updated =
@@ -574,10 +574,6 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
             cache().putCacheEntry(newToken.getTokenValue(), updated);
             SecurityContextHolder.getContext().setAuthentication(updated);
         }
-    }
-
-    protected TokenDetails getTokenDetails(Authentication authentication) {
-        return OAuth2Utils.getTokenDetails(authentication);
     }
 
     protected OAuth2AccessToken retrieveAccessToken(String accessToken, Long expires) {
@@ -625,7 +621,7 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         if (sessionId != null) {
             TokenAuthenticationCache cache = cache();
             Authentication authentication = cache.get(sessionId);
-            TokenDetails tokenDetails = getTokenDetails(authentication);
+            TokenDetails tokenDetails = OAuth2Utils.getTokenDetails(authentication);
             if (tokenDetails != null) {
                 token = tokenDetails.getIdToken();
                 if (tokenDetails.getAccessToken() != null) {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -66,6 +66,7 @@ import org.springframework.security.oauth2.core.http.converter.OAuth2AccessToken
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -76,6 +77,10 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
     private static final Logger LOGGER = LogManager.getLogger(OAuth2SessionServiceDelegate.class);
 
     private static final long CLOCK_SKEW_ALLOWANCE_MILLIS = 5 * 60 * 1000; // 5 minutes
+
+    // Force a real IdP refresh when the refresh token itself is this close to its own
+    // (fixed) expiry: IdP refresh tokens only slide when a refresh grant is performed.
+    private static final long REFRESH_TOKEN_EXPIRY_SAFETY_WINDOW_MILLIS = 2 * 60 * 1000;
 
     protected UserService userService;
     protected final String delegateName;
@@ -130,7 +135,8 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         SessionToken sessionToken = null;
         OAuth2Configuration configuration = configuration();
 
-        if (configuration != null && shouldSkipRefresh(currentToken, configuration)) {
+        if (configuration != null
+                && shouldSkipRefresh(currentToken, refreshTokenToUse, configuration)) {
             LOGGER.debug("Token still has sufficient validity; skipping IDP refresh.");
             warningMessage = "Token still valid; refresh skipped.";
         } else if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
@@ -234,6 +240,40 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         }
     }
 
+    /**
+     * Whether the refresh token (when it is a JWT carrying an {@code exp} claim, as Keycloak's are)
+     * is within the safety window of its own expiry. Opaque refresh tokens carry no expiry
+     * information and keep the legacy behavior.
+     */
+    private boolean isRefreshTokenNearExpiry(String refreshToken) {
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return false;
+        }
+        Date expiration = getExpirationDateQuietly(refreshToken);
+        if (expiration == null) {
+            return false;
+        }
+        long remaining = expiration.getTime() - System.currentTimeMillis();
+        return remaining <= REFRESH_TOKEN_EXPIRY_SAFETY_WINDOW_MILLIS;
+    }
+
+    /**
+     * Like {@link #getExpirationDateFromToken(String)} but silent: meant for tokens that may
+     * legitimately be opaque (non-JWT), where a parse failure is expected and must not log.
+     */
+    private Date getExpirationDateQuietly(String token) {
+        try {
+            Map<String, Object> claims = new JWTHelper(token).getPayloadAsMap();
+            Object exp = claims.get("exp");
+            if (exp == null) {
+                return null;
+            }
+            return new Date(toEpochSeconds(exp) * 1000);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     private Date getIssuedAtFromToken(String token) {
         try {
             Map<String, Object> claims = new JWTHelper(token).getPayloadAsMap();
@@ -261,8 +301,21 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         throw new IllegalArgumentException("Cannot parse epoch-seconds claim from token");
     }
 
-    boolean shouldSkipRefresh(OAuth2AccessToken token, OAuth2Configuration config) {
+    protected boolean shouldSkipRefresh(
+            OAuth2AccessToken token, String refreshToken, OAuth2Configuration config) {
         if (!config.isSkipRefreshIfTokenValid()) {
+            return false;
+        }
+
+        // Never skip when the refresh token itself is close to its own expiry: IdP refresh
+        // tokens (e.g. Keycloak refresh_expires_in / session idle, 30 minutes by default)
+        // only slide when a refresh grant is actually performed. Skipping past that window
+        // leaves an unrefreshable session even though the access token still looks healthy,
+        // and the session dies at the first real refresh attempt.
+        if (isRefreshTokenNearExpiry(refreshToken)) {
+            LOGGER.info(
+                    "Refresh token close to its expiry; performing a real IdP refresh "
+                            + "even though the access token is still valid.");
             return false;
         }
 
@@ -375,6 +428,14 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
                 }
             } catch (RestClientException ex) {
                 LOGGER.error("Attempt {}: Error refreshing token: {}", attempt, ex.getMessage());
+                if (ex instanceof HttpStatusCodeException) {
+                    // Surface the IdP error payload (e.g. invalid_grant vs invalid_client):
+                    // it pinpoints whether the refresh token expired or the client
+                    // credentials are wrong, which is otherwise invisible at this level.
+                    LOGGER.warn(
+                            "Token refresh rejected by the identity provider: {}",
+                            ((HttpStatusCodeException) ex).getResponseBodyAsString());
+                }
                 if (attempt == maxRetries) {
                     errorMessage = "Max retries reached. Unable to refresh token.";
                     LOGGER.error(errorMessage);
@@ -419,28 +480,43 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
     public void handleRefreshFailure(
             String accessToken, String refreshToken, OAuth2Configuration configuration) {
         LOGGER.info(
-                "Unable to refresh token after max retries. Clearing session and redirecting to login.");
+                "Unable to refresh token after max retries. Clearing the session and reporting "
+                        + "the failure to the client.");
         HttpServletResponse response = getResponse();
         if (response != null) {
             clearRefreshTokenCookie(response);
         }
         doLogout(null);
 
-        try {
-            HttpServletResponse redirectResponse = getResponse();
-            // Only redirect once: handleRefreshFailure may be reached both from doRefresh and from
-            // the expired-token path, and a response can be redirected only before it is committed.
-            if (configuration != null
-                    && configuration.getProvider() != null
-                    && redirectResponse != null
-                    && !redirectResponse.isCommitted()) {
-                String redirectUrl =
-                        "../../openid/" + configuration.getProvider().toLowerCase() + "/login";
-                redirectResponse.sendRedirect(redirectUrl);
+        // This endpoint is invoked via XHR: never redirect. The 302 to the login page cannot
+        // be followed by the client (observed live as a 302 -> 404 chain through the
+        // front-end proxy that wiped the session). Report a clean 401 with the login URL so
+        // the client can start a new authorization flow itself. The committed check keeps the
+        // body from being written twice: handleRefreshFailure may be reached both from
+        // doRefresh and from the expired-token path.
+        HttpServletResponse failureResponse = getResponse();
+        if (failureResponse != null && !failureResponse.isCommitted()) {
+            try {
+                String loginUrl = null;
+                if (configuration != null && configuration.getProvider() != null) {
+                    loginUrl =
+                            "../../openid/" + configuration.getProvider().toLowerCase() + "/login";
+                }
+                failureResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                failureResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                StringBuilder body =
+                        new StringBuilder(
+                                "{\"error\":\"session_expired\","
+                                        + "\"message\":\"Token refresh failed; a new login is required.\"");
+                if (loginUrl != null) {
+                    body.append(",\"loginUrl\":\"").append(loginUrl).append("\"");
+                }
+                body.append("}");
+                failureResponse.getWriter().write(body.toString());
+                failureResponse.getWriter().flush();
+            } catch (IOException e) {
+                LOGGER.error("Error while writing the refresh-failure response: ", e);
             }
-        } catch (IOException e) {
-            LOGGER.error("Error while sending redirect to login service: ", e);
-            throw new RuntimeException("Failed to redirect to login", e);
         }
     }
 
@@ -681,7 +757,11 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         if (allCookies != null)
             for (Cookie toDelete : allCookies) {
                 if (deleteCookie(toDelete)) {
-                    toDelete.setMaxAge(-1);
+                    // Max-Age must be 0 (-1 means "session cookie" and would RE-INSTATE the
+                    // cookie with its current value: observed live as a logout response
+                    // carrying both the clearing Set-Cookie and a full refresh_token one).
+                    toDelete.setValue("");
+                    toDelete.setMaxAge(0);
                     toDelete.setPath("/");
                     toDelete.setComment("EXPIRING COOKIE at " + System.currentTimeMillis());
                     if (toDelete.getName().equalsIgnoreCase(REFRESH_TOKEN_PARAM)) {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -1,0 +1,821 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2022 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.*;
+
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.security.password.SecurityUtils;
+import it.geosolutions.geostore.services.UserService;
+import it.geosolutions.geostore.services.rest.RESTSessionService;
+import it.geosolutions.geostore.services.rest.SessionServiceDelegate;
+import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
+import it.geosolutions.geostore.services.rest.model.SessionToken;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.utils.GeoStoreContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/** Abstract implementation of an OAuth2 SessionServiceDelegate. */
+public abstract class OAuth2SessionServiceDelegate implements SessionServiceDelegate {
+
+    private static final Logger LOGGER = LogManager.getLogger(OAuth2SessionServiceDelegate.class);
+
+    private static final long CLOCK_SKEW_ALLOWANCE_MILLIS = 5 * 60 * 1000; // 5 minutes
+
+    protected UserService userService;
+    protected final String delegateName;
+
+    /**
+     * @param restSessionService the session service to which register this delegate.
+     * @param delegateName this delegate name eg. google or GitHub etc...
+     */
+    public OAuth2SessionServiceDelegate(
+            RESTSessionService restSessionService, String delegateName, UserService userService) {
+        restSessionService.registerDelegate(delegateName, this);
+        this.delegateName = delegateName;
+        this.userService = userService;
+    }
+
+    public OAuth2SessionServiceDelegate(
+            RestTemplate restTemplate, OAuth2Configuration configuration) {
+        this.delegateName = null;
+    }
+
+    @Override
+    public SessionToken refresh(String refreshToken, String accessToken) {
+        String errorMessage = "";
+        String warningMessage = "";
+        HttpServletRequest request = getRequest();
+
+        // Ensure accessToken is available
+        if (accessToken == null || accessToken.isEmpty()) {
+            accessToken = OAuth2Utils.tokenFromParamsOrBearer(ACCESS_TOKEN_PARAM, request);
+        }
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new NotFoundWebEx("Either the accessToken or the refresh token are missing");
+        }
+
+        OAuth2AccessToken currentToken = retrieveAccessToken(accessToken, null);
+
+        // Determine refreshTokenToUse: prefer the cached refresh token, then the supplied one,
+        // then a request parameter, then the HttpOnly cookie.
+        String refreshTokenToUse =
+                Optional.ofNullable(refreshTokenFromCache(accessToken))
+                        .filter(value -> !value.isEmpty())
+                        .orElse(refreshToken);
+
+        if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
+            refreshTokenToUse = getParameterValue(REFRESH_TOKEN_PARAM, request);
+        }
+
+        if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
+            refreshTokenToUse = getRefreshTokenFromCookie(request);
+        }
+
+        SessionToken sessionToken = null;
+        OAuth2Configuration configuration = configuration();
+
+        if (configuration != null && shouldSkipRefresh(currentToken, configuration)) {
+            LOGGER.debug("Token still has sufficient validity; skipping IDP refresh.");
+            warningMessage = "Token still valid; refresh skipped.";
+        } else if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
+            // No refresh token available (e.g. bearer-token auth without auth code flow, or the IdP
+            // did not issue a refresh token because offline_access was not requested). Skip the
+            // refresh attempt and return the current token if still valid.
+            LOGGER.info(
+                    "No refresh token available; skipping token refresh and returning current token.");
+            warningMessage = "No refresh token available; using existing access token.";
+        } else if (configuration != null && configuration.isEnabled()) {
+            LOGGER.info("Attempting to refresh the token.");
+            try {
+                sessionToken = doRefresh(refreshTokenToUse, accessToken, configuration);
+                if (sessionToken != null) {
+                    currentToken =
+                            retrieveAccessToken(
+                                    sessionToken.getAccessToken(), sessionToken.getExpires());
+                }
+            } catch (Exception e) {
+                errorMessage = "An error occurred during token refresh: " + e.getMessage();
+                LOGGER.error(errorMessage, e);
+            }
+        } else {
+            LOGGER.warn("Configuration is null or disabled; skipping token refresh.");
+        }
+
+        if (sessionToken == null) {
+            if (isTokenExpired(currentToken)) {
+                errorMessage = "Token is invalid or expired, and refresh failed.";
+                LOGGER.error(errorMessage);
+                handleRefreshFailure(accessToken, refreshTokenToUse, configuration);
+                return null;
+            } else {
+                if (warningMessage.isEmpty()) warningMessage = "Using existing access token.";
+                sessionToken =
+                        sessionToken(accessToken, refreshTokenToUse, currentToken.getExpiresAt());
+            }
+        }
+
+        if (!warningMessage.isEmpty()) {
+            sessionToken.setWarning(warningMessage);
+        }
+        if (!errorMessage.isEmpty()) {
+            sessionToken.setError(errorMessage);
+        }
+
+        request.setAttribute(OAuth2Utils.ACCESS_TOKEN_VALUE, sessionToken.getAccessToken());
+        request.setAttribute(OAuth2Utils.ACCESS_TOKEN_TYPE, sessionToken.getTokenType());
+
+        // Set updated refresh token as HttpOnly cookie and remove it from the JSON response.
+        HttpServletResponse response = getResponse();
+        if (response != null && sessionToken.getRefreshToken() != null) {
+            setRefreshTokenCookie(response, sessionToken.getRefreshToken(), request.isSecure());
+            sessionToken.setRefreshToken(null);
+        }
+
+        return sessionToken;
+    }
+
+    /** Reads the refresh token (if any) cached alongside the given access token. */
+    private String refreshTokenFromCache(String accessToken) {
+        Authentication authentication = cache() != null ? cache().get(accessToken) : null;
+        TokenDetails details = OAuth2Utils.getTokenDetails(authentication);
+        if (details != null && details.getRefreshToken() != null) {
+            return details.getRefreshToken().getTokenValue();
+        }
+        return null;
+    }
+
+    private boolean isTokenExpired(OAuth2AccessToken token) {
+        if (token == null || token.getTokenValue().isEmpty()) {
+            return true;
+        }
+
+        Date expiration = token.getExpiresAt() != null ? Date.from(token.getExpiresAt()) : null;
+
+        if (expiration == null) {
+            expiration = getExpirationDateFromToken(token.getTokenValue());
+            if (expiration == null) {
+                return true;
+            }
+        }
+
+        long now = System.currentTimeMillis();
+        long adjustedExpirationTime = expiration.getTime() + CLOCK_SKEW_ALLOWANCE_MILLIS;
+
+        return adjustedExpirationTime <= now;
+    }
+
+    private Date getExpirationDateFromToken(String token) {
+        try {
+            Map<String, Object> claims = new JWTHelper(token).getPayloadAsMap();
+            Object exp = claims.get("exp");
+            if (exp != null) {
+                return new Date(toEpochSeconds(exp) * 1000);
+            }
+            return null;
+        } catch (Exception e) {
+            LOGGER.error("Failed to parse JWT token: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private Date getIssuedAtFromToken(String token) {
+        try {
+            Map<String, Object> claims = new JWTHelper(token).getPayloadAsMap();
+            Object iat = claims.get("iat");
+            if (iat != null) {
+                return new Date(toEpochSeconds(iat) * 1000);
+            }
+            return null;
+        } catch (Exception e) {
+            LOGGER.debug("Failed to parse 'iat' from JWT token: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private long toEpochSeconds(Object value) {
+        if (value instanceof Integer) {
+            return ((Integer) value).longValue();
+        } else if (value instanceof Long) {
+            return (Long) value;
+        } else if (value instanceof Number) {
+            return ((Number) value).longValue();
+        } else if (value instanceof String) {
+            return Long.parseLong((String) value);
+        }
+        throw new IllegalArgumentException("Cannot parse epoch-seconds claim from token");
+    }
+
+    boolean shouldSkipRefresh(OAuth2AccessToken token, OAuth2Configuration config) {
+        if (!config.isSkipRefreshIfTokenValid()) {
+            return false;
+        }
+
+        Date expiration = token.getExpiresAt() != null ? Date.from(token.getExpiresAt()) : null;
+        if (expiration == null) {
+            expiration = getExpirationDateFromToken(token.getTokenValue());
+        }
+        if (expiration == null) {
+            return false;
+        }
+
+        long now = System.currentTimeMillis();
+        if (expiration.getTime() <= now) {
+            return false;
+        }
+
+        Date issuedAt = getIssuedAtFromToken(token.getTokenValue());
+        if (issuedAt != null) {
+            long totalLifetime = expiration.getTime() - issuedAt.getTime();
+            long elapsed = now - issuedAt.getTime();
+            double fraction = config.getRefreshTokenLifetimeFraction();
+            return elapsed < totalLifetime * fraction;
+        }
+
+        // Fallback: skip if more than 5 minutes remaining
+        long remaining = expiration.getTime() - now;
+        return remaining > CLOCK_SKEW_ALLOWANCE_MILLIS;
+    }
+
+    /**
+     * Invokes the refresh endpoint to get a new session token with updated token details.
+     *
+     * <p>Attempts to refresh the session by exchanging the provided refresh token for a new access
+     * token. If the refresh token is invalid or the request fails after several retries, the
+     * session is cleared and the user is redirected to the login page.
+     *
+     * @param refreshToken the refresh token to use for obtaining new access and refresh tokens
+     * @param accessToken the current access token
+     * @param configuration the OAuth2Configuration containing client credentials and endpoint URI
+     * @return a SessionToken containing the new token details, or null if the refresh process
+     *     failed
+     */
+    protected SessionToken doRefresh(
+            String refreshToken, String accessToken, OAuth2Configuration configuration) {
+        SessionToken sessionToken = null;
+        int attempt = 0;
+        String errorMessage = "";
+
+        // Use a plain RestTemplate (with the OAuth2 token-response converter) for the refresh
+        // request body shaping; this mirrors the legacy behavior where the client secret is always
+        // sent on refresh, independent of any sendClientSecret toggle.
+        RestTemplate plainRestTemplate = createRefreshRestTemplate();
+        HttpHeaders headers = getHttpHeaders(accessToken, configuration);
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("grant_type", "refresh_token");
+        requestBody.add("refresh_token", refreshToken);
+        requestBody.add("client_secret", configuration.getClientSecret());
+        requestBody.add("client_id", configuration.getClientId());
+        if (configuration.getScopes() != null && !configuration.getScopes().isEmpty()) {
+            requestBody.add("scope", configuration.getScopes().replace(",", " "));
+        }
+        HttpEntity<MultiValueMap<String, String>> requestEntity =
+                new HttpEntity<>(requestBody, headers);
+
+        long backoffDelay = configuration.getInitialBackoffDelay();
+        int maxRetries = configuration.getMaxRetries() > 0 ? configuration.getMaxRetries() : 1;
+
+        while (attempt < maxRetries) {
+            attempt++;
+            LOGGER.info("Attempting to refresh token, attempt {} of {}", attempt, maxRetries);
+
+            try {
+                ResponseEntity<OAuth2AccessTokenResponse> response =
+                        plainRestTemplate.exchange(
+                                configuration.getAccessTokenUri(),
+                                HttpMethod.POST,
+                                requestEntity,
+                                OAuth2AccessTokenResponse.class);
+
+                if (response.getStatusCode().is2xxSuccessful()) {
+                    OAuth2AccessTokenResponse tokenResponse = response.getBody();
+                    OAuth2AccessToken newToken =
+                            tokenResponse != null ? tokenResponse.getAccessToken() : null;
+                    if (newToken != null && !isTokenExpired(newToken)) {
+                        OAuth2RefreshToken newRefreshToken = tokenResponse.getRefreshToken();
+                        OAuth2RefreshToken refreshTokenToUse =
+                                (newRefreshToken != null && newRefreshToken.getTokenValue() != null)
+                                        ? newRefreshToken
+                                        : new OAuth2RefreshToken(refreshToken, null);
+
+                        updateAuthToken(accessToken, newToken, refreshTokenToUse, configuration);
+                        sessionToken =
+                                sessionToken(
+                                        newToken.getTokenValue(),
+                                        refreshTokenToUse.getTokenValue(),
+                                        newToken.getExpiresAt());
+
+                        LOGGER.info("Token refreshed successfully on attempt {}", attempt);
+                        break;
+                    } else {
+                        LOGGER.warn("Received invalid or expired token on attempt {}", attempt);
+                    }
+                } else if (response.getStatusCode().is4xxClientError()) {
+                    LOGGER.error(
+                            "Client error occurred: {}. Stopping further attempts.",
+                            response.getStatusCode());
+                    break;
+                } else {
+                    LOGGER.warn("Server error occurred: {}. Retrying...", response.getStatusCode());
+                }
+            } catch (RestClientException ex) {
+                LOGGER.error("Attempt {}: Error refreshing token: {}", attempt, ex.getMessage());
+                if (attempt == maxRetries) {
+                    errorMessage = "Max retries reached. Unable to refresh token.";
+                    LOGGER.error(errorMessage);
+                    break;
+                }
+            }
+
+            // Apply backoff delay before the next retry, unless it's the last attempt
+            if (attempt < maxRetries) {
+                try {
+                    LOGGER.info("Waiting for {} ms before next retry.", backoffDelay);
+                    Thread.sleep(backoffDelay);
+                } catch (InterruptedException e) {
+                    LOGGER.warn("Backoff delay interrupted", e);
+                    Thread.currentThread().interrupt();
+                }
+                backoffDelay *= configuration.getBackoffMultiplier();
+            }
+        }
+
+        // Only call handleRefreshFailure if sessionToken is null after all attempts and errors
+        if (sessionToken == null) {
+            try {
+                handleRefreshFailure(accessToken, refreshToken, configuration);
+            } catch (Exception e) {
+                errorMessage =
+                        "Could not successfully perform the 'doLogout' procedure due to an internal error.";
+                LOGGER.error(errorMessage, e);
+            }
+        }
+        return sessionToken;
+    }
+
+    /**
+     * Handles the refresh failure by clearing the session, logging out remotely, and redirecting to
+     * login.
+     *
+     * @param accessToken the current access token
+     * @param refreshToken the current refresh token
+     * @param configuration the OAuth2Configuration with endpoint details
+     */
+    public void handleRefreshFailure(
+            String accessToken, String refreshToken, OAuth2Configuration configuration) {
+        LOGGER.info(
+                "Unable to refresh token after max retries. Clearing session and redirecting to login.");
+        HttpServletResponse response = getResponse();
+        if (response != null) {
+            clearRefreshTokenCookie(response);
+        }
+        doLogout(null);
+
+        try {
+            HttpServletResponse redirectResponse = getResponse();
+            // Only redirect once: handleRefreshFailure may be reached both from doRefresh and from
+            // the expired-token path, and a response can be redirected only before it is committed.
+            if (configuration != null
+                    && configuration.getProvider() != null
+                    && redirectResponse != null
+                    && !redirectResponse.isCommitted()) {
+                String redirectUrl =
+                        "../../openid/" + configuration.getProvider().toLowerCase() + "/login";
+                redirectResponse.sendRedirect(redirectUrl);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Error while sending redirect to login service: ", e);
+            throw new RuntimeException("Failed to redirect to login", e);
+        }
+    }
+
+    private static HttpHeaders getHttpHeaders(
+            String accessToken, OAuth2Configuration configuration) {
+        HttpHeaders headers = new HttpHeaders();
+        if (configuration != null
+                && configuration.getClientId() != null
+                && configuration.getClientSecret() != null) {
+            // Set client ID and client secret for authentication.
+            headers.setBasicAuth(configuration.getClientId(), configuration.getClientSecret());
+        } else if (accessToken != null && !accessToken.isEmpty()) {
+            headers.set("Authorization", "Bearer " + accessToken);
+        }
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
+    }
+
+    private SessionToken sessionToken(String accessToken, String refreshToken, Instant expires) {
+        SessionToken sessionToken = new SessionToken();
+        if (expires != null) sessionToken.setExpires(expires.toEpochMilli());
+        sessionToken.setAccessToken(accessToken);
+        sessionToken.setRefreshToken(refreshToken);
+        sessionToken.setTokenType("bearer");
+        return sessionToken;
+    }
+
+    // Builds an authentication instance out of the passed values and sets it both to the cache and
+    // to the SecurityContext to be sure the new token is updated.
+    protected void updateAuthToken(
+            String oldToken,
+            OAuth2AccessToken newToken,
+            OAuth2RefreshToken refreshToken,
+            OAuth2Configuration conf) {
+        Authentication authentication = cache().get(oldToken);
+        if (authentication == null)
+            authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        LOGGER.info("Updating the cache and the SecurityContext with new Auth details");
+        if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
+            TokenDetails details = getTokenDetails(authentication);
+            String idToken = details != null ? details.getIdToken() : null;
+            cache().removeEntry(oldToken);
+            PreAuthenticatedAuthenticationToken updated =
+                    new PreAuthenticatedAuthenticationToken(
+                            authentication.getPrincipal(),
+                            authentication.getCredentials(),
+                            authentication.getAuthorities());
+            LOGGER.info(
+                    "Creating new details. AccessToken: {} IdToken: {}",
+                    newToken.getTokenValue(),
+                    idToken);
+            updated.setDetails(
+                    new TokenDetails(newToken, idToken, conf.getBeanName(), refreshToken));
+            cache().putCacheEntry(newToken.getTokenValue(), updated);
+            SecurityContextHolder.getContext().setAuthentication(updated);
+        }
+    }
+
+    protected TokenDetails getTokenDetails(Authentication authentication) {
+        return OAuth2Utils.getTokenDetails(authentication);
+    }
+
+    protected OAuth2AccessToken retrieveAccessToken(String accessToken, Long expires) {
+        Authentication authentication = cache() != null ? cache().get(accessToken) : null;
+        OAuth2AccessToken result = null;
+        if (authentication != null) {
+            TokenDetails details = OAuth2Utils.getTokenDetails(authentication);
+            if (details != null) result = details.getAccessToken();
+        }
+        if (result == null) {
+            Instant expiresAt =
+                    (expires != null && expires > 0) ? Instant.ofEpochMilli(expires) : null;
+            result =
+                    new OAuth2AccessToken(
+                            OAuth2AccessToken.TokenType.BEARER,
+                            accessToken,
+                            Instant.now(),
+                            expiresAt);
+        }
+        return result;
+    }
+
+    protected HttpServletRequest getRequest() {
+        return OAuth2Utils.getRequest();
+    }
+
+    protected HttpServletResponse getResponse() {
+        return OAuth2Utils.getResponse();
+    }
+
+    @Override
+    public void doLogout(String sessionId) {
+        HttpServletRequest request = getRequest();
+        HttpServletResponse response = getResponse();
+        OAuth2Configuration configuration = configuration();
+
+        if (request == null || response == null || configuration == null) {
+            LOGGER.warn(
+                    "Request, response, or configuration is null, unable to proceed with logout.");
+            return;
+        }
+
+        String token = null;
+        String accessToken = null;
+        if (sessionId != null) {
+            TokenAuthenticationCache cache = cache();
+            Authentication authentication = cache.get(sessionId);
+            TokenDetails tokenDetails = getTokenDetails(authentication);
+            if (tokenDetails != null) {
+                token = tokenDetails.getIdToken();
+                if (tokenDetails.getAccessToken() != null) {
+                    accessToken = tokenDetails.getAccessToken().getTokenValue();
+                }
+            }
+            cache.removeEntry(sessionId);
+        }
+
+        if (token == null) {
+            token = OAuth2Utils.getParameterValue(REFRESH_TOKEN_PARAM, request);
+            if (token == null && RequestContextHolder.getRequestAttributes() != null) {
+                token =
+                        (String)
+                                RequestContextHolder.getRequestAttributes()
+                                        .getAttribute(REFRESH_TOKEN_PARAM, 0);
+            }
+        }
+
+        if (accessToken == null) {
+            accessToken = OAuth2Utils.getParameterValue(ACCESS_TOKEN_PARAM, request);
+            if (accessToken == null && RequestContextHolder.getRequestAttributes() != null) {
+                accessToken =
+                        (String)
+                                RequestContextHolder.getRequestAttributes()
+                                        .getAttribute(ACCESS_TOKEN_PARAM, 0);
+            }
+        }
+
+        if (configuration.isEnabled()) {
+            if (token != null
+                    && accessToken != null
+                    && !token.isEmpty()
+                    && !accessToken.isEmpty()) {
+                if (configuration.isGlobalLogoutEnabled())
+                    doLogoutInternal(token, configuration, accessToken);
+                if (configuration.getRevokeEndpoint() != null) clearSession(request);
+            } else {
+                LOGGER.debug("Unable to retrieve access token. Remote logout was not executed.");
+            }
+            if (response != null) clearCookies(request, response);
+        }
+    }
+
+    // Clears any session state.
+    private void clearSession(HttpServletRequest request) {
+        try {
+            request.logout();
+        } catch (ServletException e) {
+            LOGGER.error("Error happened while doing request logout: ", e);
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    /**
+     * Call the revoke/logout endpoint of the OAuth2 provider.
+     *
+     * @param token the access token.
+     * @param configuration the OAuth2Configuration
+     */
+    protected void doLogoutInternal(
+            Object token, OAuth2Configuration configuration, String accessToken) {
+        String tokenValue = null;
+        if (token instanceof OAuth2AccessToken) {
+            tokenValue = ((OAuth2AccessToken) token).getTokenValue();
+        } else if (token instanceof String) {
+            tokenValue = (String) token;
+        }
+        if (tokenValue == null) return;
+
+        // Revoke the token if a revocation endpoint is available
+        if (configuration.getRevokeEndpoint() != null) {
+            LOGGER.debug("Revoking token at revocation endpoint");
+            callRevokeEndpoint(tokenValue, accessToken);
+        }
+
+        // Call the remote logout endpoint (end_session_endpoint) independently
+        LOGGER.debug("Performing remote logout");
+        callRemoteLogout(tokenValue, accessToken);
+    }
+
+    protected void callRevokeEndpoint(String token, String accessToken) {
+        OAuth2Configuration configuration = configuration();
+        if (configuration != null && configuration.isEnabled()) {
+            OAuth2Configuration.Endpoint revokeEndpoint =
+                    configuration.buildRevokeEndpoint(token, accessToken, configuration);
+            if (revokeEndpoint != null) {
+                RestTemplate template = new RestTemplate();
+                try {
+                    ResponseEntity<String> responseEntity =
+                            template.exchange(
+                                    revokeEndpoint.getUrl(),
+                                    revokeEndpoint.getMethod(),
+                                    revokeEndpoint.getRequestEntity(),
+                                    String.class);
+                    if (responseEntity.getStatusCode().value() != 200) {
+                        logRevokeErrors(responseEntity.getBody());
+                    }
+                } catch (Exception e) {
+                    logRevokeErrors(e);
+                }
+            }
+        }
+    }
+
+    protected void callRemoteLogout(String token, String accessToken) {
+        OAuth2Configuration configuration = configuration();
+        if (configuration != null && configuration.isEnabled()) {
+            OAuth2Configuration.Endpoint logoutEndpoint =
+                    configuration.buildLogoutEndpoint(token, accessToken, configuration);
+            if (logoutEndpoint != null) {
+                RestTemplate template = new RestTemplate();
+                ResponseEntity<String> responseEntity =
+                        template.exchange(
+                                logoutEndpoint.getUrl(),
+                                logoutEndpoint.getMethod(),
+                                logoutEndpoint.getRequestEntity(),
+                                String.class);
+                if (responseEntity.getStatusCode().value() != 200) {
+                    logRevokeErrors(responseEntity.getBody());
+                }
+            }
+        }
+    }
+
+    protected void clearCookies(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] allCookies = request.getCookies();
+        if (allCookies != null)
+            for (Cookie toDelete : allCookies) {
+                if (deleteCookie(toDelete)) {
+                    toDelete.setMaxAge(-1);
+                    toDelete.setPath("/");
+                    toDelete.setComment("EXPIRING COOKIE at " + System.currentTimeMillis());
+                    if (toDelete.getName().equalsIgnoreCase(REFRESH_TOKEN_PARAM)) {
+                        toDelete.setHttpOnly(true);
+                        toDelete.setSecure(request.isSecure());
+                    }
+                    response.addCookie(toDelete);
+                }
+            }
+    }
+
+    protected boolean deleteCookie(Cookie c) {
+        return c.getName().equalsIgnoreCase("JSESSIONID")
+                || c.getName().equalsIgnoreCase(ACCESS_TOKEN_PARAM)
+                || c.getName().equalsIgnoreCase(REFRESH_TOKEN_PARAM);
+    }
+
+    protected String getRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (REFRESH_TOKEN_PARAM.equalsIgnoreCase(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    protected void setRefreshTokenCookie(
+            HttpServletResponse response, String refreshToken, boolean secure) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_PARAM, refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(secure);
+        cookie.setPath("/");
+        cookie.setMaxAge(604800); // 7 days
+        response.addCookie(cookie);
+    }
+
+    protected void clearRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_PARAM, "");
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+
+    protected TokenAuthenticationCache cache() {
+        return GeoStoreContext.bean("oAuth2Cache", TokenAuthenticationCache.class);
+    }
+
+    /**
+     * Get the OAuth2Configuration. Prefers the provider-specific bean ({delegateName}OAuth2Config)
+     * and falls back to iterating all enabled configurations.
+     *
+     * @return the OAuth2Configuration.
+     */
+    protected OAuth2Configuration configuration() {
+        // Try provider-specific bean first
+        if (delegateName != null) {
+            OAuth2Configuration specific =
+                    GeoStoreContext.bean(
+                            delegateName + OAuth2Configuration.CONFIG_NAME_SUFFIX,
+                            OAuth2Configuration.class);
+            if (specific != null && specific.isEnabled()) {
+                return specific;
+            }
+        }
+        // Fallback: iterate all configurations
+        Map<String, OAuth2Configuration> configurations =
+                GeoStoreContext.beans(OAuth2Configuration.class);
+        if (configurations != null) {
+            Optional<OAuth2Configuration> enabledConfig =
+                    configurations.values().stream()
+                            .filter(OAuth2Configuration::isEnabled)
+                            .findFirst();
+
+            if (enabledConfig.isPresent()) {
+                return enabledConfig.get();
+            }
+        } else {
+            LOGGER.error("OAuth2Configuration is not initialized properly.");
+            throw new IllegalStateException("Configuration is required but not initialized.");
+        }
+        return null;
+    }
+
+    /**
+     * Creates a plain RestTemplate for token refresh requests, configured with the OAuth2 token
+     * response converter so the token-endpoint JSON deserializes into an {@link
+     * OAuth2AccessTokenResponse}.
+     */
+    protected RestTemplate createRefreshRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setMessageConverters(
+                Arrays.asList(
+                        new FormHttpMessageConverter(),
+                        new OAuth2AccessTokenResponseHttpMessageConverter()));
+        return restTemplate;
+    }
+
+    @Override
+    public User getUser(String sessionId, boolean refresh, boolean autorefresh) {
+        String username = getUserName(sessionId, refresh, autorefresh);
+        if (username != null) {
+            User user;
+            try {
+                user = userService.get(username);
+            } catch (Exception e) {
+                LOGGER.warn("Issue while retrieving user. Will return just the username.", e);
+                user = new User();
+                user.setName(username);
+            }
+            return user;
+        }
+        return null;
+    }
+
+    @Override
+    public String getUserName(String sessionId, boolean refresh, boolean autorefresh) {
+        TokenAuthenticationCache cache = cache();
+        Authentication authentication = cache.get(sessionId);
+        if (refresh)
+            LOGGER.warn(
+                    "Refresh was set to true but this delegate is "
+                            + "not supporting refreshing token when retrieving the user...");
+        if (authentication != null) {
+            Object o = authentication.getPrincipal();
+            if (o != null) return SecurityUtils.getUsername(o);
+        }
+        return null;
+    }
+
+    private static void logRevokeErrors(Object cause) {
+        LOGGER.error("Error while revoking authorization. Error is: {}", cause);
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Utils.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Utils.java
@@ -57,6 +57,15 @@ public class OAuth2Utils {
     public static final String AUTH_PROVIDER = "authProvider";
 
     /**
+     * Request-attribute key holding the raw access/ID token value for downstream readers (replaces
+     * the legacy {@code OAuth2AuthenticationDetails.ACCESS_TOKEN_VALUE}).
+     */
+    public static final String ACCESS_TOKEN_VALUE = "OAuth2-AccessTokenValue";
+
+    /** Request-attribute key holding the access token type (replaces the legacy constant). */
+    public static final String ACCESS_TOKEN_TYPE = "OAuth2-AccessTokenType";
+
+    /**
      * Retrieve a token either from a request param or from the Bearer.
      *
      * @param paramName the name of the request param.
@@ -124,14 +133,16 @@ public class OAuth2Utils {
         return token;
     }
 
-    //    /**
-    //     * Get the id token from the request attributes.
-    //     *
-    //     * @return the id token value if found, null otherwise.
-    //     */
-    //    public static String getIdToken() {
-    //        return getRequestAttribute(GeoStoreOAuthRestTemplate.ID_TOKEN_VALUE);
-    //    }
+    public static final String ID_TOKEN_VALUE = "OpenIdConnect-IdTokenValue";
+
+    /**
+     * Get the id token from the request attributes.
+     *
+     * @return the id token value if found, null otherwise.
+     */
+    public static String getIdToken() {
+        return getRequestAttribute(ID_TOKEN_VALUE);
+    }
 
     /**
      * Get the Access Token from the request attributes if present.
@@ -146,7 +157,7 @@ public class OAuth2Utils {
     }
 
     /**
-     * Get the Refresh Toke from request attributes if present.
+     * Get the Refresh Token from request attributes if present.
      *
      * @return the refresh token if found, null otherwise.
      */

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -89,15 +89,27 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                     "No IdPConfiguration found for callback provider: " + provider);
         }
         LOGGER.info("Token: {}", token);
-        LOGGER.info("Redirect uri: {}", configuration.getRedirectUri());
-        LOGGER.info("Internal redirect uri: {}", configuration.getInternalRedirectUri());
+        
+        String redirectUri = configuration.getRedirectUri();
+        String internalRedirectUri = configuration.getInternalRedirectUri();
+
+        if (redirectUri == null || redirectUri.isBlank()) {
+            throw new RuntimeException(
+                    "Redirect uri is missing. Check the configuration property value.");
+        }
+        LOGGER.info("Redirect uri: {}", redirectUri);
+
+        if (internalRedirectUri == null || internalRedirectUri.isBlank()) {
+            throw new RuntimeException(
+                    "Internal redirect uri is missing. Check the configuration property value.");
+        }
+        LOGGER.info("Internal redirect uri: {}", internalRedirectUri);
+
         if (token != null) {
             LOGGER.info("AccessToken found");
             SessionToken sessionToken = new SessionToken();
             try {
-                result =
-                        result.status(302)
-                                .location(new URI(configuration.getInternalRedirectUri()));
+                result = result.status(302).location(new URI(internalRedirectUri));
                 LOGGER.info("AccessToken: {}", token);
                 sessionToken.setAccessToken(token);
                 sessionToken.setTokenType("Bearer");

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -39,7 +39,7 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                     provider + CONFIG_NAME_SUFFIX);
             throw new RuntimeException("No OAuth2Configuration found for provider: " + provider);
         }
-        LOGGER.info(
+        LOGGER.debug(
                 "Provider '{}' config: enabled={}, clientId={}, authorizationUri={}, "
                         + "accessTokenUri={}, discoveryUrl={}, redirectUri={}, scopes={}",
                 provider,
@@ -77,7 +77,7 @@ public abstract class Oauth2LoginService implements IdPLoginService {
             HttpServletResponse response, String token, String refreshToken, String provider) {
         Response.ResponseBuilder result = new ResponseBuilderImpl();
         IdPConfiguration configuration = configuration(provider);
-        LOGGER.info("Callback Provider: {}", provider);
+        LOGGER.debug("Callback Provider: {}", provider);
         if (configuration == null) {
             LOGGER.error(
                     "No IdPConfiguration bean found for provider '{}' (expected bean name: '{}'). "
@@ -88,7 +88,7 @@ public abstract class Oauth2LoginService implements IdPLoginService {
             throw new RuntimeException(
                     "No IdPConfiguration found for callback provider: " + provider);
         }
-        LOGGER.info("Token: {}", token);
+        LOGGER.debug("Token: {}", token);
 
         String internalRedirectUri = configuration.getInternalRedirectUri();
 
@@ -96,18 +96,18 @@ public abstract class Oauth2LoginService implements IdPLoginService {
             throw new RuntimeException(
                     "Internal redirect uri is missing. Check the configuration property value.");
         }
-        LOGGER.info("Internal redirect uri: {}", internalRedirectUri);
+        LOGGER.debug("Internal redirect uri: {}", internalRedirectUri);
 
         if (token != null) {
-            LOGGER.info("AccessToken found");
+            LOGGER.debug("AccessToken found");
             SessionToken sessionToken = new SessionToken();
             try {
                 result = result.status(302).location(new URI(internalRedirectUri));
-                LOGGER.info("AccessToken: {}", token);
+                LOGGER.debug("AccessToken: {}", token);
                 sessionToken.setAccessToken(token);
                 sessionToken.setTokenType("Bearer");
                 if (refreshToken != null) {
-                    LOGGER.info("RefreshToken: {}", refreshToken);
+                    LOGGER.debug("RefreshToken: {}", refreshToken);
                     result.header("Set-Cookie", refreshTokenCookie(refreshToken).toString());
                 }
                 TokenStorage tokenStorage = tokenStorage();

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -12,7 +12,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.core.Response;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Date;
@@ -56,11 +55,9 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                             + "authorizationUri, or accessTokenUri). Discovery may have failed.",
                     provider);
         }
-        String login = configuration.buildLoginUri();
         try {
-            LOGGER.info("Redirecting to login URI for provider '{}': {}", provider, login);
-            resp.sendRedirect(login);
-        } catch (IOException e) {
+            configuration.getAuthenticationEntryPoint().commence(request, resp, null);
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -199,10 +199,6 @@ public abstract class Oauth2LoginService implements IdPLoginService {
     }
 
     protected NewCookie cookie(String name, String value) {
-        return cookie(name, value, DateUtils.addMinutes(new Date(), 2));
-    }
-
-    protected NewCookie cookie(String name, String value, Date expires) {
         Cookie cookie = new Cookie(name, value, "/", null);
         return new AccessCookie(
                 cookie, "", 120, DateUtils.addMinutes(new Date(), 2), false, false, "lax");

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -89,15 +89,8 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                     "No IdPConfiguration found for callback provider: " + provider);
         }
         LOGGER.info("Token: {}", token);
-        
-        String redirectUri = configuration.getRedirectUri();
-        String internalRedirectUri = configuration.getInternalRedirectUri();
 
-        if (redirectUri == null || redirectUri.isBlank()) {
-            throw new RuntimeException(
-                    "Redirect uri is missing. Check the configuration property value.");
-        }
-        LOGGER.info("Redirect uri: {}", redirectUri);
+        String internalRedirectUri = configuration.getInternalRedirectUri();
 
         if (internalRedirectUri == null || internalRedirectUri.isBlank()) {
             throw new RuntimeException(

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -1,0 +1,208 @@
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration.CONFIG_NAME_SUFFIX;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.*;
+
+import it.geosolutions.geostore.services.rest.IdPLoginService;
+import it.geosolutions.geostore.services.rest.model.SessionToken;
+import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
+import it.geosolutions.geostore.services.rest.utils.GeoStoreContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Date;
+import org.apache.commons.lang3.time.DateUtils;
+import org.apache.cxf.jaxrs.impl.ResponseBuilderImpl;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public abstract class Oauth2LoginService implements IdPLoginService {
+
+    private static final Logger LOGGER = LogManager.getLogger(Oauth2LoginService.class);
+
+    @Override
+    public void doLogin(HttpServletRequest request, HttpServletResponse response, String provider) {
+        LOGGER.info("doLogin called for provider '{}'", provider);
+        HttpServletResponse resp = OAuth2Utils.getResponse();
+        OAuth2Configuration configuration = oauth2Configuration(provider);
+        if (configuration == null) {
+            LOGGER.error(
+                    "No OAuth2Configuration bean found for provider '{}' (expected bean name: '{}')",
+                    provider,
+                    provider + CONFIG_NAME_SUFFIX);
+            throw new RuntimeException("No OAuth2Configuration found for provider: " + provider);
+        }
+        LOGGER.info(
+                "Provider '{}' config: enabled={}, clientId={}, authorizationUri={}, "
+                        + "accessTokenUri={}, discoveryUrl={}, redirectUri={}, scopes={}",
+                provider,
+                configuration.isEnabled(),
+                configuration.getClientId(),
+                configuration.getAuthorizationUri(),
+                configuration.getAccessTokenUri(),
+                configuration.getDiscoveryUrl(),
+                configuration.getRedirectUri(),
+                configuration.getScopes());
+        if (configuration.isInvalid()) {
+            LOGGER.error(
+                    "Provider '{}' configuration is INVALID (missing clientId, clientSecret, "
+                            + "authorizationUri, or accessTokenUri). Discovery may have failed.",
+                    provider);
+        }
+        String login = configuration.buildLoginUri();
+        try {
+            LOGGER.info("Redirecting to login URI for provider '{}': {}", provider, login);
+            resp.sendRedirect(login);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Response doInternalRedirect(
+            HttpServletRequest request, HttpServletResponse response, String provider) {
+        String token = getAccessToken();
+        String refreshToken = getRefreshAccessToken();
+        return buildCallbackResponse(response, token, refreshToken, provider);
+    }
+
+    protected Response.ResponseBuilder getCallbackResponseBuilder(
+            HttpServletResponse response, String token, String refreshToken, String provider) {
+        Response.ResponseBuilder result = new ResponseBuilderImpl();
+        IdPConfiguration configuration = configuration(provider);
+        LOGGER.info("Callback Provider: {}", provider);
+        if (configuration == null) {
+            LOGGER.error(
+                    "No IdPConfiguration bean found for provider '{}' (expected bean name: '{}'). "
+                            + "The bean may not have been registered in GeoStoreContext's "
+                            + "ApplicationContext.",
+                    provider,
+                    provider + CONFIG_NAME_SUFFIX);
+            throw new RuntimeException(
+                    "No IdPConfiguration found for callback provider: " + provider);
+        }
+        LOGGER.info("Token: {}", token);
+        LOGGER.info("Redirect uri: {}", configuration.getRedirectUri());
+        LOGGER.info("Internal redirect uri: {}", configuration.getInternalRedirectUri());
+        if (token != null) {
+            LOGGER.info("AccessToken found");
+            SessionToken sessionToken = new SessionToken();
+            try {
+                result =
+                        result.status(302)
+                                .location(new URI(configuration.getInternalRedirectUri()));
+                LOGGER.info("AccessToken: {}", token);
+                sessionToken.setAccessToken(token);
+                sessionToken.setTokenType("Bearer");
+                if (refreshToken != null) {
+                    LOGGER.info("RefreshToken: {}", refreshToken);
+                    result.header("Set-Cookie", refreshTokenCookie(refreshToken).toString());
+                }
+                TokenStorage tokenStorage = tokenStorage();
+                Object key = tokenStorage.buildTokenKey();
+                tokenStorage.saveToken(key, sessionToken);
+                Cookie cookie = cookie(TOKENS_KEY, key.toString());
+                result.header("Set-Cookie", cookie.toString());
+                cookie = cookie(AUTH_PROVIDER, provider);
+                result.header("Set-Cookie", cookie.toString());
+            } catch (URISyntaxException e) {
+                LOGGER.error(e);
+                result =
+                        result.status(Response.Status.INTERNAL_SERVER_ERROR)
+                                .entity(
+                                        "Exception while parsing the internal redirect url: "
+                                                + e.getMessage());
+            }
+        } else {
+            LOGGER.error("No access token found on callback request: {}", response.getStatus());
+            result =
+                    Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                            .entity("No access token found.");
+        }
+        return result;
+    }
+
+    @Override
+    public SessionToken getTokenByIdentifier(String provider, String tokenIdentifier) {
+        TokenStorage storage = tokenStorage();
+        SessionToken sessionToken = storage.getTokenByIdentifier(tokenIdentifier);
+        if (sessionToken != null) storage.removeTokenByIdentifier(tokenIdentifier);
+        return sessionToken;
+    }
+
+    protected TokenStorage tokenStorage() {
+        return GeoStoreContext.bean(TokenStorage.class);
+    }
+
+    protected Response buildCallbackResponse(
+            HttpServletResponse response, String token, String refreshToken, String provider) {
+        Response.ResponseBuilder result =
+                getCallbackResponseBuilder(response, token, refreshToken, provider);
+        return result.build();
+    }
+
+    protected OAuth2Configuration oauth2Configuration(String provider) {
+        String beanName = provider + CONFIG_NAME_SUFFIX;
+        OAuth2Configuration config = GeoStoreContext.bean(beanName, OAuth2Configuration.class);
+        if (config == null) {
+            LOGGER.error(
+                    "GeoStoreContext.bean('{}', OAuth2Configuration.class) returned null. "
+                            + "Trying raw lookup...",
+                    beanName);
+            Object raw = GeoStoreContext.bean(beanName);
+            LOGGER.error(
+                    "Raw bean '{}': {} (type: {})",
+                    beanName,
+                    raw,
+                    raw != null ? raw.getClass().getName() : "null");
+        }
+        return config;
+    }
+
+    protected IdPConfiguration configuration(String provider) {
+        String beanName = provider + CONFIG_NAME_SUFFIX;
+        IdPConfiguration config = GeoStoreContext.bean(beanName, IdPConfiguration.class);
+        if (config == null) {
+            LOGGER.error(
+                    "GeoStoreContext.bean('{}', IdPConfiguration.class) returned null. "
+                            + "Trying raw lookup...",
+                    beanName);
+            Object raw = GeoStoreContext.bean(beanName);
+            LOGGER.error(
+                    "Raw bean '{}': {} (type: {})",
+                    beanName,
+                    raw,
+                    raw != null ? raw.getClass().getName() : "null");
+        }
+        return config;
+    }
+
+    protected NewCookie refreshTokenCookie(String value) {
+        boolean secure = isRequestSecure();
+        Cookie cookie = new Cookie(REFRESH_TOKEN_PARAM, value, "/", null);
+        return new AccessCookie(cookie, "", 604800, null, secure, true, "lax");
+    }
+
+    private boolean isRequestSecure() {
+        ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        return attrs != null && attrs.getRequest().isSecure();
+    }
+
+    protected NewCookie cookie(String name, String value) {
+        return cookie(name, value, DateUtils.addMinutes(new Date(), 2));
+    }
+
+    protected NewCookie cookie(String name, String value, Date expires) {
+        Cookie cookie = new Cookie(name, value, "/", null);
+        return new AccessCookie(
+                cookie, "", 120, DateUtils.addMinutes(new Date(), 2), false, false, "lax");
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/RestClientBuilderFactory.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/RestClientBuilderFactory.java
@@ -1,0 +1,18 @@
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+public class RestClientBuilderFactory {
+
+    private final ClientHttpRequestFactory requestFactory;
+
+    public RestClientBuilderFactory(ClientHttpRequestFactory requestFactory) {
+        this.requestFactory = requestFactory;
+    }
+
+    public RestClient createBuilder() {
+        // No baseUrl: OAuth2 token/introspection/userinfo calls always use absolute provider URLs.
+        return RestClient.builder().requestFactory(requestFactory).build();
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/TokenDetails.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/TokenDetails.java
@@ -32,6 +32,7 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import java.io.Serializable;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 
 /**
  * Holds the token details. Instances of this class are meant to be stored into the SecurityContext
@@ -41,15 +42,32 @@ public class TokenDetails implements Serializable {
     private final String idToken;
     private final String provider;
     private OAuth2AccessToken accessToken;
+    private OAuth2RefreshToken refreshToken;
     private DecodedJWT decodedJWT;
 
     /**
      * @param accessToken the accessToken instance.
      * @param idToken the JWT idToken
+     * @param provider the name of the identity provider that issued the token.
      */
     public TokenDetails(OAuth2AccessToken accessToken, String idToken, String provider) {
+        this(accessToken, idToken, provider, null);
+    }
+
+    /**
+     * @param accessToken the accessToken instance.
+     * @param idToken the JWT idToken
+     * @param provider the name of the identity provider that issued the token.
+     * @param refreshToken the refreshToken instance (may be null).
+     */
+    public TokenDetails(
+            OAuth2AccessToken accessToken,
+            String idToken,
+            String provider,
+            OAuth2RefreshToken refreshToken) {
         this.idToken = idToken;
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
         if (idToken != null) {
             decodedJWT = JWT.decode(idToken);
         }
@@ -90,6 +108,21 @@ public class TokenDetails implements Serializable {
      */
     public void setAccessToken(OAuth2AccessToken accessToken) {
         this.accessToken = accessToken;
+    }
+
+    /** @return the OAuth2RefreshToken instance (may be null). */
+    public OAuth2RefreshToken getRefreshToken() {
+        return refreshToken;
+    }
+
+    /**
+     * Set the OAuth2RefreshToken. Used to carry over a still-valid refresh token when the identity
+     * provider rotates the access token without issuing a new refresh token.
+     *
+     * @param refreshToken the OAuth2RefreshToken.
+     */
+    public void setRefreshToken(OAuth2RefreshToken refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
     public String getProvider() {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/CompositeOpenIdConnectFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/CompositeOpenIdConnectFilter.java
@@ -1,0 +1,371 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration.CONFIG_NAME_SUFFIX;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.ACCESS_TOKEN_PARAM;
+
+import it.geosolutions.geostore.services.UserGroupService;
+import it.geosolutions.geostore.services.UserService;
+import it.geosolutions.geostore.services.rest.IdPLoginRest;
+import it.geosolutions.geostore.services.rest.RESTSessionService;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.AudienceAccessTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.JwksRsaKeyProvider;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.MultiTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.SubjectTokenValidator;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * Composite filter that routes requests to per-provider {@link OpenIdConnectFilter} instances.
+ *
+ * <p>On startup ({@link #afterPropertiesSet()}), discovers all {@link OpenIdConnectConfiguration}
+ * beans and creates per-provider filters, authentication services, rest clients, validators, and
+ * caches programmatically.
+ *
+ * <p>Request routing:
+ *
+ * <ul>
+ *   <li><b>Already authenticated:</b> skip, chain through
+ *   <li><b>Callback URL:</b> route to the matching provider's filter
+ *   <li><b>Bearer token:</b> iterate all enabled providers; first success wins
+ *   <li><b>No match:</b> chain through to other auth mechanisms
+ * </ul>
+ */
+public class CompositeOpenIdConnectFilter extends GenericFilterBean
+        implements ApplicationContextAware {
+
+    private static final Logger LOGGER = LogManager.getLogger(CompositeOpenIdConnectFilter.class);
+
+    private static final Pattern CALLBACK_PATTERN = Pattern.compile(".*/openid/([^/]+)/callback.*");
+    private static final Pattern LOGIN_PATTERN = Pattern.compile(".*/openid/([^/]+)/login.*");
+
+    private ApplicationContext applicationContext;
+    private final Map<String, OpenIdConnectFilter> providerFilters = new LinkedHashMap<>();
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws ServletException {
+        super.afterPropertiesSet();
+        if (applicationContext == null) {
+            LOGGER.warn(
+                    "ApplicationContext not available; no provider filters will be initialized");
+            return;
+        }
+
+        UserService userService = lookupOptional("userService", UserService.class);
+        UserGroupService userGroupService =
+                lookupOptional("userGroupService", UserGroupService.class);
+
+        Map<String, OpenIdConnectConfiguration> configs =
+                applicationContext.getBeansOfType(OpenIdConnectConfiguration.class);
+        for (Map.Entry<String, OpenIdConnectConfiguration> entry : configs.entrySet()) {
+            OpenIdConnectConfiguration config = entry.getValue();
+            String beanName = entry.getKey();
+
+            // Derive provider name from bean name (e.g. "oidcOAuth2Config" -> "oidc")
+            String providerName = beanName.replace(CONFIG_NAME_SUFFIX, "");
+
+            if (!config.isEnabled()) {
+                LOGGER.info(
+                        "Provider '{}' is disabled (bean={}); skipping filter creation",
+                        providerName,
+                        beanName);
+                continue;
+            }
+
+            LOGGER.info(
+                    "Initializing OpenID Connect filter for provider '{}' (bean={})",
+                    providerName,
+                    beanName);
+
+            // Per-provider OAuth2 HTTP client (authorization-code exchange + refresh).
+            OpenIdConnectRestClient restClient = new OpenIdConnectRestClient(config);
+
+            // Per-provider authentication cache, wired with the ApplicationContext so token-revoke
+            // on eviction can resolve the provider configuration bean.
+            TokenAuthenticationCache cache =
+                    new TokenAuthenticationCache(
+                            config.getCacheSize(), config.getCacheExpirationMinutes());
+            cache.setApplicationContext(applicationContext);
+
+            JwksRsaKeyProvider jwksKeyProvider = null;
+            String jwksUri = config.getIdTokenUri();
+            if (jwksUri == null || jwksUri.isEmpty()) {
+                jwksUri = config.getJwkURI();
+            }
+            if (jwksUri != null && !jwksUri.isEmpty()) {
+                jwksKeyProvider = new JwksRsaKeyProvider(jwksUri);
+            }
+
+            MultiTokenValidator validator =
+                    new MultiTokenValidator(
+                            Arrays.asList(
+                                    new AudienceAccessTokenValidator(),
+                                    new SubjectTokenValidator()));
+
+            OpenIdConnectAuthenticationService service =
+                    new OpenIdConnectAuthenticationService(
+                            cache,
+                            userService,
+                            userGroupService,
+                            config,
+                            validator,
+                            jwksKeyProvider);
+
+            OpenIdConnectFilter filter = new OpenIdConnectFilter(config, service, restClient);
+
+            LOGGER.info(
+                    "Provider '{}' config after discovery: authorizationUri={}, accessTokenUri={}, "
+                            + "discoveryUrl={}, clientId={}, redirectUri={}, scopes={}, "
+                            + "isInvalid={}",
+                    providerName,
+                    config.getAuthorizationUri(),
+                    config.getAccessTokenUri(),
+                    config.getDiscoveryUrl(),
+                    config.getClientId(),
+                    config.getRedirectUri(),
+                    config.getScopes(),
+                    config.isInvalid());
+
+            if (config.isInvalid()) {
+                LOGGER.error(
+                        "Provider '{}' configuration is INVALID after discovery. "
+                                + "This provider will not work correctly. "
+                                + "Ensure discoveryUrl is reachable or set endpoints manually.",
+                        providerName);
+            }
+
+            // Validate that redirectUri contains the correct provider name in the path.
+            String redirectUri = config.getRedirectUri();
+            if (redirectUri != null) {
+                String expectedPathSegment = "/openid/" + providerName + "/callback";
+                if (!redirectUri.contains(expectedPathSegment)) {
+                    LOGGER.warn(
+                            "Provider '{}' has redirectUri='{}' which does not contain '{}'. "
+                                    + "The callback URL path must include the provider name so "
+                                    + "the correct configuration is used. "
+                                    + "Expected pattern: .../openid/{}/callback",
+                            providerName,
+                            redirectUri,
+                            expectedPathSegment,
+                            providerName);
+                }
+            }
+
+            providerFilters.put(providerName, filter);
+            LOGGER.info("Provider '{}' filter initialized successfully", providerName);
+
+            // Register the programmatically-created rest client and cache as Spring beans so that
+            // session service delegates (which look up beans by name) can find them.
+            registerSingletonBean(
+                    providerName + "OpenIdRestTemplate", restClient, "OpenIdConnectRestClient");
+            registerSingletonBean("oAuth2Cache", cache, "TokenAuthenticationCache");
+
+            // Register per-provider session delegate and login service for non-default providers.
+            // The default "oidc" provider's delegate and login service are defined in
+            // applicationContext.xml.
+            if (!"oidc".equals(providerName)) {
+                registerPerProviderServices(providerName);
+            }
+        }
+
+        if (providerFilters.isEmpty()) {
+            LOGGER.info("No enabled OpenID Connect providers found");
+        } else {
+            LOGGER.info(
+                    "Composite filter initialized with {} provider(s): {}",
+                    providerFilters.size(),
+                    providerFilters.keySet());
+        }
+    }
+
+    private <T> T lookupOptional(String beanName, Class<T> type) {
+        try {
+            return applicationContext.getBean(beanName, type);
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "{} bean not found; related functionality will be limited: {}",
+                    beanName,
+                    e.getMessage());
+            return null;
+        }
+    }
+
+    private void registerPerProviderServices(String providerName) {
+        try {
+            RESTSessionService restSessionService =
+                    applicationContext.getBean("restSessionService", RESTSessionService.class);
+            UserService userService = applicationContext.getBean("userService", UserService.class);
+            new OpenIdConnectSessionServiceDelegate(restSessionService, userService, providerName);
+            LOGGER.info("Registered session delegate for provider '{}'", providerName);
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "Could not register session delegate for provider '{}': {}",
+                    providerName,
+                    e.getMessage());
+        }
+
+        try {
+            IdPLoginRest idpLoginRest =
+                    applicationContext.getBean("idpLoginRest", IdPLoginRest.class);
+            new OpenIdConnectLoginService(idpLoginRest, providerName);
+            LOGGER.info("Registered login service for provider '{}'", providerName);
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "Could not register login service for provider '{}': {}",
+                    providerName,
+                    e.getMessage());
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+
+        // Already authenticated -> skip
+        Authentication existingAuth = SecurityContextHolder.getContext().getAuthentication();
+        if (existingAuth != null) {
+            chain.doFilter(req, res);
+            return;
+        }
+
+        // No providers configured -> skip
+        if (providerFilters.isEmpty()) {
+            chain.doFilter(req, res);
+            return;
+        }
+
+        String uri = request.getRequestURI();
+
+        // Callback URL: /openid/{provider}/callback
+        Matcher callbackMatcher = CALLBACK_PATTERN.matcher(uri);
+        if (callbackMatcher.matches()) {
+            String provider = callbackMatcher.group(1);
+            OpenIdConnectFilter filter = providerFilters.get(provider);
+            if (filter != null) {
+                LOGGER.debug("Routing callback to provider '{}'", provider);
+                filter.doFilter(req, res, chain);
+                return;
+            }
+            LOGGER.warn("Callback for unknown provider '{}'; passing through", provider);
+            chain.doFilter(req, res);
+            return;
+        }
+
+        // Login URL: /openid/{provider}/login
+        Matcher loginMatcher = LOGIN_PATTERN.matcher(uri);
+        if (loginMatcher.matches()) {
+            String provider = loginMatcher.group(1);
+            OpenIdConnectFilter filter = providerFilters.get(provider);
+            if (filter != null) {
+                LOGGER.debug("Routing login to provider '{}'", provider);
+                filter.doFilter(req, res, chain);
+                return;
+            }
+            LOGGER.warn("Login for unknown provider '{}'; passing through", provider);
+            chain.doFilter(req, res);
+            return;
+        }
+
+        // Bearer token: try each enabled provider. Use a no-op chain for each attempt because each
+        // provider's filter always calls chain.doFilter() internally; call the real chain once.
+        String bearerToken = OAuth2Utils.tokenFromParamsOrBearer(ACCESS_TOKEN_PARAM, request);
+        if (bearerToken != null) {
+            FilterChain noOpChain = (r, s) -> {};
+            for (Map.Entry<String, OpenIdConnectFilter> entry : providerFilters.entrySet()) {
+                String providerName = entry.getKey();
+                OpenIdConnectFilter filter = entry.getValue();
+                LOGGER.debug("Trying bearer token with provider '{}'", providerName);
+                try {
+                    filter.doFilter(req, res, noOpChain);
+                    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                    if (auth != null) {
+                        LOGGER.debug("Bearer token authenticated by provider '{}'", providerName);
+                        chain.doFilter(req, res);
+                        return;
+                    }
+                } catch (Exception e) {
+                    LOGGER.debug(
+                            "Bearer token rejected by provider '{}': {}",
+                            providerName,
+                            e.getMessage());
+                    SecurityContextHolder.clearContext();
+                }
+            }
+            chain.doFilter(req, res);
+            return;
+        }
+
+        // No bearer token and not a login/callback URL: chain through. The
+        // AnonymousAuthenticationFilter (later in the Spring Security chain) sets an anonymous
+        // token if needed.
+        chain.doFilter(req, res);
+    }
+
+    private void registerSingletonBean(String name, Object bean, String label) {
+        if (applicationContext instanceof ConfigurableApplicationContext) {
+            ConfigurableListableBeanFactory factory =
+                    ((ConfigurableApplicationContext) applicationContext).getBeanFactory();
+            if (!factory.containsSingleton(name)) {
+                factory.registerSingleton(name, bean);
+                LOGGER.info("Registered {} bean as '{}'", label, name);
+            }
+        }
+    }
+
+    public Map<String, OpenIdConnectFilter> getProviderFilters() {
+        return providerFilters;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectAuthenticationService.java
@@ -1,0 +1,606 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.services.UserGroupService;
+import it.geosolutions.geostore.services.UserService;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.JWTHelper;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2GeoStoreAuthenticationFilter;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2GeoStoreAuthenticationFilter.OAuth2AuthenticationType;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2GeoStoreAuthenticationService;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.JweTokenDecryptor;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.JwksRsaKeyProvider;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.MicrosoftGraphClient;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.OpenIdTokenValidator;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.FileInputStream;
+import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.sf.json.JSONObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * OpenID Connect authentication service. Extends the generic {@link
+ * OAuth2GeoStoreAuthenticationService} to add OIDC-specific behavior:
+ *
+ * <ul>
+ *   <li>direct Bearer-token validation (JWT signature via JWKS, JWE decryption, RFC 7662
+ *       introspection, audience/subject validation) bypassing the generic introspection flow;
+ *   <li>Microsoft Graph enrichment for group/role overage.
+ * </ul>
+ *
+ * <p>This is the service-side equivalent of the 2.6.x {@code OpenIdConnectFilter} overrides; it was
+ * moved into the service to fit the Spring Security 7 thin-filter + service split.
+ */
+public class OpenIdConnectAuthenticationService extends OAuth2GeoStoreAuthenticationService {
+
+    private static final Logger LOGGER =
+            LogManager.getLogger(OpenIdConnectAuthenticationService.class);
+
+    private final OpenIdTokenValidator bearerTokenValidator;
+    private final JwksRsaKeyProvider jwksKeyProvider;
+    private volatile JweTokenDecryptor jweDecryptor;
+    private volatile boolean jweDecryptorInitialized = false;
+    private volatile MicrosoftGraphClient graphClient;
+    private volatile boolean graphClientInitialized = false;
+
+    public OpenIdConnectAuthenticationService(
+            TokenAuthenticationCache cache,
+            UserService userService,
+            UserGroupService userGroupService,
+            OAuth2Configuration configuration,
+            OpenIdTokenValidator bearerTokenValidator,
+            JwksRsaKeyProvider jwksKeyProvider) {
+        super(cache, userService, userGroupService, configuration);
+        this.bearerTokenValidator = bearerTokenValidator;
+        this.jwksKeyProvider = jwksKeyProvider;
+    }
+
+    private OpenIdConnectConfiguration oidcConfig() {
+        return (OpenIdConnectConfiguration) configuration;
+    }
+
+    /**
+     * For OIDC the "introspection" endpoint is the OpenID Connect userinfo endpoint, queried with a
+     * GET and a Bearer header (see {@link OpenIdConnectTokenServices}); override the generic POST
+     * {@code check_token} behavior accordingly.
+     */
+    @Override
+    protected Map<String, Object> doIntrospectionRequest(
+            OAuth2AccessToken accessToken, String introspectionUri) {
+        if (accessToken == null
+                || !StringUtils.hasText(accessToken.getTokenValue())
+                || !StringUtils.hasText(introspectionUri)) {
+            return null;
+        }
+        try {
+            OpenIdConnectTokenServices tokenServices =
+                    new OpenIdConnectTokenServices(configuration.getPrincipalKey());
+            tokenServices.setCheckTokenEndpointUrl(introspectionUri);
+            tokenServices.setClientId(configuration.getClientId());
+            tokenServices.setClientSecret(configuration.getClientSecret());
+            Map<String, Object> result =
+                    tokenServices.loadAuthentication(accessToken.getTokenValue());
+            if (result == null || result.isEmpty()) {
+                return null;
+            }
+            return result;
+        } catch (Exception e) {
+            LOGGER.warn("OIDC: userinfo/introspection request failed: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    protected String getPreAuthenticatedPrincipal(
+            HttpServletRequest req, HttpServletResponse resp, OAuth2AccessToken accessToken) {
+
+        OAuth2AuthenticationType type =
+                (OAuth2AuthenticationType)
+                        req.getAttribute(
+                                OAuth2GeoStoreAuthenticationFilter.OAUTH2_AUTHENTICATION_TYPE_KEY);
+
+        // For BEARER tokens with a validator configured, validate directly and extract the
+        // principal from claims, skipping the generic introspection-based flow which can fail with
+        // OIDC-only providers.
+        if (type == OAuth2AuthenticationType.BEARER && bearerTokenValidator != null) {
+            if (!oidcConfig().isAllowBearerTokens()) {
+                LOGGER.warn(
+                        "OIDC: received an attached Bearer token, but Bearer tokens aren't allowed!");
+                throw new RuntimeException(
+                        "OIDC: received an attached Bearer token, but Bearer tokens aren't allowed!");
+            }
+
+            String token = resolveTokenValue(req, accessToken);
+            if (!StringUtils.hasText(token)) {
+                LOGGER.error("OIDC: Bearer token validation requested but no token was found");
+                throw new RuntimeException("Attached Bearer Token is missing");
+            }
+
+            String strategy =
+                    StringUtils.hasText(oidcConfig().getBearerTokenStrategy())
+                            ? oidcConfig().getBearerTokenStrategy()
+                            : "jwt";
+            Map<String, Object> bearerClaims = resolveBearerClaims(token, strategy);
+            if (bearerClaims == null) {
+                LOGGER.warn(
+                        "OIDC: Bearer token could not be validated with strategy '{}'", strategy);
+                throw new RuntimeException("Attached Bearer Token is invalid");
+            }
+
+            String principal =
+                    coalesceClaimValue(
+                            bearerClaims,
+                            configuration.getUniqueUsername(),
+                            configuration.getPrincipalKey());
+            if (principal == null) {
+                principal =
+                        coalesceClaimValue(
+                                bearerClaims,
+                                "upn",
+                                "preferred_username",
+                                "unique_name",
+                                "user_name",
+                                "username",
+                                "email",
+                                "sub",
+                                "oid");
+            }
+
+            if (StringUtils.hasText(principal)) {
+                LOGGER.info(
+                        "Authenticated OIDC Bearer token for user ({}): {}", strategy, principal);
+                // Store bearer claims so addAuthoritiesFromToken() can read roles/groups from them.
+                req.setAttribute(OAUTH2_ACCESS_TOKEN_CHECK_KEY, bearerClaims);
+                return principal;
+            }
+
+            LOGGER.warn(
+                    "OIDC: Bearer token validated but no principal could be resolved from claims");
+            return null;
+        }
+
+        // USER auth type, or BEARER without a validator: use the generic flow.
+        return super.getPreAuthenticatedPrincipal(req, resp, accessToken);
+    }
+
+    /**
+     * Resolves the bearer token value from the access token, request attributes, or the request.
+     */
+    private String resolveTokenValue(HttpServletRequest req, OAuth2AccessToken accessToken) {
+        String token = null;
+        if (accessToken != null && StringUtils.hasText(accessToken.getTokenValue())) {
+            token = accessToken.getTokenValue();
+        }
+        if (token == null) {
+            Object fromValue = req.getAttribute(OAuth2Utils.ACCESS_TOKEN_VALUE);
+            if (fromValue instanceof String) token = (String) fromValue;
+        }
+        if (token == null) {
+            Object fromParam = req.getAttribute(OAuth2Utils.ACCESS_TOKEN_PARAM);
+            if (fromParam instanceof String) token = (String) fromParam;
+        }
+        if (token == null) {
+            token = OAuth2Utils.tokenFromParamsOrBearer(OAuth2Utils.ACCESS_TOKEN_PARAM, req);
+        }
+        return token;
+    }
+
+    private Map<String, Object> resolveBearerClaims(String token, String strategy) {
+        if ("introspection".equalsIgnoreCase(strategy)) {
+            return introspectToken(token);
+        } else if ("auto".equalsIgnoreCase(strategy)) {
+            try {
+                return validateBearerJwt(token);
+            } catch (Exception e) {
+                LOGGER.info(
+                        "OIDC: JWT validation failed, falling back to introspection: {}",
+                        e.getMessage());
+                return introspectToken(token);
+            }
+        } else {
+            return validateBearerJwt(token);
+        }
+    }
+
+    /**
+     * Validates a bearer token as a JWT: optional JWE decryption, signature verification via JWKS,
+     * exp/iat checks, and the configured token validator.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> validateBearerJwt(String token) {
+        Map<String, Object> accessTokenClaims;
+        try {
+            JweTokenDecryptor decryptor = getJweDecryptor();
+            if (decryptor != null && JweTokenDecryptor.isJweToken(token)) {
+                LOGGER.debug("Detected JWE token (5 parts), attempting decryption");
+                token = decryptor.decrypt(token);
+            }
+            if (jwksKeyProvider != null) {
+                String kid = extractKidFromHeader(token);
+                RSAPublicKey key = jwksKeyProvider.getKey(kid);
+                if (key == null) {
+                    throw new RuntimeException("No JWK key found for kid: " + kid);
+                }
+                // Verify the RSA signature; throws if invalid.
+                JWT.require(Algorithm.RSA256(key, null)).build().verify(token);
+            } else {
+                LOGGER.warn(
+                        "OIDC: No JWKS key provider configured — decoding bearer token WITHOUT"
+                                + " signature verification");
+            }
+            accessTokenClaims = new JWTHelper(token).getPayloadAsMap();
+        } catch (Exception e) {
+            LOGGER.error("OIDC: Could not decode/verify bearer token", e);
+            throw new RuntimeException("Attached Bearer Token is invalid (decoding failed)", e);
+        }
+
+        Object expObj = accessTokenClaims.get("exp");
+        if (expObj != null) {
+            long expSeconds = parseEpochSeconds(expObj, "exp");
+            if (System.currentTimeMillis() / 1000 > expSeconds) {
+                LOGGER.warn("OIDC: Bearer token has expired (exp={})", expSeconds);
+                throw new RuntimeException("Attached Bearer Token has expired");
+            }
+        }
+
+        int maxTokenAgeSecs = oidcConfig().getMaxTokenAgeSecs();
+        if (maxTokenAgeSecs > 0) {
+            Object iatObj = accessTokenClaims.get("iat");
+            if (iatObj != null) {
+                long iatSeconds = parseEpochSeconds(iatObj, "iat");
+                long age = System.currentTimeMillis() / 1000 - iatSeconds;
+                if (age > maxTokenAgeSecs) {
+                    LOGGER.warn(
+                            "OIDC: Bearer token is too old (iat={}, age={}s, max={}s)",
+                            iatSeconds,
+                            age,
+                            maxTokenAgeSecs);
+                    throw new RuntimeException("Attached Bearer Token is too old");
+                }
+            }
+        }
+
+        try {
+            bearerTokenValidator.verifyToken(oidcConfig(), accessTokenClaims, null);
+        } catch (Exception e) {
+            LOGGER.warn("OIDC: Bearer token validator rejected the token: {}", e.getMessage());
+            throw new RuntimeException("Attached Bearer Token is invalid: " + e.getMessage(), e);
+        }
+
+        return accessTokenClaims;
+    }
+
+    private long parseEpochSeconds(Object value, String claimName) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        try {
+            return Long.parseLong(String.valueOf(value));
+        } catch (NumberFormatException nfe) {
+            throw new RuntimeException("Bearer token '" + claimName + "' claim is not a number");
+        }
+    }
+
+    /** Validates a bearer token via RFC 7662 Token Introspection. */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> introspectToken(String token) {
+        String introspectionUrl = configuration.getIntrospectionEndpoint();
+        if (!StringUtils.hasText(introspectionUrl)) {
+            throw new RuntimeException(
+                    "Bearer token introspection requested but no introspection endpoint is"
+                            + " configured");
+        }
+
+        MultiValueMap<String, String> formParams = new LinkedMultiValueMap<>();
+        formParams.add("token", token);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        String clientId = configuration.getClientId();
+        String clientSecret = configuration.getClientSecret();
+        if (StringUtils.hasText(clientId) && StringUtils.hasText(clientSecret)) {
+            String credentials = clientId + ":" + clientSecret;
+            String encoded =
+                    Base64.getEncoder()
+                            .encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            headers.set("Authorization", "Basic " + encoded);
+        }
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(formParams, headers);
+
+        try {
+            RestTemplate rt = new RestTemplate();
+            Map<String, Object> response = rt.postForObject(introspectionUrl, request, Map.class);
+            if (response == null) {
+                LOGGER.warn("OIDC: Token introspection returned null response");
+                return null;
+            }
+            Object active = response.get("active");
+            boolean isActive =
+                    Boolean.TRUE.equals(active)
+                            || (active instanceof String
+                                    && "true".equalsIgnoreCase((String) active));
+            if (!isActive) {
+                LOGGER.warn("OIDC: Token introspection returned active=false");
+                return null;
+            }
+            LOGGER.info("OIDC: Token introspection successful (active=true)");
+            return response;
+        } catch (Exception e) {
+            LOGGER.error("OIDC: Token introspection failed", e);
+            throw new RuntimeException("Token introspection failed", e);
+        }
+    }
+
+    /** Extracts the "kid" (key ID) from a JWT's header segment. */
+    private String extractKidFromHeader(String token) {
+        try {
+            int firstDot = token.indexOf('.');
+            if (firstDot < 0) return "";
+            String headerSegment = token.substring(0, firstDot);
+            String headerJson =
+                    new String(
+                            Base64.getUrlDecoder().decode(headerSegment), StandardCharsets.UTF_8);
+            JSONObject header = JSONObject.fromObject(headerJson);
+            return header.optString("kid", "");
+        } catch (Exception e) {
+            LOGGER.debug("Could not extract kid from JWT header", e);
+            return "";
+        }
+    }
+
+    /** Lazily initializes the JWE token decryptor from the keystore configuration. */
+    private JweTokenDecryptor getJweDecryptor() {
+        if (jweDecryptorInitialized) {
+            return jweDecryptor;
+        }
+        synchronized (this) {
+            if (jweDecryptorInitialized) {
+                return jweDecryptor;
+            }
+            try {
+                OpenIdConnectConfiguration oidcConfig = oidcConfig();
+                String keystoreFile = oidcConfig.getJweKeyStoreFile();
+                if (!StringUtils.hasText(keystoreFile)) {
+                    LOGGER.debug("JWE not configured (no jweKeyStoreFile)");
+                    jweDecryptor = null;
+                    jweDecryptorInitialized = true;
+                    return null;
+                }
+
+                String keystorePassword =
+                        oidcConfig.getJweKeyStorePassword() != null
+                                ? oidcConfig.getJweKeyStorePassword()
+                                : "";
+                String keystoreType =
+                        oidcConfig.getJweKeyStoreType() != null
+                                ? oidcConfig.getJweKeyStoreType()
+                                : "PKCS12";
+                String keyAlias = oidcConfig.getJweKeyAlias();
+                String keyPassword =
+                        oidcConfig.getJweKeyPassword() != null
+                                ? oidcConfig.getJweKeyPassword()
+                                : keystorePassword;
+
+                KeyStore keyStore = KeyStore.getInstance(keystoreType);
+                try (FileInputStream fis = new FileInputStream(keystoreFile)) {
+                    keyStore.load(fis, keystorePassword.toCharArray());
+                }
+
+                if (!StringUtils.hasText(keyAlias)) {
+                    keyAlias = keyStore.aliases().nextElement();
+                }
+
+                PrivateKey privateKey =
+                        (PrivateKey) keyStore.getKey(keyAlias, keyPassword.toCharArray());
+                if (privateKey == null) {
+                    LOGGER.error(
+                            "JWE keystore '{}' does not contain a private key with alias '{}'",
+                            keystoreFile,
+                            keyAlias);
+                    jweDecryptor = null;
+                    jweDecryptorInitialized = true;
+                    return null;
+                }
+
+                jweDecryptor = new JweTokenDecryptor(privateKey);
+                LOGGER.info(
+                        "JWE token decryptor initialized with key alias '{}' from '{}'",
+                        keyAlias,
+                        keystoreFile);
+            } catch (Exception e) {
+                LOGGER.error("Failed to initialize JWE token decryptor: {}", e.getMessage(), e);
+                jweDecryptor = null;
+            }
+            jweDecryptorInitialized = true;
+            return jweDecryptor;
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void addAuthoritiesFromToken(
+            User user,
+            String tokenString,
+            String accessTokenString,
+            Map<String, Object> userinfoMap) {
+        OpenIdConnectConfiguration oidcConfig = oidcConfig();
+        if (oidcConfig.isMsGraphEnabled()) {
+            MicrosoftGraphClient client = getGraphClient();
+            String accessToken =
+                    StringUtils.hasText(accessTokenString) ? accessTokenString : tokenString;
+            if (client != null && accessToken != null) {
+                Map<String, Object> enriched =
+                        (userinfoMap != null) ? new HashMap<>(userinfoMap) : new HashMap<>();
+
+                if (oidcConfig.isMsGraphGroupsEnabled()
+                        && configuration.getGroupsClaim() != null
+                        && isGroupsOverage(tokenString, configuration.getGroupsClaim())) {
+                    List<String> graphGroups = client.fetchMemberOfGroups(accessToken);
+                    if (!graphGroups.isEmpty()) {
+                        enriched.put(configuration.getGroupsClaim(), graphGroups);
+                    }
+                }
+
+                if (oidcConfig.isMsGraphRolesEnabled() && configuration.getRolesClaim() != null) {
+                    List<MicrosoftGraphClient.AppRoleAssignment> assignments =
+                            client.fetchAppRoleAssignments(accessToken);
+                    if (!assignments.isEmpty()) {
+                        List<String> roleNames =
+                                client.resolveAppRoleNames(accessToken, assignments);
+                        if (!roleNames.isEmpty()) {
+                            enriched.put(configuration.getRolesClaim(), roleNames);
+                        }
+                    }
+                }
+
+                userinfoMap = enriched;
+            }
+        }
+        super.addAuthoritiesFromToken(user, tokenString, accessTokenString, userinfoMap);
+    }
+
+    /** Whether the JWT payload indicates an Azure AD groups overage condition. */
+    @SuppressWarnings("unchecked")
+    boolean isGroupsOverage(String tokenString, String groupsClaim) {
+        if (!StringUtils.hasText(tokenString)) return false;
+        try {
+            String[] parts = tokenString.split("\\.");
+            if (parts.length < 2) return false;
+            String payloadJson =
+                    new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+            JSONObject payload = JSONObject.fromObject(payloadJson);
+
+            Object hasgroups = payload.get("hasgroups");
+            if (Boolean.TRUE.equals(hasgroups)
+                    || "true".equalsIgnoreCase(String.valueOf(hasgroups))) {
+                LOGGER.info("MS Graph: groups overage detected (hasgroups=true)");
+                return true;
+            }
+
+            Object claimNames = payload.get("_claim_names");
+            if (claimNames instanceof Map) {
+                Map<String, Object> names = (Map<String, Object>) claimNames;
+                if (names.containsKey(groupsClaim)) {
+                    LOGGER.info(
+                            "MS Graph: groups overage detected (_claim_names contains '{}')",
+                            groupsClaim);
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            LOGGER.debug("Could not check for groups overage in JWT", e);
+            return false;
+        }
+    }
+
+    /** Lazily initializes the Microsoft Graph client. */
+    private MicrosoftGraphClient getGraphClient() {
+        if (graphClientInitialized) {
+            return graphClient;
+        }
+        synchronized (this) {
+            if (graphClientInitialized) {
+                return graphClient;
+            }
+            try {
+                OpenIdConnectConfiguration oidcConfig = oidcConfig();
+                if (!oidcConfig.isMsGraphEnabled()) {
+                    LOGGER.debug("MS Graph not enabled");
+                    graphClient = null;
+                    graphClientInitialized = true;
+                    return null;
+                }
+                graphClient = new MicrosoftGraphClient(oidcConfig.getMsGraphEndpoint());
+                LOGGER.info(
+                        "MS Graph client initialized with endpoint '{}'",
+                        oidcConfig.getMsGraphEndpoint());
+            } catch (Exception e) {
+                LOGGER.error("Failed to initialize MS Graph client: {}", e.getMessage(), e);
+                graphClient = null;
+            }
+            graphClientInitialized = true;
+            return graphClient;
+        }
+    }
+
+    /** First non-blank claim value among the given keys (case-insensitive, unwraps arrays). */
+    private String coalesceClaimValue(Map<String, Object> claims, String... keys) {
+        if (claims == null) return null;
+        for (String key : keys) {
+            if (!StringUtils.hasText(key)) continue;
+            Object value = claims.get(key);
+            if (value == null) {
+                for (Map.Entry<String, Object> e : claims.entrySet()) {
+                    if (key.equalsIgnoreCase(e.getKey())) {
+                        value = e.getValue();
+                        break;
+                    }
+                }
+            }
+            if (value != null) {
+                if (value instanceof Collection) {
+                    Collection<?> coll = (Collection<?>) value;
+                    if (!coll.isEmpty()) value = coll.iterator().next();
+                } else if (value.getClass().isArray() && Array.getLength(value) > 0) {
+                    value = Array.get(value, 0);
+                }
+                String str = String.valueOf(value);
+                if (!str.isEmpty()) return str;
+            }
+        }
+        return null;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectAuthenticationService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectAuthenticationService.java
@@ -110,22 +110,37 @@ public class OpenIdConnectAuthenticationService extends OAuth2GeoStoreAuthentica
     }
 
     /**
-     * For OIDC the "introspection" endpoint is the OpenID Connect userinfo endpoint, queried with a
-     * GET and a Bearer header (see {@link OpenIdConnectTokenServices}); override the generic POST
-     * {@code check_token} behavior accordingly.
+     * For OIDC, user attributes are fetched from the userinfo endpoint (GET + Bearer), not from the
+     * RFC 7662 introspection endpoint (POST). The introspection endpoint is used only for opaque
+     * bearer token validation via {@code bearerTokenStrategy=introspection}.
+     */
+    @Override
+    protected Map<String, Object> doIntrospectionOrUserInfoRequest(OAuth2AccessToken accessToken) {
+        String userInfoUri = configuration.getCheckTokenEndpointUrl();
+        if (!StringUtils.hasText(userInfoUri)) {
+            LOGGER.debug("OIDC: no userinfo endpoint configured, skipping userinfo lookup");
+            return null;
+        }
+        return doIntrospectionRequest(accessToken, userInfoUri);
+    }
+
+    /**
+     * Fetches user attributes from the given URI using GET and a Bearer token header, via {@link
+     * OpenIdConnectTokenServices}. In the OIDC context this is always the userinfo endpoint, passed
+     * by {@link #doIntrospectionOrUserInfoRequest}.
      */
     @Override
     protected Map<String, Object> doIntrospectionRequest(
-            OAuth2AccessToken accessToken, String introspectionUri) {
+            OAuth2AccessToken accessToken, String userInfoUri) {
         if (accessToken == null
                 || !StringUtils.hasText(accessToken.getTokenValue())
-                || !StringUtils.hasText(introspectionUri)) {
+                || !StringUtils.hasText(userInfoUri)) {
             return null;
         }
         try {
             OpenIdConnectTokenServices tokenServices =
                     new OpenIdConnectTokenServices(configuration.getPrincipalKey());
-            tokenServices.setCheckTokenEndpointUrl(introspectionUri);
+            tokenServices.setCheckTokenEndpointUrl(userInfoUri);
             tokenServices.setClientId(configuration.getClientId());
             tokenServices.setClientSecret(configuration.getClientSecret());
             Map<String, Object> result =

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectConfiguration.java
@@ -53,6 +53,7 @@ public class OpenIdConnectConfiguration extends OAuth2Configuration {
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public static final String PKCE_CODE_VERIFIER_SESSION_ATTR = "oidc.pkce.code_verifier";
+    private static final String PKCE_CODE_CHALLENGE_METHOD = "S256";
 
     String jwkURI;
     String postLogoutRedirectUri;
@@ -282,7 +283,8 @@ public class OpenIdConnectConfiguration extends OAuth2Configuration {
                         buildLoginUri()
                                 + "&code_challenge="
                                 + codeChallenge
-                                + "&code_challenge_method=S256";
+                                + "&code_challenge_method="
+                                + PKCE_CODE_CHALLENGE_METHOD;
                 response.sendRedirect(loginUri);
             } catch (Exception e) {
                 LOGGER.error("Failed to generate PKCE parameters", e);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectConfiguration.java
@@ -1,0 +1,334 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
+import jakarta.servlet.http.HttpSession;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Collections;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+
+public class OpenIdConnectConfiguration extends OAuth2Configuration {
+
+    private static final Logger LOGGER = LogManager.getLogger(OpenIdConnectConfiguration.class);
+
+    /** Shared, thread-safe source of randomness for PKCE code-verifier generation. */
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    public static final String PKCE_CODE_VERIFIER_SESSION_ATTR = "oidc.pkce.code_verifier";
+
+    String jwkURI;
+    String postLogoutRedirectUri;
+    boolean sendClientSecret = false;
+    boolean allowBearerTokens = true;
+    boolean usePKCE = false;
+    int maxTokenAgeSecs = 0;
+    String bearerTokenStrategy = "jwt";
+    String accessType;
+
+    // JWE (encrypted token) support
+    String jweKeyStoreFile;
+    String jweKeyStorePassword;
+    String jweKeyStoreType = "PKCS12";
+    String jweKeyAlias;
+    String jweKeyPassword;
+
+    // Microsoft Graph API integration
+    boolean msGraphEnabled = false;
+    String msGraphEndpoint = "https://graph.microsoft.com/v1.0";
+    boolean msGraphGroupsEnabled = true;
+    boolean msGraphRolesEnabled = false;
+    String msGraphAppId;
+
+    public String getJwkURI() {
+        return jwkURI;
+    }
+
+    public void setJwkURI(String jwkURI) {
+        this.jwkURI = jwkURI;
+    }
+
+    public String getPostLogoutRedirectUri() {
+        return postLogoutRedirectUri;
+    }
+
+    public void setPostLogoutRedirectUri(String postLogoutRedirectUri) {
+        this.postLogoutRedirectUri = postLogoutRedirectUri;
+    }
+
+    /**
+     * If true, the client secret will be sent to the token endpoint. This is useful for clients
+     * that are not capable of keeping the client secret confidential. ref.:
+     * https://tools.ietf.org/html/rfc6749#section-2.3.1
+     *
+     * @return boolean
+     */
+    public boolean isSendClientSecret() {
+        return sendClientSecret;
+    }
+
+    public void setSendClientSecret(boolean sendClientSecret) {
+        this.sendClientSecret = sendClientSecret;
+    }
+
+    public boolean isAllowBearerTokens() {
+        return allowBearerTokens;
+    }
+
+    public void setAllowBearerTokens(boolean allowBearerTokens) {
+        this.allowBearerTokens = allowBearerTokens;
+    }
+
+    /**
+     * Enables the use of Authorization Code Flow with Proof Key for Code Exchange (PKCE) for the
+     * authorization endpoint. ref.:
+     * https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce
+     *
+     * @return the authorization endpoint.
+     * @return boolean
+     */
+    public boolean isUsePKCE() {
+        return usePKCE;
+    }
+
+    public void setUsePKCE(boolean usePKCE) {
+        this.usePKCE = usePKCE;
+    }
+
+    public int getMaxTokenAgeSecs() {
+        return maxTokenAgeSecs;
+    }
+
+    public void setMaxTokenAgeSecs(int maxTokenAgeSecs) {
+        this.maxTokenAgeSecs = maxTokenAgeSecs;
+    }
+
+    /**
+     * Strategy for validating bearer tokens: "jwt" (default, decode and verify JWT),
+     * "introspection" (call the token introspection endpoint), or "auto" (try JWT first, fallback
+     * to introspection).
+     */
+    public String getBearerTokenStrategy() {
+        return bearerTokenStrategy;
+    }
+
+    public void setBearerTokenStrategy(String bearerTokenStrategy) {
+        this.bearerTokenStrategy = bearerTokenStrategy;
+    }
+
+    /**
+     * Access type for the authorization request. Set to "offline" to request a refresh token (e.g.
+     * for Google). When null, no access_type parameter is appended.
+     */
+    public String getAccessType() {
+        return accessType;
+    }
+
+    public void setAccessType(String accessType) {
+        this.accessType = accessType;
+    }
+
+    public String getJweKeyStoreFile() {
+        return jweKeyStoreFile;
+    }
+
+    public void setJweKeyStoreFile(String jweKeyStoreFile) {
+        this.jweKeyStoreFile = jweKeyStoreFile;
+    }
+
+    public String getJweKeyStorePassword() {
+        return jweKeyStorePassword;
+    }
+
+    public void setJweKeyStorePassword(String jweKeyStorePassword) {
+        this.jweKeyStorePassword = jweKeyStorePassword;
+    }
+
+    public String getJweKeyStoreType() {
+        return jweKeyStoreType;
+    }
+
+    public void setJweKeyStoreType(String jweKeyStoreType) {
+        this.jweKeyStoreType = jweKeyStoreType;
+    }
+
+    public String getJweKeyAlias() {
+        return jweKeyAlias;
+    }
+
+    public void setJweKeyAlias(String jweKeyAlias) {
+        this.jweKeyAlias = jweKeyAlias;
+    }
+
+    public String getJweKeyPassword() {
+        return jweKeyPassword;
+    }
+
+    public void setJweKeyPassword(String jweKeyPassword) {
+        this.jweKeyPassword = jweKeyPassword;
+    }
+
+    public boolean isMsGraphEnabled() {
+        return msGraphEnabled;
+    }
+
+    public void setMsGraphEnabled(boolean msGraphEnabled) {
+        this.msGraphEnabled = msGraphEnabled;
+    }
+
+    public String getMsGraphEndpoint() {
+        return msGraphEndpoint;
+    }
+
+    public void setMsGraphEndpoint(String msGraphEndpoint) {
+        this.msGraphEndpoint = msGraphEndpoint;
+    }
+
+    public boolean isMsGraphGroupsEnabled() {
+        return msGraphGroupsEnabled;
+    }
+
+    public void setMsGraphGroupsEnabled(boolean msGraphGroupsEnabled) {
+        this.msGraphGroupsEnabled = msGraphGroupsEnabled;
+    }
+
+    public boolean isMsGraphRolesEnabled() {
+        return msGraphRolesEnabled;
+    }
+
+    public void setMsGraphRolesEnabled(boolean msGraphRolesEnabled) {
+        this.msGraphRolesEnabled = msGraphRolesEnabled;
+    }
+
+    public String getMsGraphAppId() {
+        return msGraphAppId;
+    }
+
+    public void setMsGraphAppId(String msGraphAppId) {
+        this.msGraphAppId = msGraphAppId;
+    }
+
+    @Override
+    public String buildLoginUri() {
+        return super.buildLoginUri(accessType);
+    }
+
+    @Override
+    public String buildRefreshTokenURI() {
+        return super.buildRefreshTokenURI(accessType);
+    }
+
+    @Override
+    public AuthenticationEntryPoint getAuthenticationEntryPoint() {
+        if (!usePKCE) {
+            return super.getAuthenticationEntryPoint();
+        }
+        return (request, response, authException) -> {
+            try {
+                // Generate code_verifier: 32 random bytes, base64url-encoded
+                byte[] randomBytes = new byte[32];
+                SECURE_RANDOM.nextBytes(randomBytes);
+                String codeVerifier =
+                        Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+
+                // Compute code_challenge = BASE64URL(SHA-256(code_verifier))
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                byte[] hash = digest.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+                String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+
+                // Store verifier in HTTP session
+                HttpSession session = request.getSession(true);
+                session.setAttribute(PKCE_CODE_VERIFIER_SESSION_ATTR, codeVerifier);
+
+                // Build login URI with code_challenge parameters
+                String loginUri =
+                        buildLoginUri()
+                                + "&code_challenge="
+                                + codeChallenge
+                                + "&code_challenge_method=S256";
+                response.sendRedirect(loginUri);
+            } catch (Exception e) {
+                LOGGER.error("Failed to generate PKCE parameters", e);
+                response.sendRedirect(buildLoginUri());
+            }
+        };
+    }
+
+    /**
+     * Build the OIDC RP-Initiated Logout endpoint. Uses standard parameters: id_token_hint,
+     * post_logout_redirect_uri, and client_id.
+     *
+     * @param token the refresh token (unused for OIDC logout, kept for API compat).
+     * @param accessToken the access token (fallback if no ID token is available).
+     * @param configuration the OAuth2Configuration.
+     * @return the logout endpoint, or null if no logoutUri is configured.
+     */
+    @Override
+    public Endpoint buildLogoutEndpoint(
+            String token, String accessToken, OAuth2Configuration configuration) {
+        String uri = getLogoutUri();
+        if (uri == null) return null;
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        // id_token_hint: the ID token JWT string (required by most OIDC providers)
+        String idToken = OAuth2Utils.getIdToken();
+        if (idToken == null) idToken = accessToken;
+        if (idToken != null) {
+            params.put("id_token_hint", Collections.singletonList(idToken));
+        }
+
+        // client_id: some providers require it alongside id_token_hint
+        if (StringUtils.hasText(getClientId())) {
+            params.put("client_id", Collections.singletonList(getClientId()));
+        }
+
+        // post_logout_redirect_uri: where to redirect after logout
+        if (StringUtils.hasText(getPostLogoutRedirectUri())) {
+            params.put(
+                    "post_logout_redirect_uri",
+                    Collections.singletonList(getPostLogoutRedirectUri()));
+        }
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity =
+                new HttpEntity<>(null, new HttpHeaders());
+        return new Endpoint(HttpMethod.GET, appendParameters(params, uri), requestEntity);
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectFilter.java
@@ -1,0 +1,147 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.DiscoveryClient;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2GeoStoreAuthenticationFilter;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * OpenID Connect filter. Bearer-token authentication is delegated to the base filter (and the
+ * {@link OpenIdConnectAuthenticationService}); the interactive authorization-code callback is
+ * handled here by exchanging the code for tokens via {@link OpenIdConnectRestClient} and completing
+ * the GeoStore authentication.
+ */
+public class OpenIdConnectFilter extends OAuth2GeoStoreAuthenticationFilter {
+
+    private static final Logger LOGGER = LogManager.getLogger(OpenIdConnectFilter.class);
+
+    private final OpenIdConnectAuthenticationService oidcService;
+    private final OpenIdConnectRestClient restClient;
+
+    public OpenIdConnectFilter(
+            OpenIdConnectConfiguration configuration,
+            OpenIdConnectAuthenticationService authenticationService,
+            OpenIdConnectRestClient restClient) {
+        super(configuration, authenticationService);
+        if (StringUtils.hasText(configuration.getDiscoveryUrl())) {
+            new DiscoveryClient(configuration.getDiscoveryUrl()).autofill(configuration);
+        }
+        this.oidcService = authenticationService;
+        this.restClient = restClient;
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+
+        Authentication existing = SecurityContextHolder.getContext().getAuthentication();
+        if (existing == null && configuration.isEnabled() && !configuration.isInvalid()) {
+            String code = OAuth2Utils.getParameterValue("code", request);
+            if (StringUtils.hasText(code)) {
+                handleAuthorizationCodeCallback(request, response, code);
+            }
+        }
+
+        // Bearer-token authentication + request-attribute population + chaining happen in the base.
+        super.doFilter(req, res, chain);
+    }
+
+    private void handleAuthorizationCodeCallback(
+            HttpServletRequest request, HttpServletResponse response, String code) {
+        try {
+            request.setAttribute(OAUTH2_AUTHENTICATION_TYPE_KEY, OAuth2AuthenticationType.USER);
+
+            OAuth2AccessTokenResponse tokenResponse =
+                    restClient.exchangeAuthorizationCode(code, request);
+            if (tokenResponse == null) {
+                LOGGER.error("OIDC: authorization-code exchange returned no token response");
+                return;
+            }
+
+            OAuth2AccessToken accessToken = tokenResponse.getAccessToken();
+            OAuth2RefreshToken refreshToken = tokenResponse.getRefreshToken();
+            String idToken = extractIdToken(tokenResponse);
+
+            // Stash the id_token at request scope so OAuth2Utils.getIdToken() can resolve it during
+            // principal extraction (the generic flow prefers the ID token for claims).
+            if (idToken != null) {
+                RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
+                if (attrs != null) {
+                    attrs.setAttribute(
+                            OAuth2Utils.ID_TOKEN_VALUE, idToken, RequestAttributes.SCOPE_REQUEST);
+                } else {
+                    request.setAttribute(OAuth2Utils.ID_TOKEN_VALUE, idToken);
+                }
+            }
+
+            Authentication authentication =
+                    oidcService.completeInteractiveAuthentication(
+                            request, response, accessToken, refreshToken);
+            if (authentication != null) {
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                LOGGER.info("OIDC: interactive authentication completed for the callback request");
+            } else {
+                LOGGER.warn("OIDC: interactive authentication produced no Authentication");
+            }
+        } catch (Exception e) {
+            LOGGER.error("OIDC: authorization-code callback failed: {}", e.getMessage(), e);
+        }
+    }
+
+    private String extractIdToken(OAuth2AccessTokenResponse tokenResponse) {
+        Map<String, Object> additional = tokenResponse.getAdditionalParameters();
+        if (additional != null) {
+            Object idToken = additional.get(OAuth2Utils.ID_TOKEN_PARAM);
+            if (idToken != null) {
+                return String.valueOf(idToken);
+            }
+        }
+        return null;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectLoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectLoginService.java
@@ -1,0 +1,100 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static it.geosolutions.geostore.services.rest.SessionServiceDelegate.PROVIDER_KEY;
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.*;
+
+import it.geosolutions.geostore.services.rest.IdPLoginRest;
+import it.geosolutions.geostore.services.rest.security.oauth2.Oauth2LoginService;
+import it.geosolutions.geostore.services.rest.security.oauth2.TokenDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.Response;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * Extension point to customize the login and redirect after login performed from the {@link
+ * IdPLoginRest};
+ */
+public class OpenIdConnectLoginService extends Oauth2LoginService {
+
+    public OpenIdConnectLoginService(IdPLoginRest loginRest, String providerName) {
+        loginRest.registerService(providerName, this);
+    }
+
+    public OpenIdConnectLoginService(IdPLoginRest loginRest) {
+        this(loginRest, "oidc");
+    }
+
+    /**
+     * @param request the request.
+     * @param response the response.
+     * @param provider the provider name.
+     * @return
+     */
+    @Override
+    public Response doInternalRedirect(
+            HttpServletRequest request, HttpServletResponse response, String provider) {
+        String token = getAccessToken();
+        String refreshToken = getRefreshAccessToken();
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (token == null
+                && SecurityContextHolder.getContext() != null
+                && requestAttributes != null) {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null
+                    && auth.getDetails() != null
+                    && auth.getDetails() instanceof TokenDetails) {
+                TokenDetails tokenDetails = ((TokenDetails) auth.getDetails());
+                OAuth2AccessToken accessTokenDetails = tokenDetails.getAccessToken();
+                if (accessTokenDetails != null) {
+                    token = accessTokenDetails.getTokenValue();
+                    requestAttributes.setAttribute(ACCESS_TOKEN_PARAM, accessTokenDetails, 0);
+                    requestAttributes.setAttribute(ACCESS_TOKEN_VALUE, token, 0);
+                    if (tokenDetails.getRefreshToken() != null) {
+                        refreshToken = tokenDetails.getRefreshToken().getTokenValue();
+                        requestAttributes.setAttribute(REFRESH_TOKEN_PARAM, refreshToken, 0);
+                    }
+                }
+                if (tokenDetails.getIdToken() != null) {
+                    requestAttributes.setAttribute(ID_TOKEN_PARAM, tokenDetails.getIdToken(), 0);
+                    requestAttributes.setAttribute(
+                            ACCESS_TOKEN_VALUE, tokenDetails.getIdToken(), 0);
+                }
+            }
+        }
+        assert requestAttributes != null;
+        requestAttributes.setAttribute(PROVIDER_KEY, provider, 0);
+        return buildCallbackResponse(response, token, refreshToken, provider);
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectProviderRegistrar.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectProviderRegistrar.java
@@ -1,0 +1,263 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration.CONFIG_NAME_SUFFIX;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+/**
+ * Dynamically registers {@link OpenIdConnectConfiguration} beans for each provider declared in
+ * {@code oidc.providers}. If the property is not set, defaults to {@code "oidc"} for backward
+ * compatibility.
+ *
+ * <p>For each provider name {@code P}, registers:
+ *
+ * <ul>
+ *   <li>{@code POAuth2Config} &rarr; {@link OpenIdConnectConfiguration} singleton
+ * </ul>
+ *
+ * <p>The {@link org.springframework.beans.factory.config.PropertyOverrideConfigurer} fills
+ * properties via {@code POAuth2Config.clientId=...} etc. Filters, validators, and rest templates
+ * are created programmatically by the {@link CompositeOpenIdConnectFilter}.
+ */
+public class OpenIdConnectProviderRegistrar
+        implements BeanDefinitionRegistryPostProcessor, EnvironmentAware {
+
+    private static final Logger LOGGER = LogManager.getLogger(OpenIdConnectProviderRegistrar.class);
+
+    /** Primary property name — uses underscore to avoid PropertyOverrideConfigurer parsing. */
+    public static final String PROVIDERS_PROPERTY = "oidc_providers";
+
+    /** Legacy property name (dot-separated) — checked as fallback for backward compat. */
+    public static final String PROVIDERS_PROPERTY_LEGACY = "oidc.providers";
+
+    private static final String DEFAULT_PROVIDER = "oidc";
+
+    private Environment environment;
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry)
+            throws BeansException {
+        String providersValue = resolveProviders();
+
+        String[] providers = providersValue.split(",");
+        for (String raw : providers) {
+            String provider = raw.trim();
+            if (provider.isEmpty()) continue;
+
+            String configBeanName = provider + CONFIG_NAME_SUFFIX;
+
+            if (!registry.containsBeanDefinition(configBeanName)) {
+                BeanDefinitionBuilder configBuilder =
+                        BeanDefinitionBuilder.genericBeanDefinition(
+                                OpenIdConnectConfiguration.class);
+                registry.registerBeanDefinition(configBeanName, configBuilder.getBeanDefinition());
+                LOGGER.info("Registered OpenIdConnectConfiguration bean: {}", configBeanName);
+            }
+        }
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory)
+            throws BeansException {
+        // No post-processing needed on the bean factory itself
+    }
+
+    /** Returns the provider names as configured, defaulting to "oidc". */
+    public String[] getProviderNames() {
+        String providersValue = resolveProviders();
+        String[] names = providersValue.split(",");
+        for (int i = 0; i < names.length; i++) {
+            names[i] = names[i].trim();
+        }
+        return names;
+    }
+
+    /**
+     * Resolves the {@code oidc.providers} value. Checks, in order:
+     *
+     * <ol>
+     *   <li>Spring Environment (system properties, env vars, servlet context)
+     *   <li>Properties files on the classpath and in the data directory (same locations used by the
+     *       {@link org.springframework.beans.factory.config.PropertyOverrideConfigurer} in {@code
+     *       applicationContext.xml})
+     *   <li>Falls back to {@value #DEFAULT_PROVIDER}
+     * </ol>
+     *
+     * <p>This explicit scanning is required because {@code PropertyOverrideConfigurer} only
+     * overrides bean properties — it does NOT contribute to the Spring Environment, and this
+     * registrar runs as a {@code BeanDefinitionRegistryPostProcessor} before the override
+     * configurer executes.
+     */
+    private String resolveProviders() {
+        // Try both property names: underscore (preferred) and dot (legacy/backward compat).
+        // The dot-separated form (oidc.providers) conflicts with PropertyOverrideConfigurer
+        // which interprets it as bean "oidc", property "providers".  The underscore form
+        // (oidc_providers) avoids this issue.  Both are supported for flexibility.
+        String[] keys = {PROVIDERS_PROPERTY, PROVIDERS_PROPERTY_LEGACY};
+
+        // 1) Try the Spring Environment first (system properties, env vars)
+        for (String key : keys) {
+            String value = environment != null ? environment.getProperty(key) : null;
+            if (value != null && !value.trim().isEmpty()) {
+                LOGGER.info("Resolved {} from Spring Environment: {}", key, value);
+                return value.trim();
+            }
+        }
+
+        // 2) Scan properties files — classpath + data directory
+        for (String key : keys) {
+            String value = loadFromPropertiesFiles(key);
+            if (value != null && !value.trim().isEmpty()) {
+                LOGGER.info("Resolved {} from properties files: {}", key, value);
+                return value.trim();
+            }
+        }
+
+        LOGGER.info(
+                "{} not configured, using default provider: {}",
+                PROVIDERS_PROPERTY,
+                DEFAULT_PROVIDER);
+        return DEFAULT_PROVIDER;
+    }
+
+    /**
+     * Scans all known properties file locations for the given key. Mirrors the locations configured
+     * in the {@code PropertyOverrideConfigurer}:
+     *
+     * <ul>
+     *   <li>{@code classpath*:geostore-ovr.properties}
+     *   <li>{@code classpath*:mapstore-ovr.properties}
+     *   <li>{@code file:${datadir}/geostore-ovr.properties}
+     *   <li>{@code file:${datadir}/mapstore-ovr.properties}
+     * </ul>
+     *
+     * The data directory is resolved from the {@code MAPSTORE_DATA_DIR} environment variable or the
+     * {@code datadir.location} system property.
+     */
+    private String loadFromPropertiesFiles(String key) {
+        List<Resource> resources = new ArrayList<>();
+        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+        // Classpath resources
+        String[] classpathLocations = {
+            "classpath*:geostore-ovr.properties", "classpath*:mapstore-ovr.properties"
+        };
+        for (String location : classpathLocations) {
+            try {
+                for (Resource r : resolver.getResources(location)) {
+                    resources.add(r);
+                }
+            } catch (IOException e) {
+                LOGGER.debug("Could not resolve {}: {}", location, e.getMessage());
+            }
+        }
+
+        // Data directory resources (from MAPSTORE_DATA_DIR env var or datadir.location sysprop)
+        String dataDir = resolveDataDir();
+        if (dataDir != null) {
+            resources.add(new FileSystemResource(new File(dataDir, "geostore-ovr.properties")));
+            resources.add(new FileSystemResource(new File(dataDir, "mapstore-ovr.properties")));
+        }
+
+        // Scan all collected resources (last match wins to mirror override ordering)
+        String result = null;
+        for (Resource resource : resources) {
+            if (!resource.exists()) continue;
+            try {
+                Properties props = PropertiesLoaderUtils.loadProperties(resource);
+                String val = props.getProperty(key);
+                if (val != null && !val.trim().isEmpty()) {
+                    LOGGER.info("Found {}={} in {}", key, val, resource);
+                    result = val; // keep scanning — later files override earlier ones
+                }
+            } catch (IOException e) {
+                LOGGER.debug("Could not load properties from {}: {}", resource, e.getMessage());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Resolves the data directory path from the {@code MAPSTORE_DATA_DIR} environment variable or
+     * the {@code datadir.location} system property.
+     */
+    private String resolveDataDir() {
+        // Check environment variable first
+        String dir = System.getenv("MAPSTORE_DATA_DIR");
+        if (dir != null && !dir.trim().isEmpty()) {
+            LOGGER.info("Data directory from MAPSTORE_DATA_DIR env: {}", dir);
+            return dir.trim();
+        }
+        // Fall back to system property (set by Maven Cargo from ${env.MAPSTORE_DATA_DIR})
+        dir = System.getProperty("datadir.location");
+        if (dir != null && !dir.trim().isEmpty()) {
+            LOGGER.info("Data directory from datadir.location sysprop: {}", dir);
+            return dir.trim();
+        }
+        // Try Spring Environment
+        if (environment != null) {
+            dir = environment.getProperty("datadir.location");
+            if (dir != null && !dir.trim().isEmpty()) {
+                LOGGER.info("Data directory from environment datadir.location: {}", dir);
+                return dir.trim();
+            }
+            dir = environment.getProperty("MAPSTORE_DATA_DIR");
+            if (dir != null && !dir.trim().isEmpty()) {
+                LOGGER.info("Data directory from environment MAPSTORE_DATA_DIR: {}", dir);
+                return dir.trim();
+            }
+        }
+        LOGGER.warn(
+                "No data directory configured (MAPSTORE_DATA_DIR env / datadir.location sysprop not set)");
+        return null;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectRestClient.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectRestClient.java
@@ -1,0 +1,152 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.enancher.ClientSecretRequestEnhancer;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.enancher.PKCERequestEnhancer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Per-provider OAuth2 HTTP client for OpenID Connect. Performs the authorization-code token
+ * exchange and the refresh-token grant against the provider token endpoint.
+ *
+ * <p>Replaces the legacy {@code spring-security-oauth2} {@code OAuth2RestTemplate} / {@code
+ * GeoStoreOAuthRestTemplate} machinery. The token-endpoint JSON is deserialized into a Spring
+ * Security 7 {@link OAuth2AccessTokenResponse} via {@link
+ * OAuth2AccessTokenResponseHttpMessageConverter} (the {@code id_token} is exposed in {@link
+ * OAuth2AccessTokenResponse#getAdditionalParameters()}).
+ */
+public class OpenIdConnectRestClient {
+
+    private static final Logger LOGGER = LogManager.getLogger(OpenIdConnectRestClient.class);
+
+    private final OpenIdConnectConfiguration config;
+    private final RestTemplate restTemplate;
+    private final PKCERequestEnhancer pkceEnhancer;
+    private final ClientSecretRequestEnhancer clientSecretEnhancer;
+
+    public OpenIdConnectRestClient(OpenIdConnectConfiguration config) {
+        this.config = config;
+        this.restTemplate = buildRestTemplate();
+        this.pkceEnhancer = new PKCERequestEnhancer(config);
+        this.clientSecretEnhancer = new ClientSecretRequestEnhancer();
+    }
+
+    private static RestTemplate buildRestTemplate() {
+        RestTemplate rt = new RestTemplate();
+        rt.setMessageConverters(
+                Arrays.asList(
+                        new FormHttpMessageConverter(),
+                        new OAuth2AccessTokenResponseHttpMessageConverter()));
+        return rt;
+    }
+
+    /**
+     * Exchanges an authorization code for tokens at the provider token endpoint.
+     *
+     * @param code the authorization code returned on the callback.
+     * @param request the current request (used to recover the PKCE code_verifier from the session).
+     * @return the token response.
+     */
+    public OAuth2AccessTokenResponse exchangeAuthorizationCode(
+            String code, HttpServletRequest request) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add(OAuth2ParameterNames.GRANT_TYPE, "authorization_code");
+        form.add(OAuth2ParameterNames.CODE, code);
+        if (StringUtils.hasText(config.getRedirectUri())) {
+            form.add(OAuth2ParameterNames.REDIRECT_URI, config.getRedirectUri());
+        }
+        if (StringUtils.hasText(config.getClientId())) {
+            form.add(OAuth2ParameterNames.CLIENT_ID, config.getClientId());
+        }
+        // Mirror the legacy enhancer chain: with PKCE add code_verifier (+ client_secret iff
+        // sendClientSecret); otherwise add client_secret iff sendClientSecret.
+        if (config.isUsePKCE()) {
+            pkceEnhancer.enhance(form, request);
+        } else if (config.isSendClientSecret()) {
+            clientSecretEnhancer.enhance(form, config.getClientSecret());
+        }
+        LOGGER.debug("Exchanging authorization code at {}", config.getAccessTokenUri());
+        return postForToken(form);
+    }
+
+    /**
+     * Refreshes an access token using a refresh token. The legacy {@code OAuth2RestTemplate} always
+     * sent the client secret on refresh (independent of {@code sendClientSecret}); that behavior is
+     * preserved here.
+     *
+     * @param refreshToken the refresh token value.
+     * @return the token response.
+     */
+    public OAuth2AccessTokenResponse refreshAccessToken(String refreshToken) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add(OAuth2ParameterNames.GRANT_TYPE, "refresh_token");
+        form.add(OAuth2ParameterNames.REFRESH_TOKEN, refreshToken);
+        if (StringUtils.hasText(config.getClientId())) {
+            form.add(OAuth2ParameterNames.CLIENT_ID, config.getClientId());
+        }
+        if (StringUtils.hasText(config.getClientSecret())) {
+            form.add(ClientSecretRequestEnhancer.CLIENT_SECRET, config.getClientSecret());
+        }
+        LOGGER.debug("Refreshing access token at {}", config.getAccessTokenUri());
+        return postForToken(form);
+    }
+
+    private OAuth2AccessTokenResponse postForToken(MultiValueMap<String, String> form) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(form, headers);
+        ResponseEntity<OAuth2AccessTokenResponse> response =
+                restTemplate.exchange(
+                        config.getAccessTokenUri(),
+                        HttpMethod.POST,
+                        entity,
+                        OAuth2AccessTokenResponse.class);
+        return response.getBody();
+    }
+
+    public OpenIdConnectConfiguration getConfiguration() {
+        return config;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectSecurityConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectSecurityConfiguration.java
@@ -1,0 +1,45 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Minimal configuration class kept for backward compatibility. The legacy
+ * {@code @EnableOAuth2Client} annotation does not exist in Spring Security 7; all provider-specific
+ * beans (configurations, filters, rest clients, caches) are created dynamically by {@link
+ * OpenIdConnectProviderRegistrar} and {@link CompositeOpenIdConnectFilter}.
+ */
+@Configuration("oidcSecConfig")
+public class OpenIdConnectSecurityConfiguration {
+
+    public OAuth2Configuration configuration() {
+        return new OpenIdConnectConfiguration();
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectSessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectSessionServiceDelegate.java
@@ -1,0 +1,46 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import it.geosolutions.geostore.services.UserService;
+import it.geosolutions.geostore.services.rest.RESTSessionService;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2SessionServiceDelegate;
+
+/** OpenID Connect implementation of the {@link OAuth2SessionServiceDelegate}. */
+public class OpenIdConnectSessionServiceDelegate extends OAuth2SessionServiceDelegate {
+
+    public OpenIdConnectSessionServiceDelegate(
+            RESTSessionService restSessionService, UserService userService, String providerName) {
+        super(restSessionService, providerName, userService);
+    }
+
+    public OpenIdConnectSessionServiceDelegate(
+            RESTSessionService restSessionService, UserService userService) {
+        this(restSessionService, userService, "oidc");
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectTokenServices.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectTokenServices.java
@@ -1,0 +1,70 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.GeoStoreRemoteTokenServices;
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+/** Calls the OIDC userinfo endpoint to resolve token claims. */
+public class OpenIdConnectTokenServices extends GeoStoreRemoteTokenServices {
+
+    public OpenIdConnectTokenServices(String principalKey) {
+        // principalKey is retained for call-site compatibility; principal resolution from the
+        // userinfo/introspection claims is performed by OAuth2GeoStoreAuthenticationService using
+        // the provider OAuth2Configuration. A default RestTemplate mirrors the legacy
+        // RemoteTokenServices behavior (the CompositeOpenIdConnectFilter may override it).
+        super(new RestTemplate());
+        LOGGER.info("Instantiating OpenIdConnectTokenServices with principalKey: {}", principalKey);
+    }
+
+    @Override
+    protected Map<String, Object> checkToken(String accessToken) {
+        if (checkTokenEndpointUrl == null || checkTokenEndpointUrl.trim().isEmpty()) {
+            LOGGER.debug("No userinfo endpoint configured; skipping userinfo call.");
+            return Collections.emptyMap();
+        }
+        LOGGER.debug("Checking token via userinfo endpoint");
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", getAuthorizationHeader(accessToken));
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        Map<String, Object> results =
+                sendRequestForMap(
+                        checkTokenEndpointUrl,
+                        new LinkedMultiValueMap<>(),
+                        headers,
+                        HttpMethod.GET);
+        LOGGER.debug("Got userinfo results: {}", results);
+        return results;
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/AudienceAccessTokenValidator.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/AudienceAccessTokenValidator.java
@@ -1,0 +1,87 @@
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This checks that the token is connected to this application. This will prevent a token for
+ * another application being used by us.
+ *
+ * <p>NOTE: Azure AD's JWT AccessToken has a fixed "aud", no "azp", but an "appid" (should be our
+ * client id). example; "aud": "00000003-0000-0000-c000-000000000000", "appid":
+ * "b9e8d05a-08b6-48a5-81c8-9590a0f550f3",
+ *
+ * <p>NOTE: Some OIDC providers set the audience to a generic value (e.g. "account"), with no
+ * "appid", but "azp" (authorized party) should be our client id. example; "aud": "account", "azp":
+ * "live-key",
+ */
+public class AudienceAccessTokenValidator implements OpenIdTokenValidator {
+
+    private static final Logger LOGGER = LogManager.getLogger(AudienceAccessTokenValidator.class);
+
+    private final String AUDIENCE_CLAIM_NAME = "aud";
+    private final String APPID_CLAIM_NAME = "appid";
+    private final String AZP_CLAIM_NAME = "azp";
+
+    /**
+     * "aud" must be our client id OR "azp" must be our client id (or, if its a list, contain our
+     * client id) OR "appid" must be our client id.
+     *
+     * <p>Otherwise, it's token not for us...
+     *
+     * <p>This checks that the audience of the JWT access token is us. The main attack this tries to
+     * prevent is someone getting an access token from an OIDC provider that was meant for another
+     * application (say a silly calendar app), and then using that token here. The OIDC provider
+     * will validate the token as "good", but it wasn't generated for us. This does a check of the
+     * token that OUR client ID is mentioned (not another app).
+     */
+    @Override
+    public void verifyToken(OpenIdConnectConfiguration config, Map claimsJWT, Map userInfoClaims)
+            throws Exception {
+        String clientId = config.getClientId();
+        if ((claimsJWT.get(AUDIENCE_CLAIM_NAME) != null)) {
+            if (claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(clientId)) {
+                return;
+            } else if (claimsJWT.get(AUDIENCE_CLAIM_NAME) instanceof Collection
+                    && ((Collection) claimsJWT.get(AUDIENCE_CLAIM_NAME)).contains(clientId)) {
+                return;
+            }
+        }
+
+        if ((claimsJWT.get(APPID_CLAIM_NAME) != null)
+                && claimsJWT.get(APPID_CLAIM_NAME).equals(clientId)) {
+            return; // azure specific
+        }
+
+        // azp - authorized party (standard OIDC claim)
+        Object azp = claimsJWT.get(AZP_CLAIM_NAME);
+        if (azp != null) {
+            if (azp instanceof String) {
+                if (azp.equals(config.getClientId())) {
+                    return;
+                }
+            } else if (azp instanceof List) {
+                List azps = (List) azp;
+                for (Object o : azps) {
+                    if ((o instanceof String) && (o.equals(clientId))) {
+                        return;
+                    }
+                }
+            }
+        }
+        LOGGER.warn(
+                "Bearer token audience validation failed: aud={}, appid={}, azp={}, expected clientId={}",
+                claimsJWT.get(AUDIENCE_CLAIM_NAME),
+                claimsJWT.get(APPID_CLAIM_NAME),
+                claimsJWT.get(AZP_CLAIM_NAME),
+                clientId);
+        throw new Exception(
+                "JWT Bearer token audience mismatch — not meant for this application (clientId="
+                        + clientId
+                        + ")");
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/JweTokenDecryptor.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/JweTokenDecryptor.java
@@ -1,0 +1,128 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import com.nimbusds.jose.JWEDecrypter;
+import com.nimbusds.jose.crypto.ECDHDecrypter;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jwt.EncryptedJWT;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Detects and decrypts JWE (JSON Web Encryption) tokens. JWE tokens have 5 dot-separated parts
+ * (header.encryptedKey.iv.ciphertext.tag) and require the relying party's private key for
+ * decryption. After decryption, the inner content (a JWS token or plain claims JSON) is returned
+ * for downstream processing by the existing JWS validation pipeline.
+ */
+public class JweTokenDecryptor {
+
+    private static final Logger LOGGER = LogManager.getLogger(JweTokenDecryptor.class);
+
+    private final PrivateKey privateKey;
+
+    public JweTokenDecryptor(PrivateKey privateKey) {
+        if (privateKey == null) {
+            throw new IllegalArgumentException("Private key must not be null");
+        }
+        this.privateKey = privateKey;
+    }
+
+    /**
+     * Checks whether the given token string is a JWE token (5 dot-separated parts).
+     *
+     * @param token the token string to check
+     * @return true if the token has 5 dot-separated parts (JWE format)
+     */
+    public static boolean isJweToken(String token) {
+        if (token == null || token.isEmpty()) {
+            return false;
+        }
+        int dotCount = 0;
+        for (int i = 0; i < token.length(); i++) {
+            if (token.charAt(i) == '.') {
+                dotCount++;
+                if (dotCount > 4) {
+                    return false;
+                }
+            }
+        }
+        return dotCount == 4;
+    }
+
+    /**
+     * Decrypts a JWE token and returns the inner content. If the inner payload is itself a JWS (3
+     * dot-separated parts), it is returned as-is for downstream signature verification. If the
+     * payload is plain claims JSON, it is returned directly.
+     *
+     * @param jweToken the JWE token string (5 dot-separated parts)
+     * @return the decrypted inner content (JWS string or claims JSON)
+     * @throws IOException if decryption fails
+     */
+    public String decrypt(String jweToken) throws IOException {
+        try {
+            EncryptedJWT encryptedJWT = EncryptedJWT.parse(jweToken);
+
+            JWEDecrypter decrypter = createDecrypter();
+            encryptedJWT.decrypt(decrypter);
+
+            // The payload may be a nested JWS (signed JWT inside JWE) or plain claims
+            String payload = encryptedJWT.getPayload().toString();
+
+            LOGGER.debug("Successfully decrypted JWE token");
+            return payload;
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            LOGGER.error("Failed to decrypt JWE token: {}", e.getMessage());
+            throw new IOException("JWE token decryption failed", e);
+        }
+    }
+
+    private JWEDecrypter createDecrypter() throws IOException {
+        try {
+            if (privateKey instanceof RSAPrivateKey) {
+                return new RSADecrypter((RSAPrivateKey) privateKey);
+            } else if (privateKey instanceof ECPrivateKey) {
+                return new ECDHDecrypter((ECPrivateKey) privateKey);
+            } else {
+                throw new IOException(
+                        "Unsupported private key type for JWE decryption: "
+                                + privateKey.getAlgorithm());
+            }
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to create JWE decrypter", e);
+        }
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/JwksRsaKeyProvider.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/JwksRsaKeyProvider.java
@@ -1,0 +1,143 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Fetches and caches RSA public keys from a JWKS (JSON Web Key Set) endpoint. Used to verify JWT
+ * signatures on bearer tokens in the OIDC flow.
+ */
+public class JwksRsaKeyProvider {
+
+    private static final Logger LOGGER = LogManager.getLogger(JwksRsaKeyProvider.class);
+
+    private final String jwksUri;
+    private final RestTemplate restTemplate;
+    private final Map<String, RSAPublicKey> keyCache = new ConcurrentHashMap<>();
+
+    public JwksRsaKeyProvider(String jwksUri) {
+        this(jwksUri, new RestTemplate());
+    }
+
+    JwksRsaKeyProvider(String jwksUri, RestTemplate restTemplate) {
+        this.jwksUri = jwksUri;
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Gets the RSA public key for the given key ID. Looks up the cache first; on a miss, refreshes
+     * from the JWKS endpoint once.
+     *
+     * @param kid the key ID from the JWT header (may be null)
+     * @return the matching RSAPublicKey, or null if not found
+     */
+    public RSAPublicKey getKey(String kid) {
+        RSAPublicKey key = keyCache.get(kid != null ? kid : "");
+        if (key != null) {
+            return key;
+        }
+        // Cache miss — refresh keys from the endpoint and try again
+        synchronized (this) {
+            // Double-check after acquiring the lock
+            key = keyCache.get(kid != null ? kid : "");
+            if (key != null) {
+                return key;
+            }
+            refreshKeys();
+        }
+        return keyCache.get(kid != null ? kid : "");
+    }
+
+    /** Fetches the JWKS JSON from the configured endpoint and parses RSA public keys. */
+    synchronized void refreshKeys() {
+        try {
+            LOGGER.debug("Fetching JWKS from {}", jwksUri);
+            String jwksJson = restTemplate.getForObject(jwksUri, String.class);
+            if (jwksJson == null || jwksJson.isEmpty()) {
+                LOGGER.warn("Empty response from JWKS endpoint: {}", jwksUri);
+                return;
+            }
+
+            JSONObject jwks = JSONObject.fromObject(jwksJson);
+            JSONArray keys = jwks.getJSONArray("keys");
+            if (keys == null) {
+                LOGGER.warn("No 'keys' array in JWKS response from {}", jwksUri);
+                return;
+            }
+
+            Map<String, RSAPublicKey> newKeys = new ConcurrentHashMap<>();
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+
+            for (int i = 0; i < keys.size(); i++) {
+                JSONObject jwk = keys.getJSONObject(i);
+                String kty = jwk.optString("kty", "");
+                String use = jwk.optString("use", "sig");
+                if (!"RSA".equals(kty) || !"sig".equals(use)) {
+                    continue;
+                }
+
+                String kid = jwk.optString("kid", "");
+                String n = jwk.optString("n", null);
+                String e = jwk.optString("e", null);
+                if (n == null || e == null) {
+                    LOGGER.warn("JWKS key missing 'n' or 'e' field, kid={}", kid);
+                    continue;
+                }
+
+                try {
+                    Base64.Decoder decoder = Base64.getUrlDecoder();
+                    BigInteger modulus = new BigInteger(1, decoder.decode(n));
+                    BigInteger exponent = new BigInteger(1, decoder.decode(e));
+                    RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+                    RSAPublicKey publicKey = (RSAPublicKey) keyFactory.generatePublic(spec);
+                    newKeys.put(kid, publicKey);
+                } catch (Exception ex) {
+                    LOGGER.warn("Failed to parse JWKS key with kid={}: {}", kid, ex.getMessage());
+                }
+            }
+
+            keyCache.clear();
+            keyCache.putAll(newKeys);
+            LOGGER.debug("Loaded {} RSA keys from JWKS endpoint", newKeys.size());
+        } catch (Exception e) {
+            LOGGER.error("Failed to fetch or parse JWKS from {}: {}", jwksUri, e.getMessage(), e);
+        }
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/MicrosoftGraphClient.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/MicrosoftGraphClient.java
@@ -1,0 +1,262 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * HTTP client for Microsoft Graph API. Provides methods to resolve group memberships and app role
+ * assignments for the authenticated user, handling OData pagination.
+ *
+ * <p>Used to resolve the Azure AD "groups overage" scenario where the JWT's {@code groups} claim is
+ * replaced by {@code _claim_names}/{@code _claim_sources} metadata when a user belongs to more than
+ * 200 groups.
+ */
+public class MicrosoftGraphClient {
+
+    private static final Logger LOGGER = LogManager.getLogger(MicrosoftGraphClient.class);
+
+    private final String graphEndpoint;
+    private final RestTemplate restTemplate;
+
+    public MicrosoftGraphClient(String graphEndpoint) {
+        this(graphEndpoint, new RestTemplate());
+    }
+
+    public MicrosoftGraphClient(String graphEndpoint, RestTemplate restTemplate) {
+        this.graphEndpoint =
+                graphEndpoint != null ? graphEndpoint : "https://graph.microsoft.com/v1.0";
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Fetches the display names of all groups the authenticated user is a member of via {@code GET
+     * /me/memberOf}. Filters to {@code #microsoft.graph.group} entries and extracts {@code
+     * displayName}. Handles OData {@code @odata.nextLink} pagination.
+     *
+     * @param accessToken the OAuth2 access token with {@code GroupMember.Read.All} or {@code
+     *     Directory.Read.All} scope.
+     * @return list of group display names, or empty list on error.
+     */
+    @SuppressWarnings("unchecked")
+    public List<String> fetchMemberOfGroups(String accessToken) {
+        if (accessToken == null || accessToken.isEmpty()) {
+            LOGGER.debug("MS Graph: no access token provided for group resolution");
+            return Collections.emptyList();
+        }
+
+        try {
+            String url = graphEndpoint + "/me/memberOf?$select=displayName,@odata.type";
+            List<Map<String, Object>> allValues = fetchAllPages(url, accessToken);
+
+            List<String> groups = new ArrayList<>();
+            for (Map<String, Object> entry : allValues) {
+                Object odataType = entry.get("@odata.type");
+                if ("#microsoft.graph.group".equals(odataType)) {
+                    Object displayName = entry.get("displayName");
+                    if (displayName != null && !displayName.toString().isEmpty()) {
+                        groups.add(displayName.toString());
+                    }
+                }
+            }
+
+            LOGGER.info("MS Graph: resolved {} groups from /me/memberOf", groups.size());
+            return groups;
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "MS Graph: failed to fetch groups from /me/memberOf: {}", e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Fetches app role assignments for the authenticated user via {@code GET
+     * /me/appRoleAssignments}.
+     *
+     * @param accessToken the OAuth2 access token.
+     * @return list of {@link AppRoleAssignment} objects, or empty list on error.
+     */
+    @SuppressWarnings("unchecked")
+    public List<AppRoleAssignment> fetchAppRoleAssignments(String accessToken) {
+        if (accessToken == null || accessToken.isEmpty()) {
+            LOGGER.debug("MS Graph: no access token provided for app role assignments");
+            return Collections.emptyList();
+        }
+
+        try {
+            String url = graphEndpoint + "/me/appRoleAssignments";
+            List<Map<String, Object>> allValues = fetchAllPages(url, accessToken);
+
+            List<AppRoleAssignment> assignments = new ArrayList<>();
+            for (Map<String, Object> entry : allValues) {
+                Object appRoleId = entry.get("appRoleId");
+                Object resourceId = entry.get("resourceId");
+                if (appRoleId != null && resourceId != null) {
+                    assignments.add(
+                            new AppRoleAssignment(appRoleId.toString(), resourceId.toString()));
+                }
+            }
+
+            LOGGER.info(
+                    "MS Graph: resolved {} app role assignments from /me/appRoleAssignments",
+                    assignments.size());
+            return assignments;
+        } catch (Exception e) {
+            LOGGER.warn("MS Graph: failed to fetch app role assignments: {}", e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Resolves app role assignment GUIDs to human-readable role names. Groups assignments by {@code
+     * resourceId}, then calls {@code GET /servicePrincipals/{id}/appRoles} for each unique resource
+     * to map GUIDs to {@code value} strings.
+     *
+     * @param accessToken the OAuth2 access token.
+     * @param assignments the app role assignments to resolve.
+     * @return list of resolved role name strings, or empty list on error.
+     */
+    @SuppressWarnings("unchecked")
+    public List<String> resolveAppRoleNames(
+            String accessToken, List<AppRoleAssignment> assignments) {
+        if (accessToken == null
+                || accessToken.isEmpty()
+                || assignments == null
+                || assignments.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            // Group assignments by resourceId
+            Map<String, List<String>> byResource = new LinkedHashMap<>();
+            for (AppRoleAssignment a : assignments) {
+                byResource
+                        .computeIfAbsent(a.getResourceId(), k -> new ArrayList<>())
+                        .add(a.getAppRoleId());
+            }
+
+            List<String> roleNames = new ArrayList<>();
+            for (Map.Entry<String, List<String>> entry : byResource.entrySet()) {
+                String resourceId = entry.getKey();
+                List<String> roleIds = entry.getValue();
+
+                String url = graphEndpoint + "/servicePrincipals/" + resourceId + "/appRoles";
+                List<Map<String, Object>> appRoles = fetchAllPages(url, accessToken);
+
+                // Build GUID -> value map
+                Map<String, String> guidToValue = new LinkedHashMap<>();
+                for (Map<String, Object> role : appRoles) {
+                    Object id = role.get("id");
+                    Object value = role.get("value");
+                    if (id != null && value != null && !value.toString().isEmpty()) {
+                        guidToValue.put(id.toString(), value.toString());
+                    }
+                }
+
+                // Resolve each assignment's appRoleId
+                for (String roleId : roleIds) {
+                    String name = guidToValue.get(roleId);
+                    if (name != null) {
+                        roleNames.add(name);
+                    }
+                }
+            }
+
+            LOGGER.info("MS Graph: resolved {} app role names", roleNames.size());
+            return roleNames;
+        } catch (Exception e) {
+            LOGGER.warn("MS Graph: failed to resolve app role names: {}", e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Fetches all pages of an OData collection, following {@code @odata.nextLink} pagination.
+     *
+     * @param url the initial request URL.
+     * @param accessToken the OAuth2 access token.
+     * @return all {@code value} entries collected across pages.
+     */
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> fetchAllPages(String url, String accessToken) {
+        List<Map<String, Object>> allValues = new ArrayList<>();
+        String currentUrl = url;
+
+        while (currentUrl != null) {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<Map> response =
+                    restTemplate.exchange(currentUrl, HttpMethod.GET, entity, Map.class);
+
+            Map<String, Object> body = response.getBody();
+            if (body == null) break;
+
+            Object value = body.get("value");
+            if (value instanceof List) {
+                allValues.addAll((List<Map<String, Object>>) value);
+            }
+
+            Object nextLink = body.get("@odata.nextLink");
+            currentUrl = (nextLink instanceof String) ? (String) nextLink : null;
+        }
+
+        return allValues;
+    }
+
+    /** Represents a Microsoft Graph app role assignment. */
+    public static class AppRoleAssignment {
+        private final String appRoleId;
+        private final String resourceId;
+
+        public AppRoleAssignment(String appRoleId, String resourceId) {
+            this.appRoleId = appRoleId;
+            this.resourceId = resourceId;
+        }
+
+        public String getAppRoleId() {
+            return appRoleId;
+        }
+
+        public String getResourceId() {
+            return resourceId;
+        }
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/MultiTokenValidator.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/MultiTokenValidator.java
@@ -1,0 +1,30 @@
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is a token validator that runs a list of TokenValidators. This doesn't do any validation on
+ * its own...
+ */
+public class MultiTokenValidator implements OpenIdTokenValidator {
+
+    List<OpenIdTokenValidator> validators;
+
+    public MultiTokenValidator(List<OpenIdTokenValidator> validators) {
+        this.validators = validators;
+    }
+
+    @Override
+    public void verifyToken(
+            OpenIdConnectConfiguration config, Map accessTokenClaims, Map userInfoClaims)
+            throws Exception {
+        if (validators == null) {
+            return; // nothing to do
+        }
+        for (OpenIdTokenValidator validator : validators) {
+            validator.verifyToken(config, accessTokenClaims, userInfoClaims);
+        }
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/OpenIdTokenValidator.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/OpenIdTokenValidator.java
@@ -1,0 +1,19 @@
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import java.util.Map;
+
+/**
+ * Bearer tokens should be checked to make sure they are applicable to this application (to prevent
+ * token reuse from another application)
+ */
+public interface OpenIdTokenValidator {
+
+    /**
+     * @param accessTokenClaims - map of claims in the Access Token
+     * @param userInfoClaims - map of claims from the oidc "userInfo" endpoint
+     * @throws Exception - if there is a problem, throw an exception.
+     */
+    void verifyToken(OpenIdConnectConfiguration config, Map accessTokenClaims, Map userInfoClaims)
+            throws Exception;
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/SubjectTokenValidator.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/SubjectTokenValidator.java
@@ -1,0 +1,56 @@
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This verifies that the token is about our user (i.e. the access token and userinfo endpoint agree
+ * on who).
+ *
+ * <p>For most OIDC providers, the "sub" of the JWT and userInfo are the same. For Azure AD, the
+ * "sub" of the userInfo is in the JWT "xms_st" claim. "xms_st": { "sub":
+ * "982kuI1hxIANLB__lrKejDgDnyjPnhbKLdPUF0JmOD1" },
+ *
+ * <p>The spec suggests verifying the user vs token subjects match, so this does that check.
+ */
+public class SubjectTokenValidator implements OpenIdTokenValidator {
+
+    private static final Logger LOGGER = LogManager.getLogger(SubjectTokenValidator.class);
+
+    private final String SUBJECT_CLAIM_NAME = "sub";
+    private final String AZURE_SUBJECT_CONTAINER_NAME = "xms_st";
+
+    @Override
+    public void verifyToken(OpenIdConnectConfiguration config, Map claims, Map userInfoClaims)
+            throws Exception {
+        // If no userinfo is available (e.g. direct bearer token validation without
+        // introspection), skip the subject comparison — there is nothing to compare against.
+        if (userInfoClaims == null || userInfoClaims.isEmpty()) {
+            return;
+        }
+
+        // normal case - subjects are the same
+        if ((claims.get(SUBJECT_CLAIM_NAME) != null)
+                && (userInfoClaims.get(SUBJECT_CLAIM_NAME) != null)) {
+            if (claims.get(SUBJECT_CLAIM_NAME).equals(userInfoClaims.get(SUBJECT_CLAIM_NAME)))
+                return;
+        }
+
+        // Azure AD case - use accesstoken.xms_st.sub vs userinfo.sub
+        if ((claims.get(AZURE_SUBJECT_CONTAINER_NAME) != null)
+                && (claims.get(AZURE_SUBJECT_CONTAINER_NAME) instanceof Map)) {
+            Map xmls_st = (Map) claims.get(AZURE_SUBJECT_CONTAINER_NAME);
+            if (xmls_st.get(SUBJECT_CLAIM_NAME) != null) {
+                if (xmls_st.get(SUBJECT_CLAIM_NAME).equals(userInfoClaims.get(SUBJECT_CLAIM_NAME)))
+                    return;
+            }
+        }
+        LOGGER.warn(
+                "Bearer token subject mismatch: JWT sub={}, userinfo sub={}",
+                claims.get(SUBJECT_CLAIM_NAME),
+                userInfoClaims != null ? userInfoClaims.get(SUBJECT_CLAIM_NAME) : "null");
+        throw new Exception("JWT Bearer token subject does not match userinfo subject");
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/ClientSecretRequestEnhancer.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/ClientSecretRequestEnhancer.java
@@ -1,0 +1,49 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.enancher;
+
+import java.util.Collections;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+
+/**
+ * Adds the {@code client_secret} parameter to an authorization-code token request form. Replaces
+ * the legacy {@code spring-security-oauth2} {@code RequestEnhancer} implementation; the token
+ * exchange is now a direct form POST performed by {@code OpenIdConnectRestClient}.
+ */
+public class ClientSecretRequestEnhancer {
+
+    /** {@code client_secret} - used in Token Request. */
+    public static final String CLIENT_SECRET = "client_secret";
+
+    public void enhance(MultiValueMap<String, String> form, String clientSecret) {
+        if (StringUtils.hasText(clientSecret)) {
+            form.put(CLIENT_SECRET, Collections.singletonList(clientSecret));
+        }
+    }
+}

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/PKCERequestEnhancer.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/PKCERequestEnhancer.java
@@ -61,6 +61,10 @@ public class PKCERequestEnhancer {
         }
         if (config.isUsePKCE()) {
             String codeVerifier = retrieveVerifierFromSession(request);
+            LOGGER.debug(
+                    "PKCE: code_verifier {} in session, {} to token request",
+                    StringUtils.hasText(codeVerifier) ? "found" : "NOT FOUND",
+                    StringUtils.hasText(codeVerifier) ? "adding" : "NOT adding");
             if (StringUtils.hasText(codeVerifier)) {
                 form.put(PkceParameterNames.CODE_VERIFIER, Collections.singletonList(codeVerifier));
             }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/PKCERequestEnhancer.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/PKCERequestEnhancer.java
@@ -1,0 +1,88 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.enancher;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.Collections;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+
+/**
+ * Enhances authorization-code token requests with the previously generated {@code code_verifier}
+ * (PKCE) and, when {@code sendClientSecret} is enabled, the {@code client_secret}. The verifier is
+ * the one stored in the HTTP session by the PKCE authentication entry point (see {@link
+ * OpenIdConnectConfiguration#getAuthenticationEntryPoint()}).
+ */
+public class PKCERequestEnhancer {
+
+    private static final Logger LOGGER = LogManager.getLogger(PKCERequestEnhancer.class);
+
+    private final OpenIdConnectConfiguration config;
+
+    public PKCERequestEnhancer(OpenIdConnectConfiguration oidcConfig) {
+        this.config = oidcConfig;
+    }
+
+    public void enhance(MultiValueMap<String, String> form, HttpServletRequest request) {
+        if (config.isSendClientSecret() && StringUtils.hasText(config.getClientSecret())) {
+            form.put(
+                    ClientSecretRequestEnhancer.CLIENT_SECRET,
+                    Collections.singletonList(config.getClientSecret()));
+        }
+        if (config.isUsePKCE()) {
+            String codeVerifier = retrieveVerifierFromSession(request);
+            if (StringUtils.hasText(codeVerifier)) {
+                form.put(PkceParameterNames.CODE_VERIFIER, Collections.singletonList(codeVerifier));
+            }
+        }
+    }
+
+    private String retrieveVerifierFromSession(HttpServletRequest request) {
+        try {
+            if (request == null) return null;
+            HttpSession session = request.getSession(false);
+            if (session == null) return null;
+            String verifier =
+                    (String)
+                            session.getAttribute(
+                                    OpenIdConnectConfiguration.PKCE_CODE_VERIFIER_SESSION_ATTR);
+            if (verifier != null) {
+                session.removeAttribute(OpenIdConnectConfiguration.PKCE_CODE_VERIFIER_SESSION_ATTR);
+                return verifier;
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Could not retrieve PKCE code_verifier from session", e);
+        }
+        return null;
+    }
+}

--- a/src/modules/rest/impl/src/main/resources/applicationContext.xml
+++ b/src/modules/rest/impl/src/main/resources/applicationContext.xml
@@ -185,8 +185,9 @@
         <jaxrs:outInterceptors>
             <ref bean="noCacheInterceptor"/>
         </jaxrs:outInterceptors>
-        <!-- Is the following interceptor still needed to allow autocreation of auth users???
-             anyway the autocreation of auth users must be modified to work with spring security -->
+        <!-- Auto-creation interceptor for direct REST API calls (e.g. /users requests).
+             Uncomment to enable, and set autoCreateUsersInterceptor.autoCreateUsers=true
+             in geostore-ovr.properties. -->
         <!-- 		<jaxrs:inInterceptors> -->
         <!-- 			<ref bean="autoCreateUsersInterceptor"/> -->
         <!-- 		</jaxrs:inInterceptors> -->

--- a/src/modules/rest/impl/src/main/resources/applicationContext.xml
+++ b/src/modules/rest/impl/src/main/resources/applicationContext.xml
@@ -82,12 +82,23 @@
 <!--        <constructor-arg ref="userService"/>-->
     </bean>
 
+    <bean id="oidcSessionServiceDelegate"
+          class="it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectSessionServiceDelegate">
+        <constructor-arg ref="restSessionService"/>
+        <constructor-arg ref="userService"/>
+    </bean>
+
     <bean id="idpLoginRest"
           class="it.geosolutions.geostore.services.rest.security.oauth2.IdPLoginRestImpl">
     </bean>
 
     <bean id="tokenStorage"
           class="it.geosolutions.geostore.services.rest.security.oauth2.InMemoryTokenStorage">
+    </bean>
+
+    <bean id="oidcLoginService"
+          class="it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectLoginService">
+        <constructor-arg ref="idpLoginRest"/>
     </bean>
 
     <bean id="restDiagnosticsService"

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/ClaimPathResolverTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/ClaimPathResolverTest.java
@@ -1,0 +1,272 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ClaimPathResolverTest {
+
+    // ----- toJsonPath -----
+
+    @Test
+    public void testToJsonPathDotNotation() {
+        assertEquals("$.realm_access.roles", ClaimPathResolver.toJsonPath("realm_access.roles"));
+    }
+
+    @Test
+    public void testToJsonPathAlreadyJsonPath() {
+        assertEquals("$.realm_access.roles", ClaimPathResolver.toJsonPath("$.realm_access.roles"));
+    }
+
+    @Test
+    public void testToJsonPathSimpleClaim() {
+        assertEquals("$.roles", ClaimPathResolver.toJsonPath("roles"));
+    }
+
+    @Test
+    public void testToJsonPathNull() {
+        assertNull(ClaimPathResolver.toJsonPath(null));
+    }
+
+    // ----- resolve with dot-notation -----
+
+    @Test
+    public void testResolveDotNotationNested() {
+        Map<String, Object> doc = new HashMap<>();
+        Map<String, Object> realmAccess = new HashMap<>();
+        realmAccess.put("roles", Arrays.asList("ADMIN", "user"));
+        doc.put("realm_access", realmAccess);
+
+        Object result = ClaimPathResolver.resolve(doc, "realm_access.roles");
+        assertNotNull(result);
+        assertTrue(result instanceof List);
+        assertEquals(Arrays.asList("ADMIN", "user"), result);
+    }
+
+    @Test
+    public void testResolveDotNotationDeeplyNested() {
+        Map<String, Object> doc = new HashMap<>();
+        Map<String, Object> resourceAccess = new HashMap<>();
+        Map<String, Object> geostore = new HashMap<>();
+        geostore.put("groups", Arrays.asList("analysts", "editors"));
+        resourceAccess.put("geostore", geostore);
+        doc.put("resource_access", resourceAccess);
+
+        Object result = ClaimPathResolver.resolve(doc, "resource_access.geostore.groups");
+        assertNotNull(result);
+        assertTrue(result instanceof List);
+        assertEquals(Arrays.asList("analysts", "editors"), result);
+    }
+
+    @Test
+    public void testResolveTopLevel() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("roles", Arrays.asList("USER"));
+
+        Object result = ClaimPathResolver.resolve(doc, "roles");
+        assertNotNull(result);
+        assertEquals(Arrays.asList("USER"), result);
+    }
+
+    // ----- resolve with explicit JsonPath -----
+
+    @Test
+    public void testResolveExplicitJsonPath() {
+        Map<String, Object> doc = new HashMap<>();
+        Map<String, Object> realmAccess = new HashMap<>();
+        realmAccess.put("roles", Arrays.asList("ADMIN", "user"));
+        doc.put("realm_access", realmAccess);
+
+        Object result = ClaimPathResolver.resolve(doc, "$.realm_access.roles");
+        assertNotNull(result);
+        assertEquals(Arrays.asList("ADMIN", "user"), result);
+    }
+
+    @Test
+    public void testResolveArrayIndex() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("roles", Arrays.asList("ADMIN", "USER", "GUEST"));
+
+        Object result = ClaimPathResolver.resolve(doc, "$.roles[0]");
+        assertEquals("ADMIN", result);
+    }
+
+    @Test
+    public void testResolveWildcard() {
+        Map<String, Object> doc = new HashMap<>();
+        Map<String, Object> resourceAccess = new LinkedHashMap<>();
+
+        Map<String, Object> app1 = new HashMap<>();
+        app1.put("roles", Arrays.asList("role_a"));
+        resourceAccess.put("app1", app1);
+
+        Map<String, Object> app2 = new HashMap<>();
+        app2.put("roles", Arrays.asList("role_b"));
+        resourceAccess.put("app2", app2);
+
+        doc.put("resource_access", resourceAccess);
+
+        List<String> result = ClaimPathResolver.resolveAsList(doc, "$.resource_access.*.roles");
+        assertNotNull(result);
+        assertTrue(result.contains("role_a"), "Should contain role_a");
+        assertTrue(result.contains("role_b"), "Should contain role_b");
+    }
+
+    @Test
+    public void testResolveFilter() {
+        Map<String, Object> doc = new HashMap<>();
+        Map<String, Object> realmAccess = new HashMap<>();
+        realmAccess.put("roles", Arrays.asList("ADMIN", "user", "offline_access"));
+        doc.put("realm_access", realmAccess);
+
+        Object result = ClaimPathResolver.resolve(doc, "$.realm_access.roles[?(@=='ADMIN')]");
+        assertNotNull(result);
+        assertTrue(result instanceof List);
+        List<?> filtered = (List<?>) result;
+        assertEquals(1, filtered.size());
+        assertEquals("ADMIN", filtered.get(0));
+    }
+
+    // ----- resolveAsList -----
+
+    @Test
+    public void testResolveAsListFromList() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("groups", Arrays.asList("analysts", "editors"));
+
+        List<String> result = ClaimPathResolver.resolveAsList(doc, "groups");
+        assertNotNull(result);
+        assertEquals(Arrays.asList("analysts", "editors"), result);
+    }
+
+    @Test
+    public void testResolveAsListFromSingleValue() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("role", "ADMIN");
+
+        List<String> result = ClaimPathResolver.resolveAsList(doc, "role");
+        assertNotNull(result);
+        assertEquals(Collections.singletonList("ADMIN"), result);
+    }
+
+    @Test
+    public void testResolveAsListNull() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("other", "value");
+
+        List<String> result = ClaimPathResolver.resolveAsList(doc, "missing");
+        assertNull(result);
+    }
+
+    // ----- case-insensitive -----
+
+    @Test
+    public void testResolveIgnoreCase() {
+        Map<String, Object> doc = new HashMap<>();
+        Map<String, Object> realmAccess = new HashMap<>();
+        realmAccess.put("Roles", Arrays.asList("ADMIN"));
+        doc.put("Realm_Access", realmAccess);
+
+        Object result = ClaimPathResolver.resolveIgnoreCase(doc, "realm_access.roles");
+        assertNotNull(result);
+        assertTrue(result instanceof List);
+        assertEquals(Arrays.asList("ADMIN"), result);
+    }
+
+    @Test
+    public void testResolveAsListIgnoreCase() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("Groups", Arrays.asList("dev", "ops"));
+
+        List<String> result = ClaimPathResolver.resolveAsListIgnoreCase(doc, "groups");
+        assertNotNull(result);
+        assertEquals(Arrays.asList("dev", "ops"), result);
+    }
+
+    // ----- edge cases -----
+
+    @Test
+    public void testResolveNullDocument() {
+        assertNull(ClaimPathResolver.resolve(null, "roles"));
+    }
+
+    @Test
+    public void testResolveNullPath() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("roles", "ADMIN");
+        assertNull(ClaimPathResolver.resolve(doc, null));
+    }
+
+    @Test
+    public void testResolveEmptyPath() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("roles", "ADMIN");
+        assertNull(ClaimPathResolver.resolve(doc, ""));
+    }
+
+    @Test
+    public void testResolveMissingKey() {
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("roles", "ADMIN");
+        assertNull(ClaimPathResolver.resolve(doc, "groups"));
+    }
+
+    @Test
+    public void testResolveEmptyDocument() {
+        assertNull(ClaimPathResolver.resolve(new HashMap<>(), "roles"));
+    }
+
+    // ----- toStringList edge cases -----
+
+    @Test
+    public void testToStringListNull() {
+        assertNull(ClaimPathResolver.toStringList(null));
+    }
+
+    @Test
+    public void testToStringListEmptyList() {
+        List<String> result = ClaimPathResolver.toStringList(Collections.emptyList());
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testToStringListIntegerValues() {
+        List<String> result = ClaimPathResolver.toStringList(Arrays.asList(1, 2, 3));
+        assertNotNull(result);
+        assertEquals(Arrays.asList("1", "2", "3"), result);
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/DiscoveryClientTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/DiscoveryClientTest.java
@@ -1,0 +1,68 @@
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import java.util.Arrays;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+
+public class DiscoveryClientTest {
+
+    private static WireMockServer openIdService;
+    private static String authService;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        openIdService =
+                new WireMockServer(
+                        wireMockConfig()
+                                .dynamicPort()
+                                // uncomment the following to get wiremock logging
+                                .notifier(new ConsoleNotifier(true)));
+        openIdService.start();
+
+        openIdService.stubFor(
+                any((urlEqualTo("/.well-known/openid-configuration")))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBodyFile("discovery_result.json")));
+        authService = "http://localhost:" + openIdService.port();
+    }
+
+    @Test
+    public void testDiscovery() {
+        DiscoveryClient discoveryClient =
+                new DiscoveryClient(authService + "/.well-known/openid-configuration");
+        OAuth2Configuration configuration = new OAuth2Configuration();
+        configuration.setScopes("openid,groups");
+        discoveryClient.autofill(configuration);
+        assertEquals("https://oauth2.googleapis.com/token", configuration.getAccessTokenUri());
+        assertEquals(
+                "https://accounts.google.com/o/oauth2/v2/auth",
+                configuration.getAuthorizationUri());
+        assertEquals("https://oauth2.googleapis.com/revoke", configuration.getRevokeEndpoint());
+        assertEquals(
+                "https://openidconnect.googleapis.com/v1/userinfo",
+                configuration.getCheckTokenEndpointUrl());
+        assertEquals("https://www.googleapis.com/oauth2/v3/certs", configuration.getIdTokenUri());
+        // Split the strings into arrays
+        String[] expectedScopes = "openid,groups".split(",");
+        String[] actualScopes = configuration.getScopes().split(",");
+
+        // Sort the arrays
+        Arrays.sort(expectedScopes);
+        Arrays.sort(actualScopes);
+
+        // Compare the sorted arrays
+        assertArrayEquals("The scopes match", expectedScopes, actualScopes);
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2LoginTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2LoginTest.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -21,13 +22,20 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 public class OAuth2LoginTest {
 
     private final IdPLoginRest idPLoginRest = new IdPLoginRestImpl();
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private ServletRequestAttributes attributes;
+
+    @Before
+    public void setUp() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        attributes = new ServletRequestAttributes(request, response);
+        RequestContextHolder.setRequestAttributes(attributes);
+    }
 
     @Test
     public void testLogin() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
-        RequestContextHolder.setRequestAttributes(attributes);
         OAuth2Configuration configuration = new OAuth2Configuration();
         configuration.setScopes("openid");
         configuration.setClientId("mockClientId");
@@ -43,10 +51,6 @@ public class OAuth2LoginTest {
 
     @Test
     public void testLoginWithPKCE() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
-        RequestContextHolder.setRequestAttributes(attributes);
         OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
         configuration.setScopes("openid");
         configuration.setClientId("mockClientId");
@@ -64,10 +68,6 @@ public class OAuth2LoginTest {
 
     @Test
     public void testCallback() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
-        RequestContextHolder.setRequestAttributes(attributes);
         attributes.setAttribute(REFRESH_TOKEN_PARAM, "mockRefreshToken", 0);
         attributes.setAttribute(ACCESS_TOKEN_PARAM, "mockAccessToken", 0);
         OAuth2Configuration configuration = new OAuth2Configuration();

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2LoginTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2LoginTest.java
@@ -2,9 +2,12 @@ package it.geosolutions.geostore.services.rest.security.oauth2;
 
 import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import it.geosolutions.geostore.services.rest.IdPLoginRest;
 import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,6 +39,27 @@ public class OAuth2LoginTest {
         assertEquals(
                 "http://localhost:8080/authorization?response_type=code&client_id=mockClientId&scope=openid&redirect_uri=null",
                 response.getRedirectedUrl());
+    }
+
+    @Test
+    public void testLoginWithPKCE() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
+        RequestContextHolder.setRequestAttributes(attributes);
+        OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
+        configuration.setScopes("openid");
+        configuration.setClientId("mockClientId");
+        configuration.setAuthorizationUri("http://localhost:8080/authorization");
+        configuration.setUsePKCE(true);
+        SetConfOAuthLoginService setConfiguration = new SetConfOAuthLoginService(idPLoginRest);
+        setConfiguration.setConfiguration(configuration);
+        idPLoginRest.login("mock");
+        assertEquals(302, response.getStatus());
+        String redirectUrl = response.getRedirectedUrl();
+        assertNotNull(redirectUrl);
+        assertTrue(redirectUrl.contains("code_challenge_method=S256"));
+        assertTrue(redirectUrl.contains("code_challenge="));
     }
 
     @Test

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2LoginTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2LoginTest.java
@@ -1,0 +1,106 @@
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils.*;
+import static org.junit.Assert.assertEquals;
+
+import it.geosolutions.geostore.services.rest.IdPLoginRest;
+import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class OAuth2LoginTest {
+
+    private final IdPLoginRest idPLoginRest = new IdPLoginRestImpl();
+
+    @Test
+    public void testLogin() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
+        RequestContextHolder.setRequestAttributes(attributes);
+        OAuth2Configuration configuration = new OAuth2Configuration();
+        configuration.setScopes("openid");
+        configuration.setClientId("mockClientId");
+        configuration.setAuthorizationUri("http://localhost:8080/authorization");
+        SetConfOAuthLoginService setConfiguration = new SetConfOAuthLoginService(idPLoginRest);
+        setConfiguration.setConfiguration(configuration);
+        idPLoginRest.login("mock");
+        assertEquals(302, response.getStatus());
+        assertEquals(
+                "http://localhost:8080/authorization?response_type=code&client_id=mockClientId&scope=openid&redirect_uri=null",
+                response.getRedirectedUrl());
+    }
+
+    @Test
+    public void testCallback() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
+        RequestContextHolder.setRequestAttributes(attributes);
+        attributes.setAttribute(REFRESH_TOKEN_PARAM, "mockRefreshToken", 0);
+        attributes.setAttribute(ACCESS_TOKEN_PARAM, "mockAccessToken", 0);
+        OAuth2Configuration configuration = new OAuth2Configuration();
+        configuration.setInternalRedirectUri("http://localhost:8080/geostore/redirect");
+        SetConfOAuthLoginService setConfiguration = new SetConfOAuthLoginService(idPLoginRest);
+        setConfiguration.setConfiguration(configuration);
+        setConfiguration.setTokenStorage(new InMemoryTokenStorage());
+        Response result = idPLoginRest.callback("mock");
+        assertEquals(302, result.getStatus());
+        List<Object> cookies = result.getMetadata().get("Set-Cookie");
+        List<Object> tokenCookies =
+                cookies.stream()
+                        .filter(
+                                c ->
+                                        ((String) c).contains(AUTH_PROVIDER)
+                                                || ((String) c).contains(TOKENS_KEY))
+                        .collect(Collectors.toList());
+        assertEquals(2, tokenCookies.size());
+        assertEquals("http://localhost:8080/geostore/redirect", result.getHeaderString("Location"));
+    }
+
+    @After
+    public void afterTest() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    private class SetConfOAuthLoginService extends Oauth2LoginService {
+
+        private OAuth2Configuration configuration;
+
+        private TokenStorage tokenStorage;
+
+        public SetConfOAuthLoginService(IdPLoginRest loginRest) {
+            loginRest.registerService("mock", this);
+        }
+
+        public void setConfiguration(OAuth2Configuration configuration) {
+            this.configuration = configuration;
+        }
+
+        @Override
+        protected OAuth2Configuration oauth2Configuration(String provider) {
+            return configuration;
+        }
+
+        @Override
+        protected IdPConfiguration configuration(String provider) {
+            return configuration;
+        }
+
+        @Override
+        protected TokenStorage tokenStorage() {
+            return tokenStorage;
+        }
+
+        public void setTokenStorage(TokenStorage tokenStorage) {
+            this.tokenStorage = tokenStorage;
+        }
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceTest.java
@@ -1,0 +1,299 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2022-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static it.geosolutions.geostore.services.rest.SessionServiceDelegate.PROVIDER_KEY;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import it.geosolutions.geostore.services.rest.RESTSessionService;
+import it.geosolutions.geostore.services.rest.impl.RESTSessionServiceImpl;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectSessionServiceDelegate;
+import it.geosolutions.geostore.services.rest.utils.GeoStoreContext;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import wiremock.org.eclipse.jetty.http.HttpStatus;
+
+public class OAuth2SessionServiceTest {
+
+    private static final String ID_TOKEN = "test.id.token";
+    private static final String ACCESS_TOKEN = "access_token";
+
+    private static OAuth2AccessToken bearer(String value) {
+        return new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER, value, Instant.now(), null);
+    }
+
+    @BeforeEach
+    void setup() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void testLogout_withParamBearer_revokesAndClearsSessionAndCache() {
+        OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
+        configuration.setEnabled(true);
+        configuration.setIdTokenUri("https://www.googleapis.com/oauth2/v3/certs");
+        configuration.setRevokeEndpoint("http://google.foo/revoke");
+
+        // principal + TokenDetails
+        PreAuthenticatedAuthenticationToken authenticationToken =
+                new PreAuthenticatedAuthenticationToken("user", "", new ArrayList<>());
+        OAuth2AccessToken accessToken = bearer(ACCESS_TOKEN);
+        TokenDetails details = Mockito.mock(TokenDetails.class);
+        when(details.getProvider()).thenReturn("oidc");
+        when(details.getAccessToken()).thenReturn(accessToken);
+        when(details.getIdToken()).thenReturn(ID_TOKEN);
+        authenticationToken.setDetails(details);
+
+        // cache pre-populated with the token
+        TokenAuthenticationCache cache = new TokenAuthenticationCache();
+        cache.putCacheEntry(ACCESS_TOKEN, authenticationToken);
+
+        // prepare GeoStoreContext static lookups
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        HashMap<Object, Object> configurations = new HashMap<>();
+        configurations.put("oidcOAuth2Config", configuration);
+
+        try (MockedStatic<GeoStoreContext> ctx = Mockito.mockStatic(GeoStoreContext.class)) {
+            ctx.when(() -> GeoStoreContext.beans(OAuth2Configuration.class))
+                    .thenReturn(configurations);
+            ctx.when(() -> GeoStoreContext.bean("oidcOAuth2Config", OAuth2Configuration.class))
+                    .thenReturn(configuration);
+            ctx.when(() -> GeoStoreContext.bean("oAuth2Cache", TokenAuthenticationCache.class))
+                    .thenReturn(cache);
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer " + ACCESS_TOKEN);
+            request.setUserPrincipal(authenticationToken);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
+            attributes.setAttribute(PROVIDER_KEY, "oidc", 0);
+            RequestContextHolder.setRequestAttributes(attributes);
+
+            RESTSessionService sessionService = new RESTSessionServiceImpl();
+            new OpenIdConnectSessionServiceDelegate(sessionService, null);
+
+            // act
+            sessionService.removeSession();
+
+            // assert
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertNull(
+                    SecurityContextHolder.getContext().getAuthentication(),
+                    "SecurityContext should be cleared");
+            assertNull(request.getUserPrincipal(), "request principal should be cleared");
+            assertNull(cache.get(ACCESS_TOKEN), "token should be evicted from cache");
+        }
+    }
+
+    @Test
+    void testLogout_withAuthorizationHeader_picksTokenAndClears() {
+        OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
+        configuration.setEnabled(true);
+        configuration.setRevokeEndpoint("http://google.foo/revoke");
+
+        PreAuthenticatedAuthenticationToken authenticationToken =
+                new PreAuthenticatedAuthenticationToken("user", "", new ArrayList<>());
+        OAuth2AccessToken accessToken = bearer(ACCESS_TOKEN);
+        TokenDetails details = Mockito.mock(TokenDetails.class);
+        when(details.getProvider()).thenReturn("oidc");
+        when(details.getAccessToken()).thenReturn(accessToken);
+        when(details.getIdToken()).thenReturn(ID_TOKEN);
+        authenticationToken.setDetails(details);
+
+        TokenAuthenticationCache cache = new TokenAuthenticationCache();
+        cache.putCacheEntry(ACCESS_TOKEN, authenticationToken);
+
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        HashMap<Object, Object> configurations = new HashMap<>();
+        configurations.put("oidcOAuth2Config", configuration);
+
+        try (MockedStatic<GeoStoreContext> ctx = Mockito.mockStatic(GeoStoreContext.class)) {
+            ctx.when(() -> GeoStoreContext.beans(OAuth2Configuration.class))
+                    .thenReturn(configurations);
+            ctx.when(() -> GeoStoreContext.bean("oidcOAuth2Config", OAuth2Configuration.class))
+                    .thenReturn(configuration);
+            ctx.when(() -> GeoStoreContext.bean("oAuth2Cache", TokenAuthenticationCache.class))
+                    .thenReturn(cache);
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer " + ACCESS_TOKEN);
+            request.setUserPrincipal(authenticationToken);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
+            attributes.setAttribute(PROVIDER_KEY, "oidc", 0);
+            RequestContextHolder.setRequestAttributes(attributes);
+
+            RESTSessionService sessionService = new RESTSessionServiceImpl();
+            new OpenIdConnectSessionServiceDelegate(sessionService, null);
+
+            sessionService.removeSession();
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertNull(SecurityContextHolder.getContext().getAuthentication());
+            assertNull(request.getUserPrincipal());
+            assertNull(cache.get(ACCESS_TOKEN));
+        }
+    }
+
+    @Test
+    void testLogout_noRevokeEndpoint_stillClearsLocally() {
+        OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
+        configuration.setEnabled(true);
+        configuration.setRevokeEndpoint(null); // ensure missing remote revoke
+
+        PreAuthenticatedAuthenticationToken authenticationToken =
+                new PreAuthenticatedAuthenticationToken("user", "", new ArrayList<>());
+        OAuth2AccessToken accessToken = bearer(ACCESS_TOKEN);
+        TokenDetails details = Mockito.mock(TokenDetails.class);
+        when(details.getProvider()).thenReturn("oidc");
+        when(details.getAccessToken()).thenReturn(accessToken);
+        when(details.getIdToken()).thenReturn(ID_TOKEN);
+        authenticationToken.setDetails(details);
+
+        TokenAuthenticationCache cache = new TokenAuthenticationCache();
+        cache.putCacheEntry(ACCESS_TOKEN, authenticationToken);
+
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        HashMap<Object, Object> configurations = new HashMap<>();
+        configurations.put("oidcOAuth2Config", configuration);
+
+        try (MockedStatic<GeoStoreContext> ctx = Mockito.mockStatic(GeoStoreContext.class)) {
+            ctx.when(() -> GeoStoreContext.beans(OAuth2Configuration.class))
+                    .thenReturn(configurations);
+            ctx.when(() -> GeoStoreContext.bean("oidcOAuth2Config", OAuth2Configuration.class))
+                    .thenReturn(configuration);
+            ctx.when(() -> GeoStoreContext.bean("oAuth2Cache", TokenAuthenticationCache.class))
+                    .thenReturn(cache);
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer " + ACCESS_TOKEN);
+            request.setUserPrincipal(authenticationToken);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
+            attributes.setAttribute(PROVIDER_KEY, "oidc", 0);
+            RequestContextHolder.setRequestAttributes(attributes);
+
+            RESTSessionService sessionService = new RESTSessionServiceImpl();
+            new OpenIdConnectSessionServiceDelegate(sessionService, null);
+
+            sessionService.removeSession();
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            // Note: without a revokeEndpoint, clearSession() is not called so
+            // SecurityContextHolder is not cleared. The cache entry for the
+            // sessionId passed to doLogout IS removed, though.
+            assertNull(cache.get(ACCESS_TOKEN), "cache entry should still be removed locally");
+        }
+    }
+
+    @Test
+    void testLogout_providerMismatch_keepsOtherProvidersCache() {
+        OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
+        configuration.setEnabled(true);
+        configuration.setRevokeEndpoint("http://google.foo/revoke");
+
+        // token A (google) and token B (azure)
+        PreAuthenticatedAuthenticationToken googleAuth =
+                new PreAuthenticatedAuthenticationToken("user", "", new ArrayList<>());
+        TokenDetails googleDetails = Mockito.mock(TokenDetails.class);
+        when(googleDetails.getProvider()).thenReturn("google");
+        when(googleDetails.getAccessToken()).thenReturn(bearer("tokenA"));
+        when(googleDetails.getIdToken()).thenReturn(ID_TOKEN);
+        googleAuth.setDetails(googleDetails);
+
+        PreAuthenticatedAuthenticationToken azureAuth =
+                new PreAuthenticatedAuthenticationToken("user2", "", new ArrayList<>());
+        TokenDetails azureDetails = Mockito.mock(TokenDetails.class);
+        when(azureDetails.getProvider()).thenReturn("azure");
+        when(azureDetails.getAccessToken()).thenReturn(bearer("tokenB"));
+        when(azureDetails.getIdToken()).thenReturn(ID_TOKEN);
+        azureAuth.setDetails(azureDetails);
+
+        TokenAuthenticationCache cache = new TokenAuthenticationCache();
+        cache.putCacheEntry("tokenA", googleAuth);
+        cache.putCacheEntry("tokenB", azureAuth);
+
+        SecurityContextHolder.getContext().setAuthentication(googleAuth);
+        HashMap<Object, Object> configurations = new HashMap<>();
+        configurations.put("oidcOAuth2Config", configuration);
+
+        try (MockedStatic<GeoStoreContext> ctx = Mockito.mockStatic(GeoStoreContext.class)) {
+            ctx.when(() -> GeoStoreContext.beans(OAuth2Configuration.class))
+                    .thenReturn(configurations);
+            ctx.when(() -> GeoStoreContext.bean("oidcOAuth2Config", OAuth2Configuration.class))
+                    .thenReturn(configuration);
+            ctx.when(() -> GeoStoreContext.bean("oAuth2Cache", TokenAuthenticationCache.class))
+                    .thenReturn(cache);
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer tokenA");
+            request.setUserPrincipal(googleAuth);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            ServletRequestAttributes attributes = new ServletRequestAttributes(request, response);
+            attributes.setAttribute(PROVIDER_KEY, "oidc", 0);
+            RequestContextHolder.setRequestAttributes(attributes);
+
+            RESTSessionService sessionService = new RESTSessionServiceImpl();
+            new OpenIdConnectSessionServiceDelegate(sessionService, null);
+
+            sessionService.removeSession();
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertNull(cache.get("tokenA"), "oidc entry evicted");
+            assertNotNull(cache.get("tokenB"), "azure entry untouched");
+        }
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
@@ -31,6 +31,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -278,10 +279,10 @@ public class OpenIdIntegrationTest {
 
     @Test
     public void testDefaultGroupAssignedWhenNoGroupsResolved() throws Exception {
-        // The token of CODE carries no groups claim at all: the configured fallback group is
-        // assigned, created on the fly and tagged with the provider as sourceService.
+        // The token of CODE carries no groups claim at all: the configured default group is
+        // still assigned, created on the fly and tagged with the provider as sourceService.
         configuration.setGroupsClaim("groups");
-        configuration.setAuthenticatedDefaultGroup("infragri");
+        configuration.setDefaultGroups("infragri");
         MockHttpServletRequest request = createRequest("oidc/login");
         request.setParameter("code", CODE);
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -306,10 +307,32 @@ public class OpenIdIntegrationTest {
     }
 
     @Test
-    public void testDefaultGroupNotAssignedWhenGroupsResolved() throws Exception {
-        // Groups resolved from the claims win: the fallback group must not be added.
+    public void testDefaultGroupsMultipleAssigned() throws Exception {
+        // The property is a comma-separated list: every entry is assigned.
         configuration.setGroupsClaim("groups");
-        configuration.setAuthenticatedDefaultGroup("infragri");
+        configuration.setDefaultGroups("infragri, base-users");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(
+                names.contains("infragri"), "All configured defaultGroups are assigned: " + names);
+        assertTrue(
+                names.contains("base-users"),
+                "All configured defaultGroups are assigned: " + names);
+    }
+
+    @Test
+    public void testDefaultGroupsAssignedAlongsideMappedGroups() throws Exception {
+        // defaultGroups are ALWAYS added, alongside the claim-derived groups.
+        configuration.setGroupsClaim("groups");
+        configuration.setDefaultGroups("infragri");
         MockHttpServletRequest request = createRequest("oidc/login");
         request.setParameter("code", CODE_GROUPS_RECON);
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -322,19 +345,19 @@ public class OpenIdIntegrationTest {
                 user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
         assertTrue(names.contains("A"));
         assertTrue(names.contains("B"));
-        assertFalse(
+        assertTrue(
                 names.contains("infragri"),
-                "Fallback group must not be assigned when claims resolve groups");
+                "defaultGroups must be assigned in addition to the claim-derived groups");
     }
 
     @Test
     public void testDefaultGroupAssignedWhenAllGroupsDropped() throws Exception {
         // Every claim value is dropped by groupMappings+dropUnmapped (the typical Keycloak
-        // permission-roles setup): the fallback group keeps the user from ending up groupless.
+        // permission-roles setup): the default groups keep the user from ending up groupless.
         configuration.setGroupsClaim("groups");
         configuration.setGroupMappings("not-a-real-group:whatever");
         configuration.setDropUnmapped(true);
-        configuration.setAuthenticatedDefaultGroup("infragri");
+        configuration.setDefaultGroups("infragri");
         MockHttpServletRequest request = createRequest("oidc/login");
         request.setParameter("code", CODE_GROUPS_RECON);
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -348,6 +371,57 @@ public class OpenIdIntegrationTest {
         assertTrue(names.contains("infragri"), "Fallback group should be assigned, got " + names);
         assertFalse(names.contains("A"), "Dropped claim groups must not be assigned");
         assertFalse(names.contains("B"), "Dropped claim groups must not be assigned");
+    }
+
+    @Test
+    public void testDefaultGroupAssignedWhenGroupCreationFails() throws Exception {
+        // Claim groups resolve but their creation is rejected (e.g. reserved or invalid
+        // names): the default groups are assigned independently of the claim-derived ones.
+        configuration.setGroupsClaim("groups");
+        configuration.setDefaultGroups("infragri");
+        DummyUserGroupService rejectingSvc =
+                new DummyUserGroupService() {
+                    @Override
+                    public long insert(UserGroup g) throws BadRequestServiceEx {
+                        if (!"infragri".equals(g.getGroupName())) {
+                            throw new BadRequestServiceEx(
+                                    "group name not allowed: " + g.getGroupName());
+                        }
+                        return super.insert(g);
+                    }
+                };
+        OpenIdConnectAuthenticationService rejectingService =
+                new OpenIdConnectAuthenticationService(
+                        new TokenAuthenticationCache(
+                                configuration.getCacheSize(),
+                                configuration.getCacheExpirationMinutes()),
+                        null,
+                        rejectingSvc,
+                        configuration,
+                        null,
+                        null);
+        OpenIdConnectFilter rejectingFilter =
+                new OpenIdConnectFilter(
+                        configuration,
+                        rejectingService,
+                        new OpenIdConnectRestClient(configuration));
+        rejectingFilter.setUserGroupService(rejectingSvc);
+
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        rejectingFilter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(names.contains("infragri"), "Fallback group should be assigned, got " + names);
+        assertNotNull(
+                rejectingSvc.get("infragri"), "Fallback group should be created when missing");
+        assertNull(rejectingSvc.get("A"), "Rejected claim group must not be created");
+        assertNull(rejectingSvc.get("B"), "Rejected claim group must not be created");
     }
 
     @Test
@@ -706,7 +780,7 @@ public class OpenIdIntegrationTest {
         private long nextId = 1;
 
         @Override
-        public long insert(UserGroup g) {
+        public long insert(UserGroup g) throws BadRequestServiceEx {
             if (g.getId() == null) g.setId(nextId++);
             if (g.getAttributes() == null) g.setAttributes(new ArrayList<>());
             byId.put(g.getId(), g);

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
@@ -277,6 +277,80 @@ public class OpenIdIntegrationTest {
     }
 
     @Test
+    public void testDefaultGroupAssignedWhenNoGroupsResolved() throws Exception {
+        // The token of CODE carries no groups claim at all: the configured fallback group is
+        // assigned, created on the fly and tagged with the provider as sourceService.
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultGroup("infragri");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(names.contains("infragri"), "Fallback group should be assigned, got " + names);
+
+        UserGroup created = ((DummyUserGroupService) filter.getUserGroupService()).get("infragri");
+        assertNotNull(created, "Fallback group should be created when missing");
+        String src =
+                created.getAttributes().stream()
+                        .filter(a -> "sourceService".equals(a.getName()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getValue();
+        assertEquals(configuration.getProvider(), src);
+    }
+
+    @Test
+    public void testDefaultGroupNotAssignedWhenGroupsResolved() throws Exception {
+        // Groups resolved from the claims win: the fallback group must not be added.
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultGroup("infragri");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(names.contains("A"));
+        assertTrue(names.contains("B"));
+        assertFalse(
+                names.contains("infragri"),
+                "Fallback group must not be assigned when claims resolve groups");
+    }
+
+    @Test
+    public void testDefaultGroupAssignedWhenAllGroupsDropped() throws Exception {
+        // Every claim value is dropped by groupMappings+dropUnmapped (the typical Keycloak
+        // permission-roles setup): the fallback group keeps the user from ending up groupless.
+        configuration.setGroupsClaim("groups");
+        configuration.setGroupMappings("not-a-real-group:whatever");
+        configuration.setDropUnmapped(true);
+        configuration.setAuthenticatedDefaultGroup("infragri");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(names.contains("infragri"), "Fallback group should be assigned, got " + names);
+        assertFalse(names.contains("A"), "Dropped claim groups must not be assigned");
+        assertFalse(names.contains("B"), "Dropped claim groups must not be assigned");
+    }
+
+    @Test
     public void testRoleFromToken_adminPromotion() throws Exception {
         configuration.setRolesClaim("roles");
         MockHttpServletRequest request = createRequest("oidc/login");

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
@@ -326,6 +326,20 @@ public class OpenIdIntegrationTest {
         assertTrue(
                 names.contains("base-users"),
                 "All configured defaultGroups are assigned: " + names);
+
+        // Creation-if-missing applies to EVERY entry of the list, with the provider tag.
+        DummyUserGroupService svc = (DummyUserGroupService) filter.getUserGroupService();
+        for (String name : Arrays.asList("infragri", "base-users")) {
+            UserGroup created = svc.get(name);
+            assertNotNull(created, "Each default group must be created when missing: " + name);
+            String src =
+                    created.getAttributes().stream()
+                            .filter(a -> "sourceService".equals(a.getName()))
+                            .findFirst()
+                            .orElseThrow()
+                            .getValue();
+            assertEquals(configuration.getProvider(), src, "Provider tag on created group " + name);
+        }
     }
 
     @Test

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
@@ -1,0 +1,908 @@
+/*
+ *  Copyright (C) 2022-2025 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ *  GPLv3 + Classpath exception
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.
+ *
+ *  ====================================================================
+ *
+ *  This software consists of voluntary contributions made by developers
+ *  of GeoSolutions.  For more information on GeoSolutions, please see
+ *  <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.UserGroupAttribute;
+import it.geosolutions.geostore.core.model.enums.Role;
+import it.geosolutions.geostore.services.UserGroupService;
+import it.geosolutions.geostore.services.dto.ShortResource;
+import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
+import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectAuthenticationService;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectFilter;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectRestClient;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Integration-style tests against a WireMock-ed OpenID Provider.
+ *
+ * <p>Enhanced to verify: - Redirect flow - Basic authentication via auth code - Groups from token
+ * (hd or groups claim) - Roles resolution (present ADMIN, empty list) - Provider-scoped group
+ * reconciliation (keep local & other provider, replace own)
+ */
+public class OpenIdIntegrationTest {
+
+    private static final String CLIENT_ID = "kbyuFDidLLm280LIwVFiazOqjO3ty8KH";
+    private static final String CLIENT_SECRET =
+            "60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa";
+
+    private static final String CODE = "R-2CqM7H1agwc7Cx";
+    private static final String CODE_GROUPS_HD = "CODE_GROUPS_HD";
+    private static final String CODE_ROLES_ADMIN = "CODE_ROLES_ADMIN";
+    private static final String CODE_ROLES_EMPTY = "CODE_ROLES_EMPTY";
+    private static final String CODE_GROUPS_RECON = "CODE_GROUPS_RECON";
+    private static final String CODE_ROLES_GUEST = "CODE_ROLES_GUEST";
+    private static final String CODE_USERINFO_ROLES = "CODE_USERINFO_ROLES";
+    private static final String CODE_USERINFO_GROUPS = "CODE_USERINFO_GROUPS";
+
+    private static WireMockServer openIdService;
+    private String authService;
+    private OpenIdConnectFilter filter;
+    private TestOAuth2Configuration configuration;
+
+    @BeforeAll
+    static void beforeClass() {
+        openIdService =
+                new WireMockServer(
+                        wireMockConfig()
+                                .dynamicPort()
+                                // uncomment for verbose logging
+                                .notifier(new ConsoleNotifier(true)));
+        openIdService.start();
+
+        openIdService.stubFor(
+                WireMock.get(urlEqualTo("/certs"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody("{\"keys\":[]}")));
+
+        // generic userinfo stub
+        openIdService.stubFor(
+                any(urlPathEqualTo("/userinfo"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody("{}")));
+    }
+
+    @BeforeEach
+    void before() {
+        // base URL
+        authService = "http://localhost:" + openIdService.port();
+
+        configuration = new TestOAuth2Configuration();
+        configuration.setClientId(CLIENT_ID);
+        configuration.setClientSecret(CLIENT_SECRET);
+        configuration.setRevokeEndpoint(authService + "/revoke");
+        configuration.setAccessTokenUri(authService + "/token");
+        configuration.setAuthorizationUri(authService + "/authorize");
+        configuration.setCheckTokenEndpointUrl(authService + "/userinfo");
+        configuration.setEnabled(true);
+        configuration.setAutoCreateUser(true);
+        configuration.setIdTokenUri(authService + "/certs");
+        configuration.setBeanName("oidcOAuth2Config"); // provider will mirror this via override
+        configuration.setEnableRedirectEntryPoint(true);
+        configuration.setRedirectUri("../../../geostore/rest/users/user/details");
+        configuration.setScopes("openId,email");
+
+        OpenIdConnectRestClient restClient = new OpenIdConnectRestClient(configuration);
+        TokenAuthenticationCache cache =
+                new TokenAuthenticationCache(
+                        configuration.getCacheSize(), configuration.getCacheExpirationMinutes());
+        // attach a simple in-memory UserGroupService so group reconciliation works
+        DummyUserGroupService userGroupService = new DummyUserGroupService();
+        // null validator + null JWKS key provider: the interactive (USER) flow reads claims from
+        // the
+        // id_token returned by the trusted token endpoint and does not verify its signature (the
+        // test
+        // uses unsigned alg:none JWTs), matching the 2.6.x setup that passed null/null and disabled
+        // the token store.
+        OpenIdConnectAuthenticationService service =
+                new OpenIdConnectAuthenticationService(
+                        cache, null, userGroupService, configuration, null, null);
+        filter = new OpenIdConnectFilter(configuration, service, restClient);
+        filter.setUserGroupService(userGroupService);
+
+        // default stub for original CODE -> returns email only (no groups/roles)
+        stubTokenForCode(CODE, jsonPayload().put("email", "ritter@erdukunde.de").build());
+
+        // specific stubs for additional scenarios
+        stubTokenForCode(
+                CODE_GROUPS_HD,
+                jsonPayload().put("email", "u@ex.com").put("hd", "geosolutionsgroup.com").build());
+        stubTokenForCode(
+                CODE_ROLES_ADMIN,
+                jsonPayload().put("email", "admin@ex.com").putArray("roles", arr("ADMIN")).build());
+        stubTokenForCode(
+                CODE_ROLES_EMPTY,
+                jsonPayload().put("email", "demote@ex.com").putArray("roles", "[]").build());
+        // reconcile: provide groups ["A","B"]
+        stubTokenForCode(
+                CODE_GROUPS_RECON,
+                jsonPayload()
+                        .put("email", "recon@ex.com")
+                        .putArray("groups", arr("A", "B"))
+                        .build());
+        // demotion/promotion check for existing user override
+        stubTokenForCode(
+                CODE_ROLES_GUEST,
+                jsonPayload().put("email", "guest@ex.com").putArray("roles", arr("GUEST")).build());
+
+        // Stubs for userinfo fallback tests: JWT has NO roles/groups claim
+        stubTokenForCode(CODE_USERINFO_ROLES, jsonPayload().put("email", "uiroles@ex.com").build());
+        stubTokenForCode(
+                CODE_USERINFO_GROUPS, jsonPayload().put("email", "uigroups@ex.com").build());
+
+        // Userinfo stubs returning roles/groups for specific access tokens
+        openIdService.stubFor(
+                WireMock.get(urlPathEqualTo("/userinfo"))
+                        .withHeader("Authorization", equalTo("Bearer at-" + CODE_USERINFO_ROLES))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"email\":\"uiroles@ex.com\","
+                                                        + "\"roles\":[\"ADMIN\"]}")));
+        openIdService.stubFor(
+                WireMock.get(urlPathEqualTo("/userinfo"))
+                        .withHeader("Authorization", equalTo("Bearer at-" + CODE_USERINFO_GROUPS))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"email\":\"uigroups@ex.com\","
+                                                        + "\"groups\":[\"TEAM_X\",\"TEAM_Y\"]}")));
+    }
+
+    @AfterEach
+    void afterTest() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    public void testRedirect() throws IOException, ServletException {
+        MockHttpServletRequest request = createRequest("oidc/login");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        // In the Spring Security 7 port the interactive login redirect is owned by the OAuth2
+        // configuration's authentication entry point (invoked by the IdPLoginRest CXF endpoint on
+        // /openid/{provider}/login), not the bearer filter; assert it still issues a 302 to the IdP
+        // authorization URI.
+        configuration.getAuthenticationEntryPoint().commence(request, response, null);
+        assertEquals(302, response.getStatus());
+        assertEquals(configuration.buildLoginUri(), response.getRedirectedUrl());
+    }
+
+    @Test
+    public void testAuthentication_basic() throws IOException, ServletException {
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "authentication should not be null");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("ritter@erdukunde.de", user.getName());
+        // roles claim missing -> preserve default USER
+        assertEquals(Role.USER, user.getRole());
+    }
+
+    @Test
+    public void testGroupsFromToken_hdDomain() throws Exception {
+        configuration.setGroupsClaim("hd"); // Google hosted domain string claim
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_GROUPS_HD);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        UserGroup group = user.getGroups().stream().findAny().orElseThrow();
+        assertEquals("geosolutionsgroup.com", group.getGroupName());
+    }
+
+    @Test
+    public void testRoleFromToken_adminPromotion() throws Exception {
+        configuration.setRolesClaim("roles");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_ROLES_ADMIN);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        assertEquals(Role.ADMIN, user.getRole());
+    }
+
+    @Test
+    public void testRoleFromToken_emptyListDemotesToDefault() throws Exception {
+        configuration.setRolesClaim("roles");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_ROLES_EMPTY);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        // empty roles -> computeRole defaults to USER
+        assertEquals(Role.USER, user.getRole());
+    }
+
+    @Test
+    public void testProviderScopedGroupReconciliation() throws Exception {
+        configuration.setGroupsClaim("groups");
+
+        // Pre-seed the DummyUserGroupService with a local & other-provider remote group bound to
+        // the same user
+        DummyUserGroupService svc = (DummyUserGroupService) filter.getUserGroupService();
+        User seeded = new User();
+        seeded.setId(777L);
+        seeded.setName("recon@ex.com");
+        seeded.setRole(Role.USER);
+        seeded.setEnabled(true);
+        seeded.setGroups(new HashSet<>());
+
+        UserGroup local = new UserGroup();
+        local.setGroupName("LOCAL_GROUP");
+        local.setAttributes(new ArrayList<>());
+        svc.insert(local);
+
+        UserGroup otherProv = new UserGroup();
+        otherProv.setGroupName("OTHER_GROUP");
+        otherProv.setAttributes(new ArrayList<>(List.of(attr("sourceService", "other"))));
+        svc.insert(otherProv);
+
+        // old remote from THIS provider (should be removed)
+        UserGroup oldRemote = new UserGroup();
+        oldRemote.setGroupName("OLD_REMOTE");
+        oldRemote.setAttributes(
+                new ArrayList<>(List.of(attr("sourceService", configuration.getProvider()))));
+        svc.insert(oldRemote);
+
+        // attach seeded groups to user
+        seeded.getGroups().add(local);
+        seeded.getGroups().add(otherProv);
+        seeded.getGroups().add(oldRemote);
+
+        // Wrap the filter with a retrieveUser override that returns our seeded user
+        OpenIdConnectFilter seededFilter = getOpenIdFilter(seeded, svc);
+
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        seededFilter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Set<String> names =
+                seeded.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        // kept
+        assertTrue(names.contains("LOCAL_GROUP"));
+        assertTrue(names.contains("OTHER_GROUP"));
+        // new from token
+        assertTrue(names.contains("A"));
+        assertTrue(names.contains("B"));
+        // removed old provider-remote not in token
+        assertFalse(names.contains("OLD_REMOTE"));
+
+        // ensure new groups are tagged with sourceService = provider
+        for (String g : List.of("A", "B")) {
+            UserGroup ug = svc.get(g);
+            assertNotNull(ug);
+            String src =
+                    ug.getAttributes().stream()
+                            .filter(a -> "sourceService".equals(a.getName()))
+                            .findFirst()
+                            .orElseThrow()
+                            .getValue();
+            assertEquals(configuration.getProvider(), src);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // New tests: creation, override role, full provider-remote reset & idempotency
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testNewUserCreatedWithRoleFromOidc() throws Exception {
+        configuration.setRolesClaim("roles");
+
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_ROLES_ADMIN);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        // No pre-existing user; filter will create it based on token.
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+
+        assertEquals("admin@ex.com", user.getName());
+        assertEquals(Role.ADMIN, user.getRole());
+
+        // Created-by-provider marker attribute
+        assertTrue(
+                user.getAttribute() != null
+                        && user.getAttribute().stream()
+                                .anyMatch(
+                                        a ->
+                                                OAuth2Configuration.CONFIGURATION_NAME.equals(
+                                                                a.getName())
+                                                        && configuration
+                                                                .getBeanName()
+                                                                .equals(a.getValue())));
+    }
+
+    @Test
+    public void testExistingUserRoleOverriddenByOidc() throws Exception {
+        configuration.setRolesClaim("roles");
+
+        // Seed an existing user with ADMIN; token will demote to GUEST
+        User existing = new User();
+        existing.setId(901L);
+        existing.setName("guest@ex.com");
+        existing.setRole(Role.ADMIN);
+        existing.setEnabled(true);
+        existing.setGroups(new HashSet<>());
+        existing.setAttribute(new ArrayList<>());
+
+        OpenIdConnectFilter seededFilter =
+                getOpenIdFilter(existing, (DummyUserGroupService) filter.getUserGroupService());
+
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_ROLES_GUEST);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        seededFilter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+
+        assertEquals("guest@ex.com", user.getName());
+        assertEquals(Role.GUEST, user.getRole());
+    }
+
+    @Test
+    public void testProviderRemoteGroupsResetAlignedAndIdempotent() throws Exception {
+        configuration.setGroupsClaim("groups");
+
+        DummyUserGroupService svc = (DummyUserGroupService) filter.getUserGroupService();
+
+        // Seed user with: local + other provider remote + old provider remote
+        User seeded = new User();
+        seeded.setId(1001L);
+        seeded.setName("recon@ex.com");
+        seeded.setRole(Role.USER);
+        seeded.setEnabled(true);
+        seeded.setGroups(new HashSet<>());
+
+        UserGroup local = new UserGroup();
+        local.setGroupName("LOCAL_GROUP");
+        local.setAttributes(new ArrayList<>()); // no sourceService -> local
+        svc.insert(local);
+
+        UserGroup otherProv = new UserGroup();
+        otherProv.setGroupName("OTHER_GROUP");
+        otherProv.setAttributes(new ArrayList<>(List.of(attr("sourceService", "other"))));
+        svc.insert(otherProv);
+
+        UserGroup oldRemote = new UserGroup();
+        oldRemote.setGroupName("OLD_REMOTE");
+        oldRemote.setAttributes(
+                new ArrayList<>(List.of(attr("sourceService", configuration.getProvider()))));
+        svc.insert(oldRemote);
+
+        seeded.getGroups().add(local);
+        seeded.getGroups().add(otherProv);
+        seeded.getGroups().add(oldRemote);
+
+        OpenIdConnectFilter seededFilter = getOpenIdFilter(seeded, svc);
+
+        // First pass: token groups ["A","B"]
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        seededFilter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+
+        Set<String> names =
+                seeded.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(names.contains("LOCAL_GROUP"));
+        assertTrue(names.contains("OTHER_GROUP"));
+        assertFalse(names.contains("OLD_REMOTE"));
+        assertTrue(names.contains("A"));
+        assertTrue(names.contains("B"));
+
+        // Only A,B are provider-remote
+        Set<String> providerRemotes =
+                seeded.getGroups().stream()
+                        .filter(g -> g.getAttributes() != null)
+                        .filter(
+                                g ->
+                                        g.getAttributes().stream()
+                                                .anyMatch(
+                                                        a ->
+                                                                "sourceService".equals(a.getName())
+                                                                        && configuration
+                                                                                .getProvider()
+                                                                                .equals(
+                                                                                        a
+                                                                                                .getValue())))
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertEquals(Set.of("A", "B"), providerRemotes);
+
+        // Idempotency: second pass with same token makes no changes
+        int beforeCount = seeded.getGroups().size();
+        MockHttpServletRequest request2 = createRequest("oidc/login");
+        request2.setParameter("authorization_code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response2 = new MockHttpServletResponse();
+        seededFilter.doFilter(request2, response2, new MockFilterChain());
+        assertEquals(200, response2.getStatus());
+        int afterCount = seeded.getGroups().size();
+        assertEquals(beforeCount, afterCount);
+
+        Set<String> providerRemotesAfter =
+                seeded.getGroups().stream()
+                        .filter(g -> g.getAttributes() != null)
+                        .filter(
+                                g ->
+                                        g.getAttributes().stream()
+                                                .anyMatch(
+                                                        a ->
+                                                                "sourceService".equals(a.getName())
+                                                                        && configuration
+                                                                                .getProvider()
+                                                                                .equals(
+                                                                                        a
+                                                                                                .getValue())))
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertEquals(Set.of("A", "B"), providerRemotesAfter);
+    }
+
+    @Test
+    public void testAuthentication_rolesFromUserinfo() throws Exception {
+        // rolesClaim is configured, but the JWT does NOT contain the claim.
+        // The userinfo endpoint response (WireMock stub) returns roles=[ADMIN].
+        configuration.setRolesClaim("roles");
+
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_USERINFO_ROLES);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "authentication should not be null");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("uiroles@ex.com", user.getName());
+        // Role should come from userinfo fallback
+        assertEquals(Role.ADMIN, user.getRole());
+    }
+
+    @Test
+    public void testAuthentication_groupsFromUserinfo() throws Exception {
+        // groupsClaim is configured, but the JWT does NOT contain the claim.
+        // The userinfo endpoint response (WireMock stub) returns groups=[TEAM_X, TEAM_Y].
+        configuration.setGroupsClaim("groups");
+
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE_USERINFO_GROUPS);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "authentication should not be null");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("uigroups@ex.com", user.getName());
+        // Groups should come from userinfo fallback
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("TEAM_X"), "Should contain TEAM_X from userinfo");
+        assertTrue(groupNames.contains("TEAM_Y"), "Should contain TEAM_Y from userinfo");
+    }
+
+    private OpenIdConnectFilter getOpenIdFilter(User seeded, DummyUserGroupService svc) {
+        OpenIdConnectAuthenticationService seededService =
+                new OpenIdConnectAuthenticationService(
+                        new TokenAuthenticationCache(
+                                configuration.getCacheSize(),
+                                configuration.getCacheExpirationMinutes()),
+                        null,
+                        svc,
+                        configuration,
+                        null,
+                        null) {
+                    @Override
+                    protected User retrieveUserWithAuthorities(
+                            String username,
+                            jakarta.servlet.http.HttpServletRequest request,
+                            jakarta.servlet.http.HttpServletResponse response) {
+                        return seeded;
+                    }
+                };
+        OpenIdConnectFilter seededFilter =
+                new OpenIdConnectFilter(
+                        configuration, seededService, new OpenIdConnectRestClient(configuration));
+        seededFilter.setUserGroupService(svc);
+        return seededFilter;
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers & test support
+    // ---------------------------------------------------------------------
+
+    private static class TestOAuth2Configuration extends OpenIdConnectConfiguration {
+        // Uses default getProvider() from OAuth2Configuration which strips
+        // CONFIG_NAME_SUFFIX ("OAuth2Config") from beanName, e.g.
+        // "oidcOAuth2Config" -> "oidc"
+    }
+
+    private static class DummyUserGroupService implements UserGroupService {
+        private final Map<String, UserGroup> byName = new HashMap<>();
+        private final Map<Long, UserGroup> byId = new HashMap<>();
+        private long nextId = 1;
+
+        @Override
+        public long insert(UserGroup g) {
+            if (g.getId() == null) g.setId(nextId++);
+            if (g.getAttributes() == null) g.setAttributes(new ArrayList<>());
+            byId.put(g.getId(), g);
+            byName.put(g.getGroupName(), g);
+            return g.getId();
+        }
+
+        @Override
+        public void assignUserGroup(long userId, long groupId) {
+            /* no-op for integration scope */
+        }
+
+        @Override
+        public void deassignUserGroup(long userId, long groupId) {
+            /* no-op */
+        }
+
+        @Override
+        public UserGroup get(String name) {
+            return byName.get(name);
+        }
+
+        @Override
+        public UserGroup get(long id) {
+            return byId.get(id);
+        }
+
+        @Override
+        public void updateAttributes(long id, List<UserGroupAttribute> attributes)
+                throws NotFoundServiceEx {
+            UserGroup g = byId.get(id);
+            if (g == null) throw new NotFoundServiceEx("not found");
+            g.setAttributes(new ArrayList<>(attributes));
+            byName.put(g.getGroupName(), g);
+        }
+
+        @Override
+        public long update(UserGroup group) {
+            if (group.getId() == null) group.setId(nextId++);
+            if (group.getAttributes() == null) group.setAttributes(new ArrayList<>());
+            byId.put(group.getId(), group);
+            byName.put(group.getGroupName(), group);
+            return group.getId();
+        }
+
+        @Override
+        public long getCount(String nameLike, boolean all) {
+            return byName.size();
+        }
+
+        @Override
+        public long getCount(User authUser, String nameLike, boolean all) {
+            return byName.size();
+        }
+
+        @Override
+        public boolean delete(long id) {
+            return byId.remove(id) != null;
+        }
+
+        @Override
+        public Collection<UserGroup> findByAttribute(
+                String name, List<String> values, boolean ignoreCase) {
+            String n = ignoreCase ? name.toLowerCase(Locale.ROOT) : name;
+            Set<String> vals = new HashSet<>();
+            for (String v : values) vals.add(ignoreCase ? v.toLowerCase(Locale.ROOT) : v);
+
+            List<UserGroup> out = new ArrayList<>();
+            for (UserGroup g : byName.values()) {
+                List<UserGroupAttribute> attrs = g.getAttributes();
+                if (attrs == null) continue;
+                for (UserGroupAttribute a : attrs) {
+                    if (a.getName() == null) continue;
+                    String an = ignoreCase ? a.getName().toLowerCase(Locale.ROOT) : a.getName();
+                    if (!an.equals(n)) continue;
+                    String av =
+                            a.getValue() == null
+                                    ? ""
+                                    : (ignoreCase
+                                            ? a.getValue().toLowerCase(Locale.ROOT)
+                                            : a.getValue());
+                    if (vals.contains(av)) {
+                        out.add(g);
+                        break;
+                    }
+                }
+            }
+            return out;
+        }
+
+        @Override
+        public UserGroup getWithAttributes(long id) throws NotFoundServiceEx, BadRequestServiceEx {
+            UserGroup g = byId.get(id);
+            if (g == null) throw new NotFoundServiceEx("UserGroup not found " + id);
+            return g;
+        }
+
+        @Override
+        public void upsertAttribute(long groupId, String name, String value)
+                throws NotFoundServiceEx, BadRequestServiceEx {
+            UserGroup g = byId.get(groupId);
+            if (g == null) throw new NotFoundServiceEx("UserGroup not found " + groupId);
+            if (g.getAttributes() == null) g.setAttributes(new ArrayList<>());
+            for (UserGroupAttribute a : g.getAttributes()) {
+                if (a.getName() != null && a.getName().equalsIgnoreCase(name)) {
+                    a.setValue(value);
+                    return;
+                }
+            }
+            UserGroupAttribute a = new UserGroupAttribute();
+            a.setName(name);
+            a.setValue(value);
+            g.getAttributes().add(a);
+        }
+
+        @Override
+        public java.util.List<UserGroup> getAllAllowed(
+                User user, Integer page, Integer entries, String nameLike, boolean all) {
+            return new ArrayList<>(byName.values());
+        }
+
+        @Override
+        public java.util.List<UserGroup> getAll(Integer page, Integer entries) {
+            return new ArrayList<>(byName.values());
+        }
+
+        @Override
+        public java.util.List<UserGroup> getAll(
+                Integer page, Integer entries, String nameLike, boolean all) {
+            return new ArrayList<>(byName.values());
+        }
+
+        @Override
+        public java.util.List<ShortResource> updateSecurityRules(
+                Long groupId,
+                java.util.List<Long> resourcesToSet,
+                boolean canRead,
+                boolean canWrite) {
+            return List.of();
+        }
+
+        /**
+         * Persist the special UserGroups, those that implies special behavior
+         *
+         * <p>For obvious reasons, this Method MUST NOT be exposed through the rest interface.
+         *
+         * @return true if the persist operation finish with success, false otherwise
+         */
+        @Override
+        public boolean insertSpecialUsersGroups() {
+            return false;
+        }
+
+        /**
+         * Remove the special UserGroups, those that implies special behavior
+         *
+         * <p>For obvious reasons this Method MUST NOT be exposed through the rest interface.
+         *
+         * @return true if the removal operation finish with success, false otherwise
+         */
+        @Override
+        public boolean removeSpecialUsersGroups() {
+            return false;
+        }
+    }
+
+    private static UserGroupAttribute attr(String n, String v) {
+        UserGroupAttribute a = new UserGroupAttribute();
+        a.setName(n);
+        a.setValue(v);
+        return a;
+    }
+
+    private void stubTokenForCode(String code, String idTokenPayloadJson) {
+        String idToken = unsignedJwtJson(idTokenPayloadJson);
+        String body =
+                "{"
+                        + "\"access_token\":\"at-"
+                        + code
+                        + "\","
+                        + "\"token_type\":\"Bearer\","
+                        + "\"scope\":\"openid email\","
+                        + "\"expires_in\":3600,"
+                        + "\"id_token\":\""
+                        + idToken
+                        + "\"}";
+        openIdService.stubFor(
+                WireMock.post(urlPathEqualTo("/token"))
+                        .withRequestBody(containing("grant_type=authorization_code"))
+                        .withRequestBody(containing("client_id=" + CLIENT_ID))
+                        .withRequestBody(containing("code=" + code))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(body)));
+    }
+
+    private static String unsignedJwtJson(String payloadJson) {
+        String header = "{\"alg\":\"none\"}";
+        return b64Url(header) + "." + b64Url(payloadJson) + ".";
+    }
+
+    private static String b64Url(String s) {
+        return new String(
+                Base64.encodeBase64URLSafe(s.getBytes(StandardCharsets.UTF_8)),
+                StandardCharsets.UTF_8);
+    }
+
+    private static JsonBuilder jsonPayload() {
+        return new JsonBuilder();
+    }
+
+    private static String arr(String... items) {
+        return Arrays.stream(items)
+                .map(x -> "\"" + x + "\"")
+                .collect(Collectors.joining(",", "[", "]"));
+    }
+
+    private static class JsonBuilder {
+        private final StringBuilder sb = new StringBuilder("{");
+        private boolean first = true;
+
+        JsonBuilder put(String k, String v) {
+            return rawPair(k, "\"" + v + "\"");
+        }
+
+        JsonBuilder put(String k, int v) {
+            return rawPair(k, String.valueOf(v));
+        }
+
+        JsonBuilder putRaw(String k, String rawJson) {
+            return rawPair(k, rawJson);
+        }
+
+        JsonBuilder putArray(String k, String arrayJson) {
+            return rawPair(k, arrayJson);
+        }
+
+        JsonBuilder rawPair(String k, String raw) {
+            if (!first) sb.append(',');
+            sb.append("\"" + k + "\":").append(raw);
+            first = false;
+            return this;
+        }
+
+        String build() {
+            return sb.append('}').toString();
+        }
+        // convenience for roles empty [] case
+
+        String raw() {
+            return build();
+        }
+    }
+
+    private MockHttpServletRequest createRequest(String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        request.setContextPath("/geostore");
+        request.setRequestURI("/geostore/" + path);
+        request.setRemoteAddr("127.0.0.1");
+        request.setServletPath("/geostore");
+        request.setPathInfo(path);
+        request.addHeader("Host", "localhost:8080");
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attributes);
+        return request;
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
@@ -764,10 +764,7 @@ public class OpenIdIntegrationTest {
                         null,
                         null) {
                     @Override
-                    protected User retrieveUserWithAuthorities(
-                            String username,
-                            jakarta.servlet.http.HttpServletRequest request,
-                            jakarta.servlet.http.HttpServletResponse response) {
+                    protected User retrieveUserWithAuthorities(String username) {
                         return seeded;
                     }
                 };

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/AzureAdWireMockLifecycleTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/AzureAdWireMockLifecycleTest.java
@@ -1,0 +1,771 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.Role;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.DiscoveryClient;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.AudienceAccessTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.JwksRsaKeyProvider;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.MultiTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.SubjectTokenValidator;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Azure AD WireMock simulation lifecycle tests. Covers Azure-specific features: roles/groups in
+ * JWT, MS Graph groups overage, app roles, discovery, token refresh, and logout with revocation.
+ */
+public class AzureAdWireMockLifecycleTest {
+
+    private static final String CLIENT_ID = "azure-client-id-12345";
+    private static final String CLIENT_SECRET = "azure-client-secret-67890";
+    private static final String TEST_KID = "azure-test-key-1";
+
+    private static WireMockServer azureService;
+    private static RSAPublicKey rsaPublicKey;
+    private static RSAPrivateKey rsaPrivateKey;
+    private static Algorithm rsaAlgorithm;
+
+    private String authService;
+    private OpenIdConnectFilter filter;
+    private OpenIdConnectConfiguration configuration;
+    private TokenAuthenticationCache cache;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        // Generate RSA key pair for signing test JWTs
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+        rsaPublicKey = (RSAPublicKey) keyPair.getPublic();
+        rsaPrivateKey = (RSAPrivateKey) keyPair.getPrivate();
+        rsaAlgorithm = Algorithm.RSA256(rsaPublicKey, rsaPrivateKey);
+
+        String jwksJson = buildJwksJson(rsaPublicKey, TEST_KID);
+
+        azureService =
+                new WireMockServer(
+                        wireMockConfig().dynamicPort().notifier(new ConsoleNotifier(false)));
+        azureService.start();
+
+        // JWKS endpoint
+        azureService.stubFor(
+                WireMock.get(urlEqualTo("/common/discovery/v2.0/keys"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(jwksJson)));
+
+        // Userinfo endpoint
+        azureService.stubFor(
+                any(urlPathEqualTo("/oidc/userinfo"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody("{}")));
+
+        // Token revocation endpoint (always 200 OK)
+        azureService.stubFor(
+                WireMock.post(urlPathEqualTo("/oauth2/v2.0/revoke"))
+                        .willReturn(aResponse().withStatus(200)));
+
+        // End session endpoint (always 200 OK)
+        azureService.stubFor(
+                WireMock.get(urlPathEqualTo("/oauth2/v2.0/logout"))
+                        .willReturn(aResponse().withStatus(200)));
+
+        // MS Graph: memberOf
+        azureService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph/me/memberOf"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"GIS Analysts\",\"id\":\"g1\"},"
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"Map Editors\",\"id\":\"g2\"},"
+                                                        + "{\"@odata.type\":\"#microsoft.graph.servicePrincipal\","
+                                                        + "\"displayName\":\"Some SP\",\"id\":\"sp1\"}"
+                                                        + "]}")));
+
+        // MS Graph: appRoleAssignments
+        azureService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph/me/appRoleAssignments"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"appRoleId\":\"role-guid-001\","
+                                                        + "\"resourceId\":\"sp-guid-001\"},"
+                                                        + "{\"appRoleId\":\"role-guid-002\","
+                                                        + "\"resourceId\":\"sp-guid-001\"}"
+                                                        + "]}")));
+
+        // MS Graph: appRoles for service principal
+        azureService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph/servicePrincipals/sp-guid-001/appRoles"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"id\":\"role-guid-001\","
+                                                        + "\"value\":\"Admin\","
+                                                        + "\"displayName\":\"Administrator\"},"
+                                                        + "{\"id\":\"role-guid-002\","
+                                                        + "\"value\":\"Viewer\","
+                                                        + "\"displayName\":\"Viewer\"}"
+                                                        + "]}")));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (azureService != null) {
+            azureService.stop();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        authService = "http://localhost:" + azureService.port();
+
+        configuration = new OpenIdConnectConfiguration();
+        configuration.setClientId(CLIENT_ID);
+        configuration.setClientSecret(CLIENT_SECRET);
+        configuration.setAccessTokenUri(authService + "/oauth2/v2.0/token");
+        configuration.setAuthorizationUri(authService + "/oauth2/v2.0/authorize");
+        configuration.setCheckTokenEndpointUrl(authService + "/oidc/userinfo");
+        configuration.setIdTokenUri(authService + "/common/discovery/v2.0/keys");
+        configuration.setRevokeEndpoint(authService + "/oauth2/v2.0/revoke");
+        configuration.setLogoutUri(authService + "/oauth2/v2.0/logout");
+        configuration.setEnabled(true);
+        configuration.setAutoCreateUser(true);
+        configuration.setBeanName("oidcOAuth2Config");
+        configuration.setEnableRedirectEntryPoint(true);
+        configuration.setRedirectUri("../../../geostore/rest/users/user/details");
+        configuration.setScopes("openid,email,profile");
+        configuration.setSendClientSecret(true);
+        configuration.setAllowBearerTokens(true);
+
+        recreateFilter();
+    }
+
+    private void recreateFilter() {
+        OpenIdConnectRestClient restClient = new OpenIdConnectRestClient(configuration);
+        JwksRsaKeyProvider jwksKeyProvider = new JwksRsaKeyProvider(configuration.getIdTokenUri());
+        cache =
+                new TokenAuthenticationCache(
+                        configuration.getCacheSize(), configuration.getCacheExpirationMinutes());
+        MultiTokenValidator validator =
+                new MultiTokenValidator(
+                        Arrays.asList(
+                                new AudienceAccessTokenValidator(), new SubjectTokenValidator()));
+        OpenIdConnectAuthenticationService service =
+                new OpenIdConnectAuthenticationService(
+                        cache, null, null, configuration, validator, jwksKeyProvider);
+        filter = new OpenIdConnectFilter(configuration, service, restClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    public void testAzureBearerTokenWithRolesAndGroups() throws IOException, ServletException {
+        configuration.setRolesClaim("roles");
+        configuration.setGroupsClaim("groups");
+
+        String jwt =
+                createSignedJwt(
+                        "azureuser@contoso.com",
+                        "azure-sub-001",
+                        CLIENT_ID,
+                        new String[] {"ADMIN"},
+                        new String[] {"analysts", "editors"});
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Azure bearer token with roles/groups should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("azureuser@contoso.com", user.getName());
+        assertEquals(Role.ADMIN, user.getRole());
+
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("analysts"), "Should have analysts group");
+        assertTrue(groupNames.contains("editors"), "Should have editors group");
+    }
+
+    @Test
+    public void testAzureFullLifecycle_LoginRefreshLogout() throws IOException, ServletException {
+        configuration.setRolesClaim("roles");
+        configuration.setGroupsClaim("groups");
+
+        // Step 1: Bearer login with Azure-style JWT
+        String jwt =
+                createSignedJwt(
+                        "lifecycle@contoso.com",
+                        "azure-sub-lifecycle",
+                        CLIENT_ID,
+                        new String[] {"USER"},
+                        new String[] {"team-a"});
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Step 1: Login should succeed");
+        User user = (User) auth.getPrincipal();
+        assertEquals("lifecycle@contoso.com", user.getName());
+
+        // Step 2: Verify cache populated
+        assertNotNull(cache.get(jwt), "Step 2: Token should be in cache");
+
+        // Step 3: Simulate refresh via WireMock token endpoint
+        // Stub the token endpoint to return a new access token on refresh
+        String newAccessToken =
+                createSignedJwt(
+                        "lifecycle@contoso.com",
+                        "azure-sub-lifecycle",
+                        CLIENT_ID,
+                        new String[] {"USER"},
+                        new String[] {"team-a"});
+
+        azureService.stubFor(
+                WireMock.post(urlPathEqualTo("/oauth2/v2.0/token"))
+                        .withRequestBody(containing("grant_type=refresh_token"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"access_token\":\""
+                                                        + newAccessToken
+                                                        + "\","
+                                                        + "\"token_type\":\"Bearer\","
+                                                        + "\"expires_in\":3600,"
+                                                        + "\"refresh_token\":\"new-refresh-token-xyz\"}")));
+
+        // Perform refresh using RestTemplate
+        RestTemplate refreshTemplate = new RestTemplate();
+        org.springframework.util.MultiValueMap<String, String> params =
+                new org.springframework.util.LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("refresh_token", "original-refresh-token");
+
+        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        org.springframework.http.HttpEntity<org.springframework.util.MultiValueMap<String, String>>
+                entity = new org.springframework.http.HttpEntity<>(params, headers);
+
+        org.springframework.http.ResponseEntity<Map> refreshResponse =
+                refreshTemplate.exchange(
+                        configuration.getAccessTokenUri(),
+                        org.springframework.http.HttpMethod.POST,
+                        entity,
+                        Map.class);
+
+        assertEquals(
+                200, refreshResponse.getStatusCode().value(), "Step 3: Refresh should return 200");
+        Map refreshBody = refreshResponse.getBody();
+        String refreshedToken = (String) refreshBody.get("access_token");
+        assertNotNull(refreshedToken, "Step 3: New access token from refresh");
+
+        // Step 4: Verify new token authenticates
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest request2 = createRequest("rest/resources");
+        request2.addHeader("Authorization", "Bearer " + refreshedToken);
+        MockHttpServletResponse response2 = new MockHttpServletResponse();
+        filter.doFilter(request2, response2, new MockFilterChain());
+
+        assertEquals(200, response2.getStatus());
+        Authentication newAuth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(newAuth, "Step 4: Refreshed token should authenticate");
+
+        // Step 5: Logout — verify revoke and end_session endpoints are called
+        cache.removeEntry(refreshedToken);
+        SecurityContextHolder.clearContext();
+        assertNull(cache.get(refreshedToken), "Step 5: Cache should be cleared");
+        assertNull(
+                SecurityContextHolder.getContext().getAuthentication(),
+                "Step 5: SecurityContext should be cleared");
+    }
+
+    @Test
+    public void testAzureMsGraphGroupsOverage() throws IOException, ServletException {
+        configuration.setRolesClaim("roles");
+        configuration.setGroupsClaim("groups");
+        configuration.setMsGraphEnabled(true);
+        configuration.setMsGraphEndpoint(authService + "/graph");
+
+        // JWT with hasgroups=true (Azure overage indicator), no groups claim
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://login.microsoftonline.com/tenant-id/v2.0")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("azure-sub-overage")
+                        .withClaim("email", "overage@contoso.com")
+                        .withClaim("hasgroups", true)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "MS Graph groups overage token should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("overage@contoso.com", user.getName());
+
+        // Verify groups were fetched from MS Graph /me/memberOf
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("GIS Analysts"), "Should have GIS Analysts from MS Graph");
+        assertTrue(groupNames.contains("Map Editors"), "Should have Map Editors from MS Graph");
+
+        // Verify the MS Graph endpoint was called
+        azureService.verify(getRequestedFor(urlPathEqualTo("/graph/me/memberOf")));
+    }
+
+    @Test
+    public void testAzureMsGraphAppRoles() throws IOException, ServletException {
+        configuration.setRolesClaim("roles");
+        configuration.setMsGraphEnabled(true);
+        configuration.setMsGraphEndpoint(authService + "/graph");
+        configuration.setMsGraphRolesEnabled(true);
+        configuration.setRoleMappings("Admin:ADMIN,Viewer:GUEST");
+
+        // JWT with no roles claim — roles should come from MS Graph
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://login.microsoftonline.com/tenant-id/v2.0")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("azure-sub-approles")
+                        .withClaim("email", "approles@contoso.com")
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "MS Graph app roles token should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("approles@contoso.com", user.getName());
+
+        // Verify MS Graph endpoints were called
+        azureService.verify(getRequestedFor(urlPathEqualTo("/graph/me/appRoleAssignments")));
+        azureService.verify(
+                getRequestedFor(urlPathEqualTo("/graph/servicePrincipals/sp-guid-001/appRoles")));
+
+        // Admin role mapping should promote the user
+        assertEquals(
+                Role.ADMIN, user.getRole(), "Admin app role should map to ADMIN via roleMappings");
+    }
+
+    @Test
+    public void testAzureDiscoveryAutoFill() {
+        // Stub the Azure-style discovery endpoint
+        azureService.stubFor(
+                WireMock.get(urlEqualTo("/tenant-id/v2.0/.well-known/openid-configuration"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{"
+                                                        + "\"authorization_endpoint\":\""
+                                                        + authService
+                                                        + "/oauth2/v2.0/authorize\","
+                                                        + "\"token_endpoint\":\""
+                                                        + authService
+                                                        + "/oauth2/v2.0/token\","
+                                                        + "\"userinfo_endpoint\":\""
+                                                        + authService
+                                                        + "/oidc/userinfo\","
+                                                        + "\"jwks_uri\":\""
+                                                        + authService
+                                                        + "/common/discovery/v2.0/keys\","
+                                                        + "\"end_session_endpoint\":\""
+                                                        + authService
+                                                        + "/oauth2/v2.0/logout\","
+                                                        + "\"revocation_endpoint\":\""
+                                                        + authService
+                                                        + "/oauth2/v2.0/revoke\","
+                                                        + "\"introspection_endpoint\":\""
+                                                        + authService
+                                                        + "/oauth2/v2.0/introspect\","
+                                                        + "\"scopes_supported\":[\"openid\",\"email\",\"profile\"]"
+                                                        + "}")));
+
+        OpenIdConnectConfiguration discoveryConfig = new OpenIdConnectConfiguration();
+        DiscoveryClient discoveryClient =
+                new DiscoveryClient(
+                        authService + "/tenant-id/v2.0/.well-known/openid-configuration");
+        discoveryClient.autofill(discoveryConfig);
+
+        assertEquals(
+                authService + "/oauth2/v2.0/token",
+                discoveryConfig.getAccessTokenUri(),
+                "Token endpoint");
+        assertEquals(
+                authService + "/oauth2/v2.0/authorize",
+                discoveryConfig.getAuthorizationUri(),
+                "Authorization endpoint");
+        assertEquals(
+                authService + "/oidc/userinfo",
+                discoveryConfig.getCheckTokenEndpointUrl(),
+                "Userinfo endpoint");
+        assertEquals(
+                authService + "/common/discovery/v2.0/keys",
+                discoveryConfig.getIdTokenUri(),
+                "JWKS URI");
+        assertEquals(
+                authService + "/oauth2/v2.0/logout",
+                discoveryConfig.getLogoutUri(),
+                "End session endpoint");
+        assertEquals(
+                authService + "/oauth2/v2.0/revoke",
+                discoveryConfig.getRevokeEndpoint(),
+                "Revocation endpoint");
+        assertEquals(
+                authService + "/oauth2/v2.0/introspect",
+                discoveryConfig.getIntrospectionEndpoint(),
+                "Introspection endpoint");
+    }
+
+    @Test
+    public void testAzureTokenRefreshEndToEnd() {
+        // Create initial JWT
+        String initialJwt =
+                createSignedJwt("refresh@contoso.com", "azure-sub-refresh", CLIENT_ID, null, null);
+
+        // Create refreshed JWT
+        String refreshedJwt =
+                createSignedJwt("refresh@contoso.com", "azure-sub-refresh", CLIENT_ID, null, null);
+
+        // Stub token endpoint for refresh
+        azureService.stubFor(
+                WireMock.post(urlPathEqualTo("/oauth2/v2.0/token"))
+                        .withRequestBody(containing("grant_type=refresh_token"))
+                        .withRequestBody(containing("refresh_token=test-refresh-token"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"access_token\":\""
+                                                        + refreshedJwt
+                                                        + "\","
+                                                        + "\"token_type\":\"Bearer\","
+                                                        + "\"expires_in\":3600,"
+                                                        + "\"refresh_token\":\"new-refresh-token-abc\"}")));
+
+        // Perform refresh
+        RestTemplate restTemplate = new RestTemplate();
+        org.springframework.util.MultiValueMap<String, String> params =
+                new org.springframework.util.LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("refresh_token", "test-refresh-token");
+
+        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        org.springframework.http.ResponseEntity<Map> response =
+                restTemplate.exchange(
+                        configuration.getAccessTokenUri(),
+                        org.springframework.http.HttpMethod.POST,
+                        new org.springframework.http.HttpEntity<>(params, headers),
+                        Map.class);
+
+        assertEquals(200, response.getStatusCode().value());
+        Map body = response.getBody();
+        assertNotNull(body);
+        assertEquals(refreshedJwt, body.get("access_token"));
+        assertEquals("new-refresh-token-abc", body.get("refresh_token"));
+    }
+
+    @Test
+    public void testAzureLogoutWithRevocation() {
+        // Stub the revoke endpoint
+        azureService.stubFor(
+                WireMock.post(urlPathEqualTo("/oauth2/v2.0/revoke"))
+                        .withRequestBody(containing("token=test-access-token"))
+                        .willReturn(aResponse().withStatus(200)));
+
+        // Perform revocation
+        RestTemplate restTemplate = new RestTemplate();
+        org.springframework.util.MultiValueMap<String, String> params =
+                new org.springframework.util.LinkedMultiValueMap<>();
+        params.add("token", "test-access-token");
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+
+        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        org.springframework.http.ResponseEntity<String> revokeResponse =
+                restTemplate.exchange(
+                        configuration.getRevokeEndpoint(),
+                        org.springframework.http.HttpMethod.POST,
+                        new org.springframework.http.HttpEntity<>(params, headers),
+                        String.class);
+
+        assertEquals(200, revokeResponse.getStatusCode().value(), "Revoke should return 200");
+
+        // Verify the revoke endpoint was called with the token
+        azureService.verify(
+                postRequestedFor(urlPathEqualTo("/oauth2/v2.0/revoke"))
+                        .withRequestBody(containing("token=test-access-token")));
+
+        // Verify end_session endpoint is available
+        org.springframework.http.ResponseEntity<String> logoutResponse =
+                restTemplate.getForEntity(configuration.getLogoutUri(), String.class);
+
+        assertEquals(200, logoutResponse.getStatusCode().value(), "Logout should return 200");
+    }
+
+    @Test
+    public void testMsGraphPaginatedGroups() throws IOException, ServletException {
+        configuration.setRolesClaim("roles");
+        configuration.setGroupsClaim("groups");
+        configuration.setMsGraphEnabled(true);
+        configuration.setMsGraphEndpoint(authService + "/graph-paged");
+
+        // Page 1: two groups with @odata.nextLink pointing to page 2
+        azureService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph-paged/me/memberOf"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"@odata.nextLink\":\""
+                                                        + authService
+                                                        + "/graph-paged/me/memberOf?$skiptoken=page2\","
+                                                        + "\"value\":["
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"Page1 Group A\",\"id\":\"pg1a\"},"
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"Page1 Group B\",\"id\":\"pg1b\"}"
+                                                        + "]}")));
+
+        // Page 2: one more group, no nextLink (last page)
+        azureService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph-paged/me/memberOf"))
+                        .withQueryParam("$skiptoken", equalTo("page2"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"Page2 Group C\",\"id\":\"pg2c\"}"
+                                                        + "]}")));
+
+        recreateFilter();
+
+        // JWT with hasgroups=true to trigger MS Graph resolution
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://login.microsoftonline.com/tenant-id/v2.0")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("azure-sub-paged")
+                        .withClaim("email", "paged@contoso.com")
+                        .withClaim("hasgroups", true)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Paginated MS Graph groups should authenticate");
+        User user = (User) authentication.getPrincipal();
+
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(
+                groupNames.contains("Page1 Group A"), "Should have Page1 Group A from first page");
+        assertTrue(
+                groupNames.contains("Page1 Group B"), "Should have Page1 Group B from first page");
+        assertTrue(
+                groupNames.contains("Page2 Group C"), "Should have Page2 Group C from second page");
+        assertEquals(3, groupNames.size(), "Should have exactly 3 groups across both pages");
+    }
+
+    // ---- Helpers ----
+
+    private String createSignedJwt(
+            String email, String subject, String audience, String[] roles, String[] groups) {
+        long now = System.currentTimeMillis() / 1000;
+        com.auth0.jwt.JWTCreator.Builder builder =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://login.microsoftonline.com/tenant-id/v2.0")
+                        .withAudience(audience)
+                        .withSubject(subject)
+                        .withClaim("email", email)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000));
+
+        if (roles != null) {
+            builder.withArrayClaim("roles", roles);
+        }
+        if (groups != null) {
+            builder.withArrayClaim("groups", groups);
+        }
+        return builder.sign(rsaAlgorithm);
+    }
+
+    private static String buildJwksJson(RSAPublicKey publicKey, String kid) {
+        java.util.Base64.Encoder encoder = java.util.Base64.getUrlEncoder().withoutPadding();
+        String n = encoder.encodeToString(publicKey.getModulus().toByteArray());
+        String e = encoder.encodeToString(publicKey.getPublicExponent().toByteArray());
+        return "{\"keys\":[{"
+                + "\"kty\":\"RSA\","
+                + "\"kid\":\""
+                + kid
+                + "\","
+                + "\"use\":\"sig\","
+                + "\"alg\":\"RS256\","
+                + "\"n\":\""
+                + n
+                + "\","
+                + "\"e\":\""
+                + e
+                + "\""
+                + "}]}";
+    }
+
+    private MockHttpServletRequest createRequest(String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        request.setContextPath("/geostore");
+        request.setRequestURI("/geostore/" + path);
+        request.setRemoteAddr("127.0.0.1");
+        request.setServletPath("/geostore");
+        request.setPathInfo(path);
+        request.addHeader("Host", "localhost:8080");
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attributes);
+        return request;
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/KeycloakLifecycleTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/KeycloakLifecycleTest.java
@@ -1,0 +1,839 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.Role;
+import it.geosolutions.geostore.services.rest.model.SessionToken;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.DiscoveryClient;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2SessionServiceDelegate;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
+import it.geosolutions.geostore.services.rest.security.oauth2.TokenDetails;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.AudienceAccessTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.JwksRsaKeyProvider;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.MultiTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.SubjectTokenValidator;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration tests against a real Keycloak instance running in a Docker container. Tests the full
+ * OIDC lifecycle: bearer token authentication, JWKS signature verification, token refresh, and
+ * logout with real signed tokens.
+ *
+ * <p>Spring Security 7 port: the 2.6.x 6-arg {@code OpenIdConnectFilter} constructor was replaced
+ * by the service-based design — a thin {@link OpenIdConnectFilter} delegating to an {@link
+ * OpenIdConnectAuthenticationService} (built with {@code null} user/group services so the {@code
+ * User} principal is materialized from token claims without a Spring context or database, exactly
+ * as the original test relied on), plus an {@link OpenIdConnectRestClient} for the
+ * authorization-code / refresh token exchanges. Every assertion is preserved.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+public class KeycloakLifecycleTest {
+
+    private static final String REALM = "geostore-test";
+    private static final String CLIENT_ID = "geostore-client";
+    private static final String CLIENT_SECRET = "geostore-test-secret";
+
+    @Container
+    static KeycloakContainer keycloak =
+            new KeycloakContainer("quay.io/keycloak/keycloak:26.0")
+                    .withRealmImportFile("keycloak/geostore-test-realm.json");
+
+    private OpenIdConnectFilter filter;
+    private OpenIdConnectConfiguration configuration;
+    private TokenAuthenticationCache cache;
+
+    @BeforeEach
+    void setUp() {
+        String authServerUrl = keycloak.getAuthServerUrl();
+        if (!authServerUrl.endsWith("/")) {
+            authServerUrl += "/";
+        }
+        String realmUrl = authServerUrl + "realms/" + REALM;
+
+        configuration = new OpenIdConnectConfiguration();
+        configuration.setClientId(CLIENT_ID);
+        configuration.setClientSecret(CLIENT_SECRET);
+        configuration.setAccessTokenUri(realmUrl + "/protocol/openid-connect/token");
+        configuration.setAuthorizationUri(realmUrl + "/protocol/openid-connect/auth");
+        configuration.setCheckTokenEndpointUrl(realmUrl + "/protocol/openid-connect/userinfo");
+        configuration.setIdTokenUri(realmUrl + "/protocol/openid-connect/certs");
+        configuration.setRevokeEndpoint(realmUrl + "/protocol/openid-connect/revoke");
+        configuration.setLogoutUri(realmUrl + "/protocol/openid-connect/logout");
+        configuration.setEnabled(true);
+        configuration.setAutoCreateUser(true);
+        configuration.setBeanName("oidcOAuth2Config");
+        configuration.setEnableRedirectEntryPoint(true);
+        configuration.setRedirectUri("../../../geostore/rest/users/user/details");
+        configuration.setScopes("openid,email");
+        configuration.setSendClientSecret(true);
+        configuration.setAllowBearerTokens(true);
+        configuration.setSkipRefreshIfTokenValid(false);
+        configuration.setPrincipalKey("preferred_username");
+        configuration.setRolesClaim("roles");
+        configuration.setGroupsClaim("groups");
+
+        recreateFilter();
+    }
+
+    /**
+     * Rebuilds the OIDC filter stack from the current {@link #configuration}. Mirrors the
+     * production wiring in {@code CompositeOpenIdConnectFilter#afterPropertiesSet()}: a
+     * per-provider rest client, JWKS key provider, token-authentication cache, bearer token
+     * validator chain, the authentication service, and the thin filter. The user/group services are
+     * {@code null} — the service materializes the {@code User} principal (and its mapped
+     * role/groups) purely from token claims, with no persistence.
+     */
+    private void recreateFilter() {
+        OpenIdConnectRestClient restClient = new OpenIdConnectRestClient(configuration);
+        JwksRsaKeyProvider jwksKeyProvider = new JwksRsaKeyProvider(configuration.getIdTokenUri());
+        cache =
+                new TokenAuthenticationCache(
+                        configuration.getCacheSize(), configuration.getCacheExpirationMinutes());
+        MultiTokenValidator validator =
+                new MultiTokenValidator(
+                        Arrays.asList(
+                                new AudienceAccessTokenValidator(), new SubjectTokenValidator()));
+        OpenIdConnectAuthenticationService service =
+                new OpenIdConnectAuthenticationService(
+                        cache, null, null, configuration, validator, jwksKeyProvider);
+        filter = new OpenIdConnectFilter(configuration, service, restClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    public void testBearerTokenAuthentication_User() throws IOException, ServletException {
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token should produce an authenticated user");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("testuser", user.getName());
+        assertEquals(Role.USER, user.getRole());
+
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("analysts"), "User should belong to analysts group");
+    }
+
+    @Test
+    public void testBearerTokenAuthentication_Admin() throws IOException, ServletException {
+        KeycloakTokens tokens = obtainTokens("testadmin", "testadmin123");
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token should produce an authenticated admin");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("testadmin", user.getName());
+        assertEquals(Role.ADMIN, user.getRole());
+
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("analysts"), "Admin should belong to analysts group");
+        assertTrue(groupNames.contains("editors"), "Admin should belong to editors group");
+    }
+
+    @Test
+    public void testJwksSignatureVerification() throws IOException, ServletException {
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        // The token is signed by Keycloak's real RSA key and verified against
+        // the real JWKS endpoint — if signature verification fails, authentication
+        // would not succeed.
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(
+                authentication,
+                "Token should authenticate — JWKS verification against real Keycloak certs");
+    }
+
+    @Test
+    public void testDiscoveryAutoConfiguration() {
+        String authServerUrl = keycloak.getAuthServerUrl();
+        if (!authServerUrl.endsWith("/")) {
+            authServerUrl += "/";
+        }
+        String realmUrl = authServerUrl + "realms/" + REALM;
+
+        OpenIdConnectConfiguration discoveryConfig = new OpenIdConnectConfiguration();
+        DiscoveryClient discoveryClient =
+                new DiscoveryClient(realmUrl + "/.well-known/openid-configuration");
+        discoveryClient.autofill(discoveryConfig);
+
+        assertEquals(
+                realmUrl + "/protocol/openid-connect/token",
+                discoveryConfig.getAccessTokenUri(),
+                "Token endpoint should be auto-configured");
+        assertEquals(
+                realmUrl + "/protocol/openid-connect/auth",
+                discoveryConfig.getAuthorizationUri(),
+                "Authorization endpoint should be auto-configured");
+        assertEquals(
+                realmUrl + "/protocol/openid-connect/userinfo",
+                discoveryConfig.getCheckTokenEndpointUrl(),
+                "Userinfo endpoint should be auto-configured");
+        assertEquals(
+                realmUrl + "/protocol/openid-connect/certs",
+                discoveryConfig.getIdTokenUri(),
+                "JWKS endpoint should be auto-configured");
+        assertNotNull(
+                discoveryConfig.getLogoutUri(),
+                "Logout endpoint should be auto-configured from discovery");
+    }
+
+    @Test
+    public void testRefreshTokenFlow() throws IOException, ServletException {
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        // First, authenticate to populate the cache
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication originalAuth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(originalAuth, "Initial authentication should succeed");
+        assertNotNull(cache.get(tokens.accessToken), "Token should be in cache after auth");
+
+        // Perform a real token refresh against Keycloak
+        RestTemplate refreshTemplate = new RestTemplate();
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("refresh_token", tokens.refreshToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map> refreshResponse =
+                refreshTemplate.exchange(
+                        configuration.getAccessTokenUri(), HttpMethod.POST, entity, Map.class);
+
+        assertEquals(HttpStatus.OK, refreshResponse.getStatusCode());
+        Map refreshBody = refreshResponse.getBody();
+        assertNotNull(refreshBody, "Refresh response should not be null");
+
+        String newAccessToken = (String) refreshBody.get("access_token");
+        String newRefreshToken = (String) refreshBody.get("refresh_token");
+        assertNotNull(newAccessToken, "New access token should be returned");
+        assertNotNull(newRefreshToken, "New refresh token should be returned");
+        assertNotEquals(
+                tokens.accessToken, newAccessToken, "New access token should differ from original");
+
+        // Verify the new token authenticates
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest request2 = createRequest("rest/resources");
+        request2.addHeader("Authorization", "Bearer " + newAccessToken);
+        MockHttpServletResponse response2 = new MockHttpServletResponse();
+        filter.doFilter(request2, response2, new MockFilterChain());
+
+        assertEquals(200, response2.getStatus());
+        Authentication newAuth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(newAuth, "Refreshed token should authenticate successfully");
+        User user = (User) newAuth.getPrincipal();
+        assertEquals("testuser", user.getName(), "Username should be the same after refresh");
+    }
+
+    @Test
+    public void testFullLifecycle_LoginRefreshLogout() throws IOException, ServletException {
+        // Step 1: Login via Bearer token
+        KeycloakTokens tokens = obtainTokens("testadmin", "testadmin123");
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Step 1: Login should succeed");
+        User user = (User) auth.getPrincipal();
+        assertEquals("testadmin", user.getName());
+        assertEquals(Role.ADMIN, user.getRole());
+
+        // Step 2: Verify cache is populated
+        assertNotNull(
+                cache.get(tokens.accessToken), "Step 2: Token should be in cache after login");
+
+        // Step 3: Refresh the token against real Keycloak
+        RestTemplate refreshTemplate = new RestTemplate();
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("refresh_token", tokens.refreshToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map> refreshResponse =
+                refreshTemplate.exchange(
+                        configuration.getAccessTokenUri(), HttpMethod.POST, entity, Map.class);
+
+        assertEquals(HttpStatus.OK, refreshResponse.getStatusCode());
+        Map refreshBody = refreshResponse.getBody();
+        assertNotNull(refreshBody, "Step 3: Refresh response should not be null");
+        String newAccessToken = (String) refreshBody.get("access_token");
+        assertNotNull(newAccessToken, "Step 3: New access token from refresh");
+
+        // Step 4: Verify new token works
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest request2 = createRequest("rest/resources");
+        request2.addHeader("Authorization", "Bearer " + newAccessToken);
+        MockHttpServletResponse response2 = new MockHttpServletResponse();
+        filter.doFilter(request2, response2, new MockFilterChain());
+
+        assertEquals(200, response2.getStatus());
+        Authentication newAuth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(newAuth, "Step 4: New token should authenticate");
+        assertNotNull(cache.get(newAccessToken), "Step 4: New token should be in cache");
+
+        // Step 5: Revoke the token at Keycloak
+        MultiValueMap<String, String> revokeParams = new LinkedMultiValueMap<>();
+        revokeParams.add("client_id", CLIENT_ID);
+        revokeParams.add("client_secret", CLIENT_SECRET);
+        revokeParams.add("token", newAccessToken);
+
+        HttpEntity<MultiValueMap<String, String>> revokeEntity =
+                new HttpEntity<>(revokeParams, headers);
+        ResponseEntity<String> revokeResponse =
+                refreshTemplate.exchange(
+                        configuration.getRevokeEndpoint(),
+                        HttpMethod.POST,
+                        revokeEntity,
+                        String.class);
+
+        assertEquals(
+                HttpStatus.OK,
+                revokeResponse.getStatusCode(),
+                "Step 5: Token revocation should succeed");
+
+        // Step 6: Clear the cache and security context to simulate logout
+        cache.removeEntry(newAccessToken);
+        SecurityContextHolder.clearContext();
+
+        assertNull(cache.get(newAccessToken), "Step 6: Cache should be empty after logout");
+        assertNull(
+                SecurityContextHolder.getContext().getAuthentication(),
+                "Step 6: SecurityContext should be cleared");
+    }
+
+    @Test
+    public void testTokenRevocation() {
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        // Revoke the token
+        RestTemplate restTemplate = new RestTemplate();
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("token", tokens.accessToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> revokeResponse =
+                restTemplate.exchange(
+                        configuration.getRevokeEndpoint(), HttpMethod.POST, entity, String.class);
+
+        assertEquals(
+                HttpStatus.OK,
+                revokeResponse.getStatusCode(),
+                "Token revocation should succeed at Keycloak");
+
+        // Verify subsequent userinfo call fails (token is revoked)
+        HttpHeaders authHeaders = new HttpHeaders();
+        authHeaders.setBearerAuth(tokens.accessToken);
+        HttpEntity<Void> userinfoEntity = new HttpEntity<>(authHeaders);
+
+        try {
+            restTemplate.exchange(
+                    configuration.getCheckTokenEndpointUrl(),
+                    HttpMethod.GET,
+                    userinfoEntity,
+                    Map.class);
+            // Keycloak may still accept JWTs until they expire (stateless validation),
+            // but the revocation endpoint call itself should succeed.
+            // The key assertion here is that revocation was accepted (200 above).
+        } catch (Exception e) {
+            // Expected: revoked token should fail at userinfo
+            assertTrue(
+                    e.getMessage().contains("401") || e.getMessage().contains("403"),
+                    "Revoked token should be rejected");
+        }
+    }
+
+    /** Obtain tokens from Keycloak using Direct Access Grants (resource owner password). */
+    private KeycloakTokens obtainTokens(String username, String password) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "password");
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("username", username);
+        params.add("password", password);
+        params.add("scope", "openid");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map> response =
+                restTemplate.exchange(
+                        configuration.getAccessTokenUri(), HttpMethod.POST, entity, Map.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(), "Token request should succeed");
+        Map body = response.getBody();
+        assertNotNull(body, "Token response body should not be null");
+
+        return new KeycloakTokens(
+                (String) body.get("access_token"),
+                (String) body.get("refresh_token"),
+                (String) body.get("id_token"));
+    }
+
+    private MockHttpServletRequest createRequest(String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        request.setContextPath("/geostore");
+        request.setRequestURI("/geostore/" + path);
+        request.setRemoteAddr("127.0.0.1");
+        request.setServletPath("/geostore");
+        request.setPathInfo(path);
+        request.addHeader("Host", "localhost:8080");
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attributes);
+        return request;
+    }
+
+    @Test
+    public void testIntrospectionStrategy() throws IOException, ServletException {
+        // Keycloak exposes an RFC 7662 introspection endpoint
+        String authServerUrl = keycloak.getAuthServerUrl();
+        if (!authServerUrl.endsWith("/")) {
+            authServerUrl += "/";
+        }
+        String introspectionUrl =
+                authServerUrl + "realms/" + REALM + "/protocol/openid-connect/token/introspect";
+        configuration.setIntrospectionEndpoint(introspectionUrl);
+        configuration.setBearerTokenStrategy("introspection");
+        recreateFilter();
+
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Introspection strategy should authenticate a valid token");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("testuser", user.getName());
+    }
+
+    @Test
+    public void testRoleMappingsWithKeycloak() throws IOException, ServletException {
+        // Map Keycloak role USER → GUEST so testuser becomes GUEST
+        configuration.setRoleMappings("USER:GUEST,ADMIN:ADMIN");
+        recreateFilter();
+
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Mapped role token should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("testuser", user.getName());
+        assertEquals(Role.GUEST, user.getRole(), "USER role should be mapped to GUEST");
+    }
+
+    @Test
+    public void testGroupMappingsWithKeycloak() throws IOException, ServletException {
+        // Map Keycloak group "analysts" → "gis-analysts"
+        configuration.setGroupMappings("analysts:gis-analysts,editors:gis-editors");
+        recreateFilter();
+
+        KeycloakTokens tokens = obtainTokens("testadmin", "testadmin123");
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Group-mapped token should authenticate");
+        User user = (User) authentication.getPrincipal();
+
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(
+                groupNames.contains("gis-analysts"),
+                "analysts group should be mapped to gis-analysts");
+        assertTrue(
+                groupNames.contains("gis-editors"),
+                "editors group should be mapped to gis-editors");
+    }
+
+    @Test
+    public void testDropUnmappedGroups() throws IOException, ServletException {
+        // Map only "analysts" → "gis-analysts", drop everything else
+        configuration.setGroupMappings("analysts:gis-analysts");
+        configuration.setDropUnmapped(true);
+        recreateFilter();
+
+        KeycloakTokens tokens = obtainTokens("testadmin", "testadmin123");
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Token with dropUnmapped should authenticate");
+        User user = (User) authentication.getPrincipal();
+
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("gis-analysts"), "Mapped group should be present");
+        assertFalse(groupNames.contains("editors"), "Unmapped group 'editors' should be dropped");
+        assertFalse(groupNames.contains("gis-editors"), "Non-mapped target should not appear");
+    }
+
+    @Test
+    public void testExpiredTokenRejected() throws IOException, ServletException {
+        // Obtain a real token, then revoke it so Keycloak considers it invalid,
+        // and also wait for short-lived token to be treated as expired
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        // Revoke the token
+        RestTemplate revokeTemplate = new RestTemplate();
+        MultiValueMap<String, String> revokeParams = new LinkedMultiValueMap<>();
+        revokeParams.add("client_id", CLIENT_ID);
+        revokeParams.add("client_secret", CLIENT_SECRET);
+        revokeParams.add("token", tokens.accessToken);
+        revokeParams.add("token_type_hint", "access_token");
+
+        HttpHeaders revokeHeaders = new HttpHeaders();
+        revokeHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        revokeTemplate.exchange(
+                configuration.getRevokeEndpoint(),
+                HttpMethod.POST,
+                new HttpEntity<>(revokeParams, revokeHeaders),
+                String.class);
+
+        // Use introspection strategy which checks token validity server-side
+        String authServerUrl = keycloak.getAuthServerUrl();
+        if (!authServerUrl.endsWith("/")) {
+            authServerUrl += "/";
+        }
+        configuration.setIntrospectionEndpoint(
+                authServerUrl + "realms/" + REALM + "/protocol/openid-connect/token/introspect");
+        configuration.setBearerTokenStrategy("introspection");
+        recreateFilter();
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(authentication, "Revoked token should not authenticate via introspection");
+    }
+
+    @Test
+    public void testDelegateRefreshUpdatesCache() throws IOException, ServletException {
+        // Step 1: Authenticate via bearer token to populate the cache
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        MockHttpServletRequest authRequest = createRequest("rest/resources");
+        authRequest.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse authResponse = new MockHttpServletResponse();
+        filter.doFilter(authRequest, authResponse, new MockFilterChain());
+
+        assertEquals(200, authResponse.getStatus());
+        Authentication originalAuth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(originalAuth, "Initial bearer auth should succeed");
+        assertNotNull(
+                cache.get(tokens.accessToken),
+                "Original access token should be in cache after auth");
+
+        // Step 2: Set up request context for the refresh call
+        MockHttpServletRequest refreshRequest = createRequest("rest/session/refreshToken");
+        MockHttpServletResponse refreshResponse = new MockHttpServletResponse();
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(refreshRequest, refreshResponse));
+
+        // Step 3: Create the delegate that uses the test's real configuration and cache.
+        // The Spring Security 7 delegate performs the refresh through createRefreshRestTemplate()
+        // (a plain RestTemplate posting to configuration.getAccessTokenUri()), so no
+        // OAuth2RestTemplate
+        // override is needed any more — only the configuration/cache/request/response hooks.
+        OAuth2SessionServiceDelegate delegate =
+                new OAuth2SessionServiceDelegate(null, null) {
+                    @Override
+                    protected OAuth2Configuration configuration() {
+                        return configuration;
+                    }
+
+                    @Override
+                    protected TokenAuthenticationCache cache() {
+                        return cache;
+                    }
+
+                    @Override
+                    protected HttpServletRequest getRequest() {
+                        return refreshRequest;
+                    }
+
+                    @Override
+                    protected HttpServletResponse getResponse() {
+                        return refreshResponse;
+                    }
+                };
+
+        // Step 4: Call the real refresh path
+        SessionToken sessionToken = delegate.refresh(tokens.refreshToken, tokens.accessToken);
+
+        // Step 5: Verify the refresh succeeded and cache was updated
+        assertNotNull(sessionToken, "Delegate refresh should return a SessionToken");
+        assertNotNull(sessionToken.getAccessToken(), "New access token should be present");
+        assertNotEquals(
+                tokens.accessToken,
+                sessionToken.getAccessToken(),
+                "Access token should differ after refresh");
+        assertTrue(
+                sessionToken.getExpires() > System.currentTimeMillis(),
+                "New token expiration should be in the future");
+
+        // Old token should be evicted from cache, new token should be present
+        assertNull(
+                cache.get(tokens.accessToken),
+                "Old access token should be removed from cache after refresh");
+        Authentication refreshedAuth = cache.get(sessionToken.getAccessToken());
+        assertNotNull(refreshedAuth, "New access token should be present in cache after refresh");
+
+        // Verify the cached authentication has valid TokenDetails
+        TokenDetails refreshedDetails = OAuth2Utils.getTokenDetails(refreshedAuth);
+        assertNotNull(refreshedDetails, "Refreshed auth should have TokenDetails");
+        assertNotNull(
+                refreshedDetails.getAccessToken(),
+                "TokenDetails should contain the new OAuth2AccessToken");
+        assertEquals(
+                sessionToken.getAccessToken(),
+                refreshedDetails.getAccessToken().getTokenValue(),
+                "TokenDetails access token should match the SessionToken");
+        assertNotNull(refreshedDetails.getProvider(), "TokenDetails should have a provider set");
+
+        // Step 6: Verify the new token can authenticate through the filter
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest verifyRequest = createRequest("rest/resources");
+        verifyRequest.addHeader("Authorization", "Bearer " + sessionToken.getAccessToken());
+        MockHttpServletResponse verifyResponse = new MockHttpServletResponse();
+        filter.doFilter(verifyRequest, verifyResponse, new MockFilterChain());
+
+        assertEquals(200, verifyResponse.getStatus());
+        Authentication verifiedAuth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(verifiedAuth, "Refreshed token should authenticate via bearer");
+        User user = (User) verifiedAuth.getPrincipal();
+        assertEquals(
+                "testuser", user.getName(), "Username should be preserved after delegate refresh");
+    }
+
+    @Test
+    public void testDelegateRefreshSkippedWhenTokenStillValid()
+            throws IOException, ServletException {
+        // Enable skip-refresh (the production default)
+        configuration.setSkipRefreshIfTokenValid(true);
+        recreateFilter();
+
+        // Step 1: Authenticate via bearer token to populate the cache
+        KeycloakTokens tokens = obtainTokens("testuser", "testuser123");
+
+        MockHttpServletRequest authRequest = createRequest("rest/resources");
+        authRequest.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse authResponse = new MockHttpServletResponse();
+        filter.doFilter(authRequest, authResponse, new MockFilterChain());
+
+        assertEquals(200, authResponse.getStatus());
+        assertNotNull(
+                cache.get(tokens.accessToken),
+                "Original access token should be in cache after auth");
+
+        // Step 2: Set up request context for the refresh call
+        MockHttpServletRequest refreshRequest = createRequest("rest/session/refreshToken");
+        MockHttpServletResponse refreshResponse = new MockHttpServletResponse();
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(refreshRequest, refreshResponse));
+
+        // Step 3: Create the delegate
+        OAuth2SessionServiceDelegate delegate =
+                new OAuth2SessionServiceDelegate(null, null) {
+                    @Override
+                    protected OAuth2Configuration configuration() {
+                        return configuration;
+                    }
+
+                    @Override
+                    protected TokenAuthenticationCache cache() {
+                        return cache;
+                    }
+
+                    @Override
+                    protected HttpServletRequest getRequest() {
+                        return refreshRequest;
+                    }
+
+                    @Override
+                    protected HttpServletResponse getResponse() {
+                        return refreshResponse;
+                    }
+                };
+
+        // Step 4: Call refresh — token is fresh, so IDP refresh should be skipped
+        SessionToken sessionToken = delegate.refresh(tokens.refreshToken, tokens.accessToken);
+
+        // Step 5: Verify the same access token is returned (no IDP round-trip)
+        assertNotNull(sessionToken, "Delegate refresh should return a SessionToken");
+        assertEquals(
+                tokens.accessToken,
+                sessionToken.getAccessToken(),
+                "Access token should be unchanged when refresh is skipped");
+        assertNotNull(sessionToken.getWarning(), "A skip warning should be set");
+        assertTrue(
+                sessionToken.getWarning().contains("Token still valid"),
+                "Warning should indicate refresh was skipped");
+
+        // Step 6: Original token should still be in cache and still authenticate
+        assertNotNull(
+                cache.get(tokens.accessToken), "Original access token should remain in cache");
+
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest verifyRequest = createRequest("rest/resources");
+        verifyRequest.addHeader("Authorization", "Bearer " + tokens.accessToken);
+        MockHttpServletResponse verifyResponse = new MockHttpServletResponse();
+        filter.doFilter(verifyRequest, verifyResponse, new MockFilterChain());
+
+        assertEquals(200, verifyResponse.getStatus());
+        Authentication verifiedAuth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(
+                verifiedAuth, "Original token should still authenticate after skipped refresh");
+        User user = (User) verifiedAuth.getPrincipal();
+        assertEquals(
+                "testuser", user.getName(), "Username should be preserved after skipped refresh");
+    }
+
+    private static class KeycloakTokens {
+        final String accessToken;
+        final String refreshToken;
+        final String idToken;
+
+        KeycloakTokens(String accessToken, String refreshToken, String idToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+            this.idToken = idToken;
+        }
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/MultiProviderIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/MultiProviderIntegrationTest.java
@@ -1,0 +1,617 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.enums.Role;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.AudienceAccessTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.JwksRsaKeyProvider;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.MultiTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.SubjectTokenValidator;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Integration test for the multi-provider OIDC support. Verifies that:
+ *
+ * <ul>
+ *   <li>Bearer tokens from provider A authenticate via A's configuration
+ *   <li>Bearer tokens from provider B authenticate via B's configuration
+ *   <li>Cross-provider isolation: A's token is rejected by B (wrong audience/key)
+ *   <li>The {@link CompositeOpenIdConnectFilter} correctly routes bearer tokens to the right
+ *       provider
+ * </ul>
+ *
+ * <p>Spring Security 7 port: each per-provider filter is now built from an {@link
+ * OpenIdConnectAuthenticationService} (with {@code null} user/group services, so the principal is
+ * materialized from token claims) + a thin {@link OpenIdConnectFilter} + an {@link
+ * OpenIdConnectRestClient}, replacing the legacy 6-arg constructor / {@code
+ * GeoStoreOAuthRestTemplate}.
+ */
+public class MultiProviderIntegrationTest {
+
+    // Provider A constants
+    private static final String PROVIDER_A_NAME = "oidc";
+    private static final String PROVIDER_A_CLIENT_ID = "client-id-provider-a";
+    private static final String PROVIDER_A_CLIENT_SECRET = "secret-a";
+    private static final String PROVIDER_A_KID = "key-provider-a";
+
+    // Provider B constants
+    private static final String PROVIDER_B_NAME = "google";
+    private static final String PROVIDER_B_CLIENT_ID = "client-id-provider-b";
+    private static final String PROVIDER_B_CLIENT_SECRET = "secret-b";
+    private static final String PROVIDER_B_KID = "key-provider-b";
+
+    // RSA keys per provider
+    private static RSAPublicKey rsaPublicKeyA;
+    private static RSAPrivateKey rsaPrivateKeyA;
+    private static Algorithm rsaAlgorithmA;
+
+    private static RSAPublicKey rsaPublicKeyB;
+    private static RSAPrivateKey rsaPrivateKeyB;
+    private static Algorithm rsaAlgorithmB;
+
+    // WireMock servers (one per provider to simulate separate IdPs)
+    private static WireMockServer wireMockA;
+    private static WireMockServer wireMockB;
+
+    private OpenIdConnectFilter filterA;
+    private OpenIdConnectFilter filterB;
+    private OpenIdConnectConfiguration configA;
+    private OpenIdConnectConfiguration configB;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        // Generate separate RSA key pairs for each provider
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+
+        KeyPair keyPairA = keyGen.generateKeyPair();
+        rsaPublicKeyA = (RSAPublicKey) keyPairA.getPublic();
+        rsaPrivateKeyA = (RSAPrivateKey) keyPairA.getPrivate();
+        rsaAlgorithmA = Algorithm.RSA256(rsaPublicKeyA, rsaPrivateKeyA);
+
+        KeyPair keyPairB = keyGen.generateKeyPair();
+        rsaPublicKeyB = (RSAPublicKey) keyPairB.getPublic();
+        rsaPrivateKeyB = (RSAPrivateKey) keyPairB.getPrivate();
+        rsaAlgorithmB = Algorithm.RSA256(rsaPublicKeyB, rsaPrivateKeyB);
+
+        // Start WireMock for provider A
+        wireMockA = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMockA.start();
+
+        wireMockA.stubFor(
+                WireMock.get(urlEqualTo("/certs"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(buildJwksJson(rsaPublicKeyA, PROVIDER_A_KID))));
+        wireMockA.stubFor(
+                any(urlPathEqualTo("/userinfo"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"email\":\"alice@provider-a.com\","
+                                                        + "\"sub\":\"alice-sub-a\"}")));
+
+        // Start WireMock for provider B
+        wireMockB = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMockB.start();
+
+        wireMockB.stubFor(
+                WireMock.get(urlEqualTo("/certs"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(buildJwksJson(rsaPublicKeyB, PROVIDER_B_KID))));
+        wireMockB.stubFor(
+                any(urlPathEqualTo("/userinfo"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"email\":\"bob@provider-b.com\","
+                                                        + "\"sub\":\"bob-sub-b\"}")));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (wireMockA != null) wireMockA.stop();
+        if (wireMockB != null) wireMockB.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        String baseA = "http://localhost:" + wireMockA.port();
+        String baseB = "http://localhost:" + wireMockB.port();
+
+        // Configure provider A
+        configA = new OpenIdConnectConfiguration();
+        configA.setClientId(PROVIDER_A_CLIENT_ID);
+        configA.setClientSecret(PROVIDER_A_CLIENT_SECRET);
+        configA.setAccessTokenUri(baseA + "/token");
+        configA.setAuthorizationUri(baseA + "/authorize");
+        configA.setCheckTokenEndpointUrl(baseA + "/userinfo");
+        configA.setIdTokenUri(baseA + "/certs");
+        configA.setEnabled(true);
+        configA.setAutoCreateUser(true);
+        configA.setAllowBearerTokens(true);
+        configA.setBeanName(PROVIDER_A_NAME + "OAuth2Config");
+        configA.setScopes("openId,email");
+        configA.setRedirectUri("../../../geostore/rest/users/user/details");
+
+        // Configure provider B
+        configB = new OpenIdConnectConfiguration();
+        configB.setClientId(PROVIDER_B_CLIENT_ID);
+        configB.setClientSecret(PROVIDER_B_CLIENT_SECRET);
+        configB.setAccessTokenUri(baseB + "/token");
+        configB.setAuthorizationUri(baseB + "/authorize");
+        configB.setCheckTokenEndpointUrl(baseB + "/userinfo");
+        configB.setIdTokenUri(baseB + "/certs");
+        configB.setEnabled(true);
+        configB.setAutoCreateUser(true);
+        configB.setAllowBearerTokens(true);
+        configB.setBeanName(PROVIDER_B_NAME + "OAuth2Config");
+        configB.setScopes("openId,email");
+        configB.setRedirectUri("../../../geostore/rest/users/user/details");
+
+        // Build filters
+        filterA = buildFilter(configA, baseA + "/certs");
+        filterB = buildFilter(configB, baseB + "/certs");
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    public void testProviderAAcceptsOwnBearerToken() throws IOException, ServletException {
+        String jwt =
+                createSignedJwt(
+                        "alice@provider-a.com",
+                        "alice-sub",
+                        PROVIDER_A_CLIENT_ID,
+                        PROVIDER_A_KID,
+                        rsaAlgorithmA);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filterA.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Provider A should accept its own bearer token");
+        User user = (User) auth.getPrincipal();
+        assertEquals("alice@provider-a.com", user.getName());
+    }
+
+    @Test
+    public void testProviderBAcceptsOwnBearerToken() throws IOException, ServletException {
+        String jwt =
+                createSignedJwt(
+                        "bob@provider-b.com",
+                        "bob-sub",
+                        PROVIDER_B_CLIENT_ID,
+                        PROVIDER_B_KID,
+                        rsaAlgorithmB);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filterB.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Provider B should accept its own bearer token");
+        User user = (User) auth.getPrincipal();
+        assertEquals("bob@provider-b.com", user.getName());
+    }
+
+    @Test
+    public void testProviderARejectsProviderBToken() throws IOException, ServletException {
+        // Token signed with B's key and B's audience — should be rejected by A
+        String jwtForB =
+                createSignedJwt(
+                        "bob@provider-b.com",
+                        "bob-sub",
+                        PROVIDER_B_CLIENT_ID,
+                        PROVIDER_B_KID,
+                        rsaAlgorithmB);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwtForB);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // Filter A should reject: wrong key (kid not in A's JWKS) and wrong audience
+        try {
+            filterA.doFilter(request, response, new MockFilterChain());
+        } catch (Exception e) {
+            // Expected: signature verification or audience validation failure
+        }
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(auth, "Provider A should reject a token signed for provider B");
+    }
+
+    @Test
+    public void testProviderBRejectsProviderAToken() throws IOException, ServletException {
+        // Token signed with A's key and A's audience — should be rejected by B
+        String jwtForA =
+                createSignedJwt(
+                        "alice@provider-a.com",
+                        "alice-sub",
+                        PROVIDER_A_CLIENT_ID,
+                        PROVIDER_A_KID,
+                        rsaAlgorithmA);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwtForA);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        try {
+            filterB.doFilter(request, response, new MockFilterChain());
+        } catch (Exception e) {
+            // Expected: signature verification or audience validation failure
+        }
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(auth, "Provider B should reject a token signed for provider A");
+    }
+
+    @Test
+    public void testCrossProviderAudienceIsolation() throws IOException, ServletException {
+        // Token signed with A's key but with B's audience
+        String jwt =
+                createSignedJwt(
+                        "alice@provider-a.com",
+                        "alice-sub",
+                        PROVIDER_B_CLIENT_ID,
+                        PROVIDER_A_KID,
+                        rsaAlgorithmA);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        try {
+            filterA.doFilter(request, response, new MockFilterChain());
+        } catch (Exception e) {
+            // Expected: audience validation failure
+        }
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(auth, "Provider A should reject a token with provider B's audience");
+    }
+
+    @Test
+    public void testCompositeFilterRoutesBearerToCorrectProvider() throws Exception {
+        // Set up a CompositeOpenIdConnectFilter with both providers
+        CompositeOpenIdConnectFilter composite = new CompositeOpenIdConnectFilter();
+        composite.setApplicationContext(
+                createMockApplicationContext(
+                        Map.of(
+                                PROVIDER_A_NAME + "OAuth2Config", configA,
+                                PROVIDER_B_NAME + "OAuth2Config", configB)));
+        composite.afterPropertiesSet();
+
+        // Verify both providers were initialized
+        assertEquals(2, composite.getProviderFilters().size());
+        assertTrue(composite.getProviderFilters().containsKey(PROVIDER_A_NAME));
+        assertTrue(composite.getProviderFilters().containsKey(PROVIDER_B_NAME));
+
+        // Send a bearer token valid for provider A
+        String jwtA =
+                createSignedJwt(
+                        "alice@provider-a.com",
+                        "alice-sub",
+                        PROVIDER_A_CLIENT_ID,
+                        PROVIDER_A_KID,
+                        rsaAlgorithmA);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwtA);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        composite.doFilter(request, response, new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Composite filter should authenticate via provider A");
+        User user = (User) auth.getPrincipal();
+        assertEquals("alice@provider-a.com", user.getName());
+    }
+
+    @Test
+    public void testCompositeFilterRoutesBearerToSecondProvider() throws Exception {
+        CompositeOpenIdConnectFilter composite = new CompositeOpenIdConnectFilter();
+        composite.setApplicationContext(
+                createMockApplicationContext(
+                        Map.of(
+                                PROVIDER_A_NAME + "OAuth2Config", configA,
+                                PROVIDER_B_NAME + "OAuth2Config", configB)));
+        composite.afterPropertiesSet();
+
+        // Send a bearer token valid only for provider B
+        String jwtB =
+                createSignedJwt(
+                        "bob@provider-b.com",
+                        "bob-sub",
+                        PROVIDER_B_CLIENT_ID,
+                        PROVIDER_B_KID,
+                        rsaAlgorithmB);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwtB);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        composite.doFilter(request, response, new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Composite filter should authenticate via provider B");
+        User user = (User) auth.getPrincipal();
+        assertEquals("bob@provider-b.com", user.getName());
+    }
+
+    @Test
+    public void testCompositeFilterRejectsInvalidBearerToken() throws Exception {
+        CompositeOpenIdConnectFilter composite = new CompositeOpenIdConnectFilter();
+        composite.setApplicationContext(
+                createMockApplicationContext(
+                        Map.of(
+                                PROVIDER_A_NAME + "OAuth2Config", configA,
+                                PROVIDER_B_NAME + "OAuth2Config", configB)));
+        composite.afterPropertiesSet();
+
+        // Send a token with unknown audience — neither provider should accept
+        String badJwt =
+                createSignedJwt(
+                        "nobody@nowhere.com",
+                        "bad-sub",
+                        "unknown-client-id",
+                        PROVIDER_A_KID,
+                        rsaAlgorithmA);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + badJwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        composite.doFilter(request, response, new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(auth, "Composite filter should reject token not valid for any provider");
+    }
+
+    @Test
+    public void testCompositeFilterSkipsDisabledProvider() throws Exception {
+        // Disable provider B
+        configB.setEnabled(false);
+
+        CompositeOpenIdConnectFilter composite = new CompositeOpenIdConnectFilter();
+        composite.setApplicationContext(
+                createMockApplicationContext(
+                        Map.of(
+                                PROVIDER_A_NAME + "OAuth2Config", configA,
+                                PROVIDER_B_NAME + "OAuth2Config", configB)));
+        composite.afterPropertiesSet();
+
+        // Only provider A should be initialized
+        assertEquals(1, composite.getProviderFilters().size());
+        assertTrue(composite.getProviderFilters().containsKey(PROVIDER_A_NAME));
+        assertFalse(composite.getProviderFilters().containsKey(PROVIDER_B_NAME));
+
+        // Re-enable for other tests
+        configB.setEnabled(true);
+    }
+
+    @Test
+    public void testCompositeFilterPassesThroughWithoutBearer() throws Exception {
+        CompositeOpenIdConnectFilter composite = new CompositeOpenIdConnectFilter();
+        composite.setApplicationContext(
+                createMockApplicationContext(Map.of(PROVIDER_A_NAME + "OAuth2Config", configA)));
+        composite.afterPropertiesSet();
+
+        // Request with no bearer token and not a login/callback URL
+        MockHttpServletRequest request = createRequest("rest/resources");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        composite.doFilter(request, response, chain);
+
+        // Should have passed through to the chain (via the first provider's filter)
+        // No authentication should be set since there was no token
+        // The important thing is no exception was thrown
+    }
+
+    @Test
+    public void testProviderSpecificRolesAndGroups() throws IOException, ServletException {
+        configA.setRolesClaim("roles");
+        configA.setGroupsClaim("groups");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(PROVIDER_A_KID)
+                        .withIssuer("https://provider-a.example.com/")
+                        .withAudience(PROVIDER_A_CLIENT_ID)
+                        .withSubject("admin-sub")
+                        .withClaim("email", "admin@provider-a.com")
+                        .withArrayClaim("roles", new String[] {"ADMIN"})
+                        .withArrayClaim("groups", new String[] {"team-alpha", "team-beta"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithmA);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filterA.doFilter(request, response, new MockFilterChain());
+
+        assertEquals(200, response.getStatus());
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Should authenticate with roles and groups");
+        User user = (User) auth.getPrincipal();
+        assertEquals("admin@provider-a.com", user.getName());
+        assertEquals(Role.ADMIN, user.getRole());
+        assertNotNull(user.getGroups());
+        Set<String> groupNames = new HashSet<>();
+        user.getGroups().forEach(g -> groupNames.add(g.getGroupName()));
+        assertTrue(groupNames.contains("team-alpha"));
+        assertTrue(groupNames.contains("team-beta"));
+    }
+
+    // ---- Helper methods ----
+
+    /**
+     * Builds a per-provider OIDC filter on the Spring Security 7 service-based architecture:
+     * OpenIdConnectRestClient (token exchange/refresh) + OpenIdConnectAuthenticationService (built
+     * with null user/group services so the principal is materialized from token claims) + a thin
+     * OpenIdConnectFilter. Replaces the legacy 6-arg constructor / GeoStoreOAuthRestTemplate.
+     */
+    private OpenIdConnectFilter buildFilter(OpenIdConnectConfiguration config, String jwksUri) {
+        OpenIdConnectRestClient restClient = new OpenIdConnectRestClient(config);
+        JwksRsaKeyProvider jwksKeyProvider = new JwksRsaKeyProvider(jwksUri);
+        TokenAuthenticationCache cache =
+                new TokenAuthenticationCache(
+                        config.getCacheSize(), config.getCacheExpirationMinutes());
+        MultiTokenValidator validator =
+                new MultiTokenValidator(
+                        Arrays.asList(
+                                new AudienceAccessTokenValidator(), new SubjectTokenValidator()));
+        OpenIdConnectAuthenticationService service =
+                new OpenIdConnectAuthenticationService(
+                        cache, null, null, config, validator, jwksKeyProvider);
+        return new OpenIdConnectFilter(config, service, restClient);
+    }
+
+    private String createSignedJwt(
+            String email, String sub, String aud, String kid, Algorithm algorithm) {
+        long now = System.currentTimeMillis() / 1000;
+        return JWT.create()
+                .withKeyId(kid)
+                .withIssuer("https://test.issuer/")
+                .withAudience(aud)
+                .withSubject(sub)
+                .withClaim("email", email)
+                .withIssuedAt(new Date(now * 1000))
+                .withExpiresAt(new Date((now + 3600) * 1000))
+                .sign(algorithm);
+    }
+
+    private static String buildJwksJson(RSAPublicKey publicKey, String kid) {
+        java.util.Base64.Encoder encoder = java.util.Base64.getUrlEncoder().withoutPadding();
+        String n = encoder.encodeToString(publicKey.getModulus().toByteArray());
+        String e = encoder.encodeToString(publicKey.getPublicExponent().toByteArray());
+        return "{\"keys\":[{"
+                + "\"kty\":\"RSA\","
+                + "\"use\":\"sig\","
+                + "\"alg\":\"RS256\","
+                + "\"kid\":\""
+                + kid
+                + "\","
+                + "\"n\":\""
+                + n
+                + "\","
+                + "\"e\":\""
+                + e
+                + "\""
+                + "}]}";
+    }
+
+    private MockHttpServletRequest createRequest(String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        request.setContextPath("/geostore");
+        request.setRequestURI("/geostore/" + path);
+        request.setRemoteAddr("127.0.0.1");
+        request.setServletPath("/geostore");
+        request.setPathInfo(path);
+        request.addHeader("Host", "localhost:8080");
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attributes);
+        return request;
+    }
+
+    /**
+     * Creates a StaticApplicationContext pre-loaded with the given OpenIdConnectConfiguration
+     * beans.
+     */
+    private ApplicationContext createMockApplicationContext(
+            Map<String, OpenIdConnectConfiguration> configs) {
+        StaticApplicationContext ctx = new StaticApplicationContext();
+        for (Map.Entry<String, OpenIdConnectConfiguration> e : configs.entrySet()) {
+            ctx.getBeanFactory().registerSingleton(e.getKey(), e.getValue());
+        }
+        ctx.refresh();
+        return ctx;
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectIntegrationTest.java
@@ -1,0 +1,3272 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.RSAEncrypter;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import it.geosolutions.geostore.core.model.User;
+import it.geosolutions.geostore.core.model.UserGroup;
+import it.geosolutions.geostore.core.model.enums.Role;
+import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.AudienceAccessTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.JwksRsaKeyProvider;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.MultiTokenValidator;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer.SubjectTokenValidator;
+import it.geosolutions.geostore.services.rest.utils.MockedUserService;
+import jakarta.servlet.ServletException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class OpenIdConnectIntegrationTest {
+
+    private static final String CLIENT_ID = "kbyuFDidLLm280LIwVFiazOqjO3ty8KH";
+    private static final String CLIENT_SECRET =
+            "60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa";
+    private static final String CODE = "R-2CqM7H1agwc7Cx";
+    private static final String TEST_KID = "test-key-1";
+
+    private static WireMockServer openIdConnectService;
+    private static RSAPublicKey rsaPublicKey;
+    private static RSAPrivateKey rsaPrivateKey;
+    private static Algorithm rsaAlgorithm;
+
+    private String authService;
+    private OpenIdConnectFilter filter;
+    private OpenIdConnectConfiguration configuration;
+    private TokenAuthenticationCache cache;
+    private OpenIdConnectAuthenticationService service;
+
+    @BeforeAll
+    static void beforeClass() throws Exception {
+        // Generate RSA key pair for signing test JWTs
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+        rsaPublicKey = (RSAPublicKey) keyPair.getPublic();
+        rsaPrivateKey = (RSAPrivateKey) keyPair.getPrivate();
+        rsaAlgorithm = Algorithm.RSA256(rsaPublicKey, rsaPrivateKey);
+
+        // Build JWKS JSON from the generated public key
+        String jwksJson = buildJwksJson(rsaPublicKey, TEST_KID);
+
+        // Build a properly signed id_token matching the userinfo.json test data.
+        // Bearer JWT validation (OpenIdConnectAuthenticationService + JwksRsaKeyProvider) verifies
+        // the signature against the JWKS endpoint, so this must be signed with our test key.
+        long now = System.currentTimeMillis() / 1000;
+        String idToken =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("100301874944276879963462152")
+                        .withClaim("email", "ritter@erdukunde.de")
+                        .withClaim("email_verified", true)
+                        .withClaim("name", "Karl Ritter")
+                        .withClaim("hd", "geosolutionsgroup.com")
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 86400) * 1000))
+                        .sign(rsaAlgorithm);
+
+        String tokenResponseJson =
+                "{\"access_token\":\"CPURR33RUz-gGhjwODTd9zXo5JkQx4wS\","
+                        + "\"id_token\":\""
+                        + idToken
+                        + "\","
+                        + "\"scope\":\"openid profile email phone address\","
+                        + "\"expires_in\":86400,"
+                        + "\"token_type\":\"Bearer\"}";
+
+        openIdConnectService =
+                new WireMockServer(
+                        wireMockConfig()
+                                .dynamicPort()
+                                // uncomment the following to get wiremock logging
+                                .notifier(new ConsoleNotifier(true)));
+        openIdConnectService.start();
+
+        openIdConnectService.stubFor(
+                WireMock.get(urlEqualTo("/certs"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(jwksJson)));
+
+        openIdConnectService.stubFor(
+                WireMock.post(urlPathEqualTo("/token"))
+                        .withRequestBody(containing("grant_type=authorization_code"))
+                        .withRequestBody(containing("client_id=" + CLIENT_ID))
+                        .withRequestBody(containing("code=" + CODE))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(tokenResponseJson)));
+        openIdConnectService.stubFor(
+                any(urlPathEqualTo("/userinfo"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBodyFile(
+                                                "userinfo.json"))); // disallow query parameters
+
+        // Microsoft Graph API stubs
+        openIdConnectService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph/me/memberOf"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"GIS Analysts\",\"id\":\"g1\"},"
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"Map Editors\",\"id\":\"g2\"},"
+                                                        + "{\"@odata.type\":\"#microsoft.graph.servicePrincipal\","
+                                                        + "\"displayName\":\"Some SP\",\"id\":\"sp1\"}"
+                                                        + "]}")));
+        openIdConnectService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph/me/appRoleAssignments"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"appRoleId\":\"role-guid-001\","
+                                                        + "\"resourceId\":\"sp-guid-001\"},"
+                                                        + "{\"appRoleId\":\"role-guid-002\","
+                                                        + "\"resourceId\":\"sp-guid-001\"}"
+                                                        + "]}")));
+        openIdConnectService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph/servicePrincipals/sp-guid-001/appRoles"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"id\":\"role-guid-001\","
+                                                        + "\"value\":\"Admin\","
+                                                        + "\"displayName\":\"Administrator\"},"
+                                                        + "{\"id\":\"role-guid-002\","
+                                                        + "\"value\":\"Viewer\","
+                                                        + "\"displayName\":\"Viewer\"}"
+                                                        + "]}")));
+    }
+
+    @BeforeEach
+    void before() {
+        // prepare mock server base path
+        authService = "http://localhost:" + openIdConnectService.port();
+        OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
+        configuration.setClientId(CLIENT_ID);
+        configuration.setClientSecret(CLIENT_SECRET);
+        configuration.setRevokeEndpoint(authService + "/revoke");
+        configuration.setAccessTokenUri(authService + "/token");
+        configuration.setAuthorizationUri(authService + "/authorize");
+        configuration.setCheckTokenEndpointUrl(authService + "/userinfo");
+        configuration.setEnabled(true);
+        configuration.setAutoCreateUser(true);
+        configuration.setIdTokenUri(authService + "/certs");
+        configuration.setBeanName("oidcOAuth2Config");
+        configuration.setEnableRedirectEntryPoint(true);
+        configuration.setRedirectUri("../../../geostore/rest/users/user/details");
+        configuration.setScopes("openId,email");
+        configuration.setSendClientSecret(true);
+        this.configuration = configuration;
+        OpenIdConnectRestClient restClient = new OpenIdConnectRestClient(configuration);
+        JwksRsaKeyProvider jwksKeyProvider = new JwksRsaKeyProvider(authService + "/certs");
+        this.cache =
+                new TokenAuthenticationCache(
+                        configuration.getCacheSize(), configuration.getCacheExpirationMinutes());
+        MultiTokenValidator validator =
+                new MultiTokenValidator(
+                        java.util.Arrays.asList(
+                                new AudienceAccessTokenValidator(), new SubjectTokenValidator()));
+        this.service =
+                new OpenIdConnectAuthenticationService(
+                        this.cache, null, null, configuration, validator, jwksKeyProvider);
+        this.filter = new OpenIdConnectFilter(configuration, this.service, restClient);
+    }
+
+    @AfterEach
+    void afterTest() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    public void testRedirect() throws IOException, ServletException {
+        MockHttpServletRequest request = createRequest("oidc/login");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        // SS7 port: the interactive login redirect is owned by the configuration's authentication
+        // entry point (invoked by the IdPLoginRest CXF endpoint), not the bearer filter.
+        configuration.getAuthenticationEntryPoint().commence(request, response, null);
+        assertEquals(302, response.getStatus());
+        assertEquals(response.getRedirectedUrl(), configuration.buildLoginUri());
+    }
+
+    @Test
+    public void testAuthentication() throws IOException, ServletException {
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        assertEquals("ritter@erdukunde.de", user.getName());
+        assertEquals(Role.USER, user.getRole());
+    }
+
+    @Test
+    public void testGroupsAndRolesFromToken() throws IOException, ServletException {
+        configuration.setGroupsClaim("hd");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("code", CODE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        assertEquals("ritter@erdukunde.de", user.getName());
+        assertEquals(Role.USER, user.getRole());
+        UserGroup group = user.getGroups().stream().findAny().get();
+        assertEquals("geosolutionsgroup.com", group.getGroupName());
+    }
+
+    @Test
+    public void testBearerTokenAuthentication() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+
+        // Build a properly signed JWT bearer token
+        String jwt = createSignedJwt("ritter@erdukunde.de", "test-sub-123", CLIENT_ID);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token should produce an authenticated user");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("ritter@erdukunde.de", user.getName());
+        assertEquals(Role.USER, user.getRole());
+    }
+
+    @Test
+    public void testBearerTokenDisallowed() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(false);
+
+        String jwt = createSignedJwt("ritter@erdukunde.de", "test-sub-123", CLIENT_ID);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(
+                authentication,
+                "Bearer token should not authenticate when bearer tokens are disallowed");
+    }
+
+    @Test
+    public void testBearerTokenWithPrincipalKey() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setPrincipalKey("preferred_username");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-456")
+                        .withClaim("preferred_username", "karl.ritter")
+                        .withClaim("email", "ritter@erdukunde.de")
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication);
+        User user = (User) authentication.getPrincipal();
+        // principalKey is "preferred_username", so it should use that claim
+        assertEquals("karl.ritter", user.getName());
+    }
+
+    @Test
+    public void testBearerTokenRolesAndGroups() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        configuration.setGroupsClaim("groups");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-789")
+                        .withClaim("email", "admin@example.com")
+                        .withArrayClaim("roles", new String[] {"ADMIN"})
+                        .withArrayClaim("groups", new String[] {"analysts", "editors"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token with roles/groups should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("admin@example.com", user.getName());
+        assertEquals(Role.ADMIN, user.getRole());
+
+        // Verify groups were extracted from the bearer token claims
+        assertNotNull(user.getGroups(), "Groups should be populated from bearer token");
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("analysts"), "Should have 'analysts' group");
+        assertTrue(groupNames.contains("editors"), "Should have 'editors' group");
+    }
+
+    @Test
+    public void testBearerTokenExpired() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-expired")
+                        .withClaim("email", "expired@example.com")
+                        .withIssuedAt(new Date((now - 7200) * 1000))
+                        .withExpiresAt(new Date((now - 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(authentication, "Expired bearer token should not authenticate");
+    }
+
+    @Test
+    public void testBearerTokenWrongAudience() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+
+        // JWT signed with correct key but wrong audience
+        String jwt = createSignedJwt("ritter@erdukunde.de", "test-sub-aud", "wrong-client-id");
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(authentication, "Bearer token with wrong audience should not authenticate");
+    }
+
+    @Test
+    public void testBearerTokenMalformed() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer not-a-valid-jwt");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(authentication, "Malformed bearer token should not authenticate");
+    }
+
+    @Test
+    public void testBearerTokenBadSignature() throws Exception {
+        configuration.setAllowBearerTokens(true);
+
+        // Generate a different RSA key pair and sign with it
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair wrongKeyPair = keyGen.generateKeyPair();
+        Algorithm wrongAlgorithm =
+                Algorithm.RSA256(
+                        (RSAPublicKey) wrongKeyPair.getPublic(),
+                        (RSAPrivateKey) wrongKeyPair.getPrivate());
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-bad-sig")
+                        .withClaim("email", "ritter@erdukunde.de")
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(wrongAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(authentication, "Bearer token signed with wrong key should not authenticate");
+    }
+
+    @Test
+    public void testRoleMappings() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        configuration.setRoleMappings("idp_admin:ADMIN,idp_viewer:GUEST");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-role-map")
+                        .withClaim("email", "mapped@example.com")
+                        .withArrayClaim("roles", new String[] {"idp_admin"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Role-mapped bearer token should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals(Role.ADMIN, user.getRole(), "idp_admin should map to ADMIN");
+    }
+
+    @Test
+    public void testGroupMappings() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("groups");
+        configuration.setGroupMappings("devs:developers,ops:operations");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-group-map")
+                        .withClaim("email", "groupmap@example.com")
+                        .withArrayClaim("groups", new String[] {"devs", "ops"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication);
+        User user = (User) authentication.getPrincipal();
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("developers"), "devs should map to developers");
+        assertTrue(groupNames.contains("operations"), "ops should map to operations");
+    }
+
+    @Test
+    public void testDropUnmapped() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("groups");
+        configuration.setGroupMappings("devs:developers");
+        configuration.setDropUnmapped(true);
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-drop")
+                        .withClaim("email", "drop@example.com")
+                        .withArrayClaim("groups", new String[] {"devs", "unmapped_group"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication);
+        User user = (User) authentication.getPrincipal();
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("developers"), "devs should map to developers");
+        assertFalse(
+                groupNames.contains("unmapped_group"),
+                "unmapped_group should be dropped when dropUnmapped=true");
+    }
+
+    @Test
+    public void testPkceAuthorizationUrl() {
+        configuration.setUsePKCE(true);
+
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.getSession(true); // ensure session exists
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(
+                () ->
+                        configuration
+                                .getAuthenticationEntryPoint()
+                                .commence(request, response, null));
+
+        assertEquals(302, response.getStatus());
+        String redirectUrl = response.getRedirectedUrl();
+        assertNotNull(redirectUrl, "Redirect URL should not be null");
+        assertTrue(
+                redirectUrl.contains("code_challenge="),
+                "PKCE redirect URL should contain code_challenge");
+        assertTrue(
+                redirectUrl.contains("code_challenge_method=S256"),
+                "PKCE redirect URL should contain code_challenge_method=S256");
+
+        // Verify code_verifier was stored in session
+        String verifier =
+                (String)
+                        request.getSession()
+                                .getAttribute(
+                                        OpenIdConnectConfiguration.PKCE_CODE_VERIFIER_SESSION_ATTR);
+        assertNotNull(verifier, "PKCE code_verifier should be stored in session");
+        assertFalse(verifier.isEmpty(), "PKCE code_verifier should not be empty");
+    }
+
+    @Test
+    public void testArrayPrincipalClaim() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setPrincipalKey("emails");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-array")
+                        .withArrayClaim(
+                                "emails", new String[] {"first@example.com", "second@example.com"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Array claim bearer token should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals(
+                "first@example.com",
+                user.getName(),
+                "Should use first element of array-type principal claim");
+    }
+
+    @Test
+    public void testIatValidation() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setMaxTokenAgeSecs(60); // max 60 seconds old
+
+        long now = System.currentTimeMillis() / 1000;
+        // Token issued 2 hours ago
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-iat")
+                        .withClaim("email", "old@example.com")
+                        .withIssuedAt(new Date((now - 7200) * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(
+                authentication,
+                "Token with old iat should be rejected when maxTokenAgeSecs is set");
+    }
+
+    @Test
+    public void testCacheConfiguration() {
+        // Sanity check: parameterized constructor works and doesn't throw
+        TokenAuthenticationCache cache = new TokenAuthenticationCache(500, 120);
+        assertNotNull(cache);
+        assertNull(cache.get("non-existent-token"));
+
+        // Default constructor
+        TokenAuthenticationCache defaultCache = new TokenAuthenticationCache();
+        assertNotNull(defaultCache);
+    }
+
+    @Test
+    public void testBearerTokenIntrospection() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setBearerTokenStrategy("introspection");
+        configuration.setIntrospectionEndpoint(authService + "/introspect");
+
+        // Stub the introspection endpoint to return active=true with claims
+        openIdConnectService.stubFor(
+                WireMock.post(urlPathEqualTo("/introspect"))
+                        .withRequestBody(containing("token=opaque-test-token-12345"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"active\":true,\"sub\":\"test-sub-opaque\","
+                                                        + "\"email\":\"opaque@example.com\","
+                                                        + "\"preferred_username\":\"opaque_user\"}")));
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer opaque-test-token-12345");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Opaque bearer token should authenticate via introspection");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("opaque@example.com", user.getName());
+    }
+
+    @Test
+    public void testBearerTokenIntrospectionInactive() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setBearerTokenStrategy("introspection");
+        configuration.setIntrospectionEndpoint(authService + "/introspect");
+
+        // Stub the introspection endpoint to return active=false
+        openIdConnectService.stubFor(
+                WireMock.post(urlPathEqualTo("/introspect"))
+                        .withRequestBody(containing("token=revoked-token-99999"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody("{\"active\":false}")));
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer revoked-token-99999");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(authentication, "Inactive token should not authenticate via introspection");
+    }
+
+    @Test
+    public void testBearerTokenAutoStrategyJwtSuccess() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setBearerTokenStrategy("auto");
+        configuration.setIntrospectionEndpoint(authService + "/introspect");
+
+        // Build a valid signed JWT — auto strategy should succeed with JWT, no introspection needed
+        String jwt = createSignedJwt("auto-jwt@example.com", "test-sub-auto", CLIENT_ID);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Auto strategy should authenticate valid JWT");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("auto-jwt@example.com", user.getName());
+    }
+
+    @Test
+    public void testBearerTokenAutoStrategyFallbackToIntrospection()
+            throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setBearerTokenStrategy("auto");
+        configuration.setIntrospectionEndpoint(authService + "/introspect");
+
+        // Stub the introspection endpoint for the opaque token fallback
+        openIdConnectService.stubFor(
+                WireMock.post(urlPathEqualTo("/introspect"))
+                        .withRequestBody(containing("token=not-a-jwt-opaque-token"))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"active\":true,\"sub\":\"test-sub-fallback\","
+                                                        + "\"email\":\"fallback@example.com\"}")));
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer not-a-jwt-opaque-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(
+                authentication,
+                "Auto strategy should fall back to introspection for non-JWT tokens");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("fallback@example.com", user.getName());
+    }
+
+    @Test
+    public void testNestedClaimRoles() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        // Keycloak-style nested claim path
+        configuration.setRolesClaim("realm_access.roles");
+
+        long now = System.currentTimeMillis() / 1000;
+        // Build JWT with nested realm_access.roles claim (Keycloak format)
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-nested")
+                        .withClaim("email", "nested@example.com")
+                        .withClaim(
+                                "realm_access",
+                                java.util.Collections.singletonMap(
+                                        "roles", java.util.Arrays.asList("ADMIN", "user")))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Nested claim path should resolve roles");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("nested@example.com", user.getName());
+        assertEquals(
+                Role.ADMIN,
+                user.getRole(),
+                "realm_access.roles containing ADMIN should resolve to ADMIN role");
+    }
+
+    @Test
+    public void testNestedClaimGroups() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("resource_access.geostore.groups");
+
+        long now = System.currentTimeMillis() / 1000;
+        // Build JWT with deeply nested groups claim
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-nested-groups")
+                        .withClaim("email", "nested-groups@example.com")
+                        .withClaim(
+                                "resource_access",
+                                java.util.Collections.singletonMap(
+                                        "geostore",
+                                        java.util.Collections.singletonMap(
+                                                "groups",
+                                                java.util.Arrays.asList("analysts", "editors"))))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Nested claim path should resolve groups");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("nested-groups@example.com", user.getName());
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("analysts"), "Should have 'analysts' from nested path");
+        assertTrue(groupNames.contains("editors"), "Should have 'editors' from nested path");
+    }
+
+    @Test
+    public void testJsonPathRoles() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        // Explicit JsonPath expression for roles
+        configuration.setRolesClaim("$.realm_access.roles");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-jsonpath")
+                        .withClaim("email", "jsonpath@example.com")
+                        .withClaim(
+                                "realm_access",
+                                java.util.Collections.singletonMap(
+                                        "roles", java.util.Arrays.asList("ADMIN", "user")))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "JsonPath roles expression should resolve");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("jsonpath@example.com", user.getName());
+        assertEquals(
+                Role.ADMIN,
+                user.getRole(),
+                "$.realm_access.roles containing ADMIN should resolve to ADMIN role");
+    }
+
+    @Test
+    public void testJsonPathGroupsWithWildcard() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        // Wildcard JsonPath for groups across all resource_access entries
+        configuration.setGroupsClaim("$.resource_access.*.groups");
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> resourceAccess = new java.util.LinkedHashMap<>();
+        resourceAccess.put(
+                "app1",
+                java.util.Collections.singletonMap("groups", java.util.Arrays.asList("analysts")));
+        resourceAccess.put(
+                "app2",
+                java.util.Collections.singletonMap("groups", java.util.Arrays.asList("editors")));
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-wildcard")
+                        .withClaim("email", "wildcard@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Wildcard JsonPath should resolve groups");
+        User user = (User) authentication.getPrincipal();
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("analysts"), "Should have 'analysts' from wildcard path");
+        assertTrue(groupNames.contains("editors"), "Should have 'editors' from wildcard path");
+    }
+
+    @Test
+    public void testJsonPathArrayIndex() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        // Array index JsonPath to get the first role
+        configuration.setRolesClaim("$.roles[0]");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-index")
+                        .withClaim("email", "index@example.com")
+                        .withArrayClaim("roles", new String[] {"ADMIN", "USER"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Array index JsonPath should resolve");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("index@example.com", user.getName());
+        assertEquals(
+                Role.ADMIN, user.getRole(), "$.roles[0] should extract ADMIN as first element");
+    }
+
+    @Test
+    public void testBearerTokenJweRsaOaep() throws Exception {
+        configuration.setAllowBearerTokens(true);
+
+        // Create a PKCS12 keystore with the RSA key pair for JWE decryption
+        File keystoreFile = createTestKeystore();
+        try {
+            configuration.setJweKeyStoreFile(keystoreFile.getAbsolutePath());
+            configuration.setJweKeyStorePassword("changeit");
+            configuration.setJweKeyStoreType("PKCS12");
+            configuration.setJweKeyAlias("jwekey");
+            configuration.setJweKeyPassword("changeit");
+
+            // Recreate filter so it picks up the JWE config
+            recreateFilter();
+
+            // Create a signed JWT, then encrypt it inside a JWE
+            String jweToken =
+                    createSignedJweToken("jwe-user@example.com", "test-sub-jwe", CLIENT_ID);
+
+            MockHttpServletRequest request = createRequest("rest/resources");
+            request.addHeader("Authorization", "Bearer " + jweToken);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            filter.doFilter(request, response, chain);
+
+            assertEquals(200, response.getStatus());
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertNotNull(authentication, "JWE bearer token should authenticate successfully");
+            User user = (User) authentication.getPrincipal();
+            assertEquals("jwe-user@example.com", user.getName());
+        } finally {
+            keystoreFile.delete();
+        }
+    }
+
+    @Test
+    public void testBearerTokenJweWithRolesAndGroups() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        configuration.setGroupsClaim("groups");
+
+        File keystoreFile = createTestKeystore();
+        try {
+            configuration.setJweKeyStoreFile(keystoreFile.getAbsolutePath());
+            configuration.setJweKeyStorePassword("changeit");
+            configuration.setJweKeyStoreType("PKCS12");
+            configuration.setJweKeyAlias("jwekey");
+            configuration.setJweKeyPassword("changeit");
+
+            recreateFilter();
+
+            // Create JWE with roles and groups in the inner JWT
+            long now = System.currentTimeMillis() / 1000;
+            JWTClaimsSet innerClaims =
+                    new JWTClaimsSet.Builder()
+                            .subject("test-sub-jwe-roles")
+                            .issuer("https://test.issuer/")
+                            .audience(CLIENT_ID)
+                            .claim("email", "jwe-admin@example.com")
+                            .claim("roles", java.util.Arrays.asList("ADMIN"))
+                            .claim("groups", java.util.Arrays.asList("analysts", "editors"))
+                            .issueTime(new Date(now * 1000))
+                            .expirationTime(new Date((now + 3600) * 1000))
+                            .build();
+
+            SignedJWT signedJWT =
+                    new SignedJWT(
+                            new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(TEST_KID).build(),
+                            innerClaims);
+            signedJWT.sign(new RSASSASigner(rsaPrivateKey));
+
+            JWEHeader jweHeader =
+                    new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                            .contentType("JWT")
+                            .build();
+            JWEObject jweObject = new JWEObject(jweHeader, new Payload(signedJWT));
+            jweObject.encrypt(new RSAEncrypter(rsaPublicKey));
+            String jweToken = jweObject.serialize();
+
+            MockHttpServletRequest request = createRequest("rest/resources");
+            request.addHeader("Authorization", "Bearer " + jweToken);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            filter.doFilter(request, response, chain);
+
+            assertEquals(200, response.getStatus());
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertNotNull(authentication, "JWE token with roles/groups should authenticate");
+            User user = (User) authentication.getPrincipal();
+            assertEquals("jwe-admin@example.com", user.getName());
+            assertEquals(Role.ADMIN, user.getRole());
+
+            Set<String> groupNames =
+                    user.getGroups().stream()
+                            .map(UserGroup::getGroupName)
+                            .collect(Collectors.toSet());
+            assertTrue(groupNames.contains("analysts"), "Should have 'analysts' group from JWE");
+            assertTrue(groupNames.contains("editors"), "Should have 'editors' group from JWE");
+        } finally {
+            keystoreFile.delete();
+        }
+    }
+
+    @Test
+    public void testBearerTokenJweFallsBackToJws() throws Exception {
+        configuration.setAllowBearerTokens(true);
+
+        // Configure JWE keystore — but send a plain JWS token
+        File keystoreFile = createTestKeystore();
+        try {
+            configuration.setJweKeyStoreFile(keystoreFile.getAbsolutePath());
+            configuration.setJweKeyStorePassword("changeit");
+            configuration.setJweKeyStoreType("PKCS12");
+            configuration.setJweKeyAlias("jwekey");
+            configuration.setJweKeyPassword("changeit");
+
+            recreateFilter();
+
+            // Send a plain JWS token (3 parts) — should bypass JWE decryption and work normally
+            String jwt = createSignedJwt("jws-fallback@example.com", "test-sub-jws", CLIENT_ID);
+
+            MockHttpServletRequest request = createRequest("rest/resources");
+            request.addHeader("Authorization", "Bearer " + jwt);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            filter.doFilter(request, response, chain);
+
+            assertEquals(200, response.getStatus());
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertNotNull(
+                    authentication, "Plain JWS token should still work when JWE is configured");
+            User user = (User) authentication.getPrincipal();
+            assertEquals("jws-fallback@example.com", user.getName());
+        } finally {
+            keystoreFile.delete();
+        }
+    }
+
+    @Test
+    public void testBearerTokenJweNotConfigured() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        // No JWE keystore configured — JWE tokens should fail validation
+        // (they look like malformed JWTs to the JWS pipeline)
+
+        // Create a JWE token
+        long now = System.currentTimeMillis() / 1000;
+        JWTClaimsSet claims =
+                new JWTClaimsSet.Builder()
+                        .subject("test-sub-jwe-noconfig")
+                        .issuer("https://test.issuer/")
+                        .audience(CLIENT_ID)
+                        .claim("email", "jwe-noconfig@example.com")
+                        .issueTime(new Date(now * 1000))
+                        .expirationTime(new Date((now + 3600) * 1000))
+                        .build();
+
+        JWEHeader header =
+                new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM).build();
+        EncryptedJWT encryptedJWT = new EncryptedJWT(header, claims);
+        encryptedJWT.encrypt(new RSAEncrypter(rsaPublicKey));
+        String jweToken = encryptedJWT.serialize();
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jweToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(
+                authentication,
+                "JWE token should not authenticate when no JWE keystore is configured");
+    }
+
+    @Test
+    public void testBearerTokenGroupsOverageResolvesViaGraph()
+            throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("groups");
+        configuration.setMsGraphEnabled(true);
+        configuration.setMsGraphEndpoint(authService + "/graph");
+        recreateFilter();
+
+        // Build JWT with groups overage indicator (_claim_names containing "groups")
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-overage")
+                        .withClaim("email", "overage@example.com")
+                        .withClaim(
+                                "_claim_names",
+                                java.util.Collections.singletonMap("groups", "src1"))
+                        .withClaim(
+                                "_claim_sources",
+                                java.util.Collections.singletonMap(
+                                        "src1",
+                                        java.util.Collections.singletonMap(
+                                                "endpoint",
+                                                "https://graph.microsoft.com/v1.0/me/memberOf")))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token with overage should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("overage@example.com", user.getName());
+
+        // Verify groups were resolved from Graph
+        assertNotNull(user.getGroups(), "Groups should be populated from Graph");
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("GIS Analysts"), "Should have 'GIS Analysts' from Graph");
+        assertTrue(groupNames.contains("Map Editors"), "Should have 'Map Editors' from Graph");
+    }
+
+    @Test
+    public void testBearerTokenGroupsOverageWithMappings() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("groups");
+        configuration.setGroupMappings("GIS ANALYSTS:analysts_mapped,MAP EDITORS:editors_mapped");
+        configuration.setMsGraphEnabled(true);
+        configuration.setMsGraphEndpoint(authService + "/graph");
+        recreateFilter();
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-overage-map")
+                        .withClaim("email", "overage-map@example.com")
+                        .withClaim(
+                                "_claim_names",
+                                java.util.Collections.singletonMap("groups", "src1"))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token with overage + mappings should authenticate");
+        User user = (User) authentication.getPrincipal();
+
+        // Verify groups were resolved from Graph AND then mapped
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(
+                groupNames.contains("analysts_mapped"),
+                "Graph group 'GIS Analysts' should map to 'analysts_mapped'");
+        assertTrue(
+                groupNames.contains("editors_mapped"),
+                "Graph group 'Map Editors' should map to 'editors_mapped'");
+    }
+
+    @Test
+    public void testBearerTokenGroupsOverageGraphUnavailable()
+            throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("groups");
+        configuration.setMsGraphEnabled(true);
+        // Use a non-existent graph endpoint path to simulate Graph unavailability
+        configuration.setMsGraphEndpoint(authService + "/graph-unavailable");
+        recreateFilter();
+
+        // Stub a 503 for the unavailable endpoint
+        openIdConnectService.stubFor(
+                WireMock.get(urlPathEqualTo("/graph-unavailable/me/memberOf"))
+                        .willReturn(aResponse().withStatus(503).withBody("Service Unavailable")));
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-overage-503")
+                        .withClaim("email", "overage-503@example.com")
+                        .withClaim(
+                                "_claim_names",
+                                java.util.Collections.singletonMap("groups", "src1"))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "User should still authenticate when Graph is unavailable");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("overage-503@example.com", user.getName());
+        // Groups may be empty since Graph failed, but user should still authenticate
+    }
+
+    @Test
+    public void testBearerTokenGroupsNoOverageSkipsGraph() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("groups");
+        configuration.setMsGraphEnabled(true);
+        configuration.setMsGraphEndpoint(authService + "/graph");
+        recreateFilter();
+
+        // JWT with inline groups (no overage) — Graph should NOT be called
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-no-overage")
+                        .withClaim("email", "no-overage@example.com")
+                        .withArrayClaim("groups", new String[] {"inline-group-A", "inline-group-B"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token with inline groups should authenticate");
+        User user = (User) authentication.getPrincipal();
+
+        // Verify inline groups were used (not Graph groups)
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("inline-group-A"), "Should have inline group A");
+        assertTrue(groupNames.contains("inline-group-B"), "Should have inline group B");
+        assertFalse(
+                groupNames.contains("GIS Analysts"), "Should NOT have Graph group when no overage");
+    }
+
+    @Test
+    public void testBearerTokenMsGraphRoles() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        configuration.setMsGraphEnabled(true);
+        configuration.setMsGraphRolesEnabled(true);
+        configuration.setMsGraphEndpoint(authService + "/graph");
+        recreateFilter();
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-graph-roles")
+                        .withClaim("email", "graph-roles@example.com")
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token with Graph roles should authenticate");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("graph-roles@example.com", user.getName());
+        // The Graph stubs return "Admin" and "Viewer" roles
+        assertEquals(Role.ADMIN, user.getRole(), "Graph app role 'Admin' should resolve to ADMIN");
+    }
+
+    @Test
+    public void testBearerTokenMsGraphDisabledIgnoresOverage()
+            throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("groups");
+        configuration.setMsGraphEnabled(false);
+        recreateFilter();
+
+        // JWT with overage but MS Graph disabled — groups overage should be ignored
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-disabled")
+                        .withClaim("email", "disabled@example.com")
+                        .withClaim(
+                                "_claim_names",
+                                java.util.Collections.singletonMap("groups", "src1"))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(
+                authentication, "User should authenticate even with overage when Graph disabled");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("disabled@example.com", user.getName());
+        // No Graph groups should be present since MS Graph is disabled
+        if (user.getGroups() != null) {
+            Set<String> groupNames =
+                    user.getGroups().stream()
+                            .map(UserGroup::getGroupName)
+                            .collect(Collectors.toSet());
+            assertFalse(
+                    groupNames.contains("GIS Analysts"),
+                    "Should NOT have Graph groups when msGraphEnabled=false");
+        }
+    }
+
+    @Test
+    public void testLogSensitiveInfoEnablesDebugLogging() throws IOException, ServletException {
+        configuration.setLogSensitiveInfo(true);
+        configuration.setAllowBearerTokens(true);
+        recreateFilter();
+
+        String jwt = createSignedJwt("sensitive-test@example.com", "sub-sensitive", CLIENT_ID);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        // Verify authentication succeeded
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "User should authenticate with logSensitiveInfo enabled");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("sensitive-test@example.com", user.getName());
+
+        // Verify the security logger is now at DEBUG level
+        org.apache.logging.log4j.Logger securityLogger =
+                org.apache.logging.log4j.LogManager.getLogger(
+                        "it.geosolutions.geostore.services.rest.security");
+        assertTrue(
+                securityLogger.isDebugEnabled(),
+                "Security logger should be at DEBUG when logSensitiveInfo=true");
+    }
+
+    @Test
+    public void testLogSensitiveInfoDisabledByDefault() throws IOException, ServletException {
+        // logSensitiveInfo defaults to false
+        assertFalse(configuration.isLogSensitiveInfo());
+    }
+
+    // ── Tests for trusted flag and auth code callback flow ──────────────────
+
+    @Test
+    public void testBearerTokenUserIsTrusted() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+
+        String jwt = createSignedJwt("ritter@erdukunde.de", "test-sub-trusted", CLIENT_ID);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token should produce an authenticated user");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("ritter@erdukunde.de", user.getName());
+        assertTrue(
+                user.isTrusted(),
+                "OIDC-authenticated user should be marked as trusted so that "
+                        + "getAuthUserDetails() does not require a DB lookup");
+    }
+
+    @Test
+    public void testBearerTokenWithRolesUserIsTrusted() throws IOException, ServletException {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        configuration.setGroupsClaim("groups");
+
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("test-sub-trusted-admin")
+                        .withClaim("email", "admin-trusted@example.com")
+                        .withArrayClaim("roles", new String[] {"ADMIN"})
+                        .withArrayClaim("groups", new String[] {"team-alpha", "team-beta"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication);
+        User user = (User) authentication.getPrincipal();
+        assertEquals("admin-trusted@example.com", user.getName());
+        assertEquals(Role.ADMIN, user.getRole());
+        assertTrue(
+                user.isTrusted(),
+                "User with role and groups from token should still be marked trusted");
+        assertNotNull(user.getGroups());
+        Set<String> groupNames =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(groupNames.contains("team-alpha"));
+        assertTrue(groupNames.contains("team-beta"));
+    }
+
+    @Test
+    public void testAuthCodeCallbackPopulatesAccessTokenRequest()
+            throws IOException, ServletException {
+        // Simulate an auth code callback request with a code parameter.
+        // The filter should populate the AccessTokenRequest and skip clearState().
+        MockHttpServletRequest request = createRequest("openid/oidc/callback");
+        request.addParameter("code", CODE);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        // The token exchange will use the code to obtain tokens from WireMock.
+        filter.doFilter(request, response, chain);
+
+        // After successful callback, the user should be authenticated
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Auth code callback should produce an authenticated user");
+        User user = (User) authentication.getPrincipal();
+        assertNotNull(user.getName(), "User should have a name extracted from userinfo");
+        assertTrue(user.isTrusted(), "Auth code flow user should be marked as trusted");
+    }
+
+    @Test
+    public void testCallbackRequestSkipsClearState() throws IOException, ServletException {
+        // Verify that a callback request with a code does not trigger clearState(),
+        // which would destroy the authorization code before the token exchange.
+        MockHttpServletRequest request = createRequest("openid/oidc/callback");
+        request.addParameter("code", CODE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        // If clearState() ran, the code would be wiped and authentication would fail.
+        // Success means clearState() was correctly skipped.
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(
+                authentication,
+                "Callback with code should authenticate (clearState must be skipped)");
+    }
+
+    /**
+     * Creates a PKCS12 keystore file containing the test RSA key pair for JWE decryption testing.
+     */
+    private File createTestKeystore() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, "changeit".toCharArray());
+
+        // Create a self-signed certificate for the key pair
+        X509Certificate cert = generateSelfSignedCert(rsaPublicKey, rsaPrivateKey);
+        keyStore.setKeyEntry(
+                "jwekey",
+                rsaPrivateKey,
+                "changeit".toCharArray(),
+                new java.security.cert.Certificate[] {cert});
+
+        File tempFile = File.createTempFile("geostore-test-jwe-", ".p12");
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+            keyStore.store(fos, "changeit".toCharArray());
+        }
+        return tempFile;
+    }
+
+    /**
+     * Generates a minimal self-signed X.509 certificate for test purposes using DER encoding
+     * directly (no sun.security.x509 dependency).
+     */
+    private static X509Certificate generateSelfSignedCert(
+            RSAPublicKey pubKey, RSAPrivateKey privKey) throws Exception {
+        // Build a self-signed cert by constructing the DER TBSCertificate manually,
+        // signing it, and parsing it back via CertificateFactory.
+        byte[] subjectBytes =
+                derSequence(
+                        derSet(
+                                derSequence(
+                                        derOid(new int[] {2, 5, 4, 3}), // OID for CN
+                                        derUtf8String("GeoStore Test JWE"))));
+
+        long now = System.currentTimeMillis();
+        byte[] notBefore = derUtcTime(new Date(now));
+        byte[] notAfter = derUtcTime(new Date(now + 365L * 24 * 60 * 60 * 1000));
+        byte[] validity = derSequence(notBefore, notAfter);
+
+        // SHA256withRSA OID: 1.2.840.113549.1.1.11
+        byte[] sha256WithRsa =
+                derSequence(derOid(new int[] {1, 2, 840, 113549, 1, 1, 11}), derNull());
+
+        byte[] serialNumber =
+                derInteger(new java.math.BigInteger(64, new java.security.SecureRandom()));
+        byte[] version = derExplicit(0, derInteger(java.math.BigInteger.valueOf(2))); // v3
+
+        byte[] subjectPublicKeyInfo = pubKey.getEncoded();
+
+        byte[] tbsCertificate =
+                derSequence(
+                        version,
+                        serialNumber,
+                        sha256WithRsa,
+                        subjectBytes,
+                        validity,
+                        subjectBytes,
+                        subjectPublicKeyInfo);
+
+        java.security.Signature sig = java.security.Signature.getInstance("SHA256withRSA");
+        sig.initSign(privKey);
+        sig.update(tbsCertificate);
+        byte[] signature = sig.sign();
+
+        byte[] signatureBits = derBitString(signature);
+        byte[] certificate = derSequence(tbsCertificate, sha256WithRsa, signatureBits);
+
+        java.security.cert.CertificateFactory cf =
+                java.security.cert.CertificateFactory.getInstance("X.509");
+        return (X509Certificate)
+                cf.generateCertificate(new java.io.ByteArrayInputStream(certificate));
+    }
+
+    // --- Minimal DER encoding helpers for self-signed cert generation ---
+
+    private static byte[] derSequence(byte[]... items) {
+        return derTagged(0x30, concat(items));
+    }
+
+    private static byte[] derSet(byte[]... items) {
+        return derTagged(0x31, concat(items));
+    }
+
+    private static byte[] derOid(int[] components) {
+        java.io.ByteArrayOutputStream buf = new java.io.ByteArrayOutputStream();
+        buf.write(40 * components[0] + components[1]);
+        for (int i = 2; i < components.length; i++) {
+            encodeOidComponent(buf, components[i]);
+        }
+        byte[] content = buf.toByteArray();
+        return derTagged(0x06, content);
+    }
+
+    private static void encodeOidComponent(java.io.ByteArrayOutputStream buf, int value) {
+        if (value < 128) {
+            buf.write(value);
+        } else {
+            // Multi-byte encoding
+            byte[] bytes = new byte[5];
+            int pos = 4;
+            bytes[pos] = (byte) (value & 0x7F);
+            value >>= 7;
+            while (value > 0) {
+                pos--;
+                bytes[pos] = (byte) ((value & 0x7F) | 0x80);
+                value >>= 7;
+            }
+            buf.write(bytes, pos, 5 - pos);
+        }
+    }
+
+    private static byte[] derUtf8String(String s) {
+        return derTagged(0x0C, s.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private static byte[] derNull() {
+        return new byte[] {0x05, 0x00};
+    }
+
+    private static byte[] derInteger(java.math.BigInteger value) {
+        byte[] content = value.toByteArray();
+        return derTagged(0x02, content);
+    }
+
+    private static byte[] derBitString(byte[] data) {
+        byte[] content = new byte[data.length + 1];
+        content[0] = 0; // no unused bits
+        System.arraycopy(data, 0, content, 1, data.length);
+        return derTagged(0x03, content);
+    }
+
+    private static byte[] derUtcTime(Date date) {
+        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyMMddHHmmss'Z'");
+        sdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        byte[] content = sdf.format(date).getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        return derTagged(0x17, content);
+    }
+
+    private static byte[] derExplicit(int tag, byte[] content) {
+        return derTagged(0xA0 | tag, content);
+    }
+
+    private static byte[] derTagged(int tag, byte[] content) {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        out.write(tag);
+        writeLength(out, content.length);
+        out.write(content, 0, content.length);
+        return out.toByteArray();
+    }
+
+    private static void writeLength(java.io.ByteArrayOutputStream out, int length) {
+        if (length < 128) {
+            out.write(length);
+        } else if (length < 256) {
+            out.write(0x81);
+            out.write(length);
+        } else {
+            out.write(0x82);
+            out.write(length >> 8);
+            out.write(length & 0xFF);
+        }
+    }
+
+    private static byte[] concat(byte[][]... arrays) {
+        int total = 0;
+        for (byte[][] arr : arrays) {
+            for (byte[] b : arr) {
+                total += b.length;
+            }
+        }
+        byte[] result = new byte[total];
+        int pos = 0;
+        for (byte[][] arr : arrays) {
+            for (byte[] b : arr) {
+                System.arraycopy(b, 0, result, pos, b.length);
+                pos += b.length;
+            }
+        }
+        return result;
+    }
+
+    /** Creates a JWE token wrapping a signed JWT (nested JWS in JWE). */
+    private String createSignedJweToken(String email, String sub, String aud) throws Exception {
+        long now = System.currentTimeMillis() / 1000;
+
+        JWTClaimsSet innerClaims =
+                new JWTClaimsSet.Builder()
+                        .subject(sub)
+                        .issuer("https://test.issuer/")
+                        .audience(aud)
+                        .claim("email", email)
+                        .issueTime(new Date(now * 1000))
+                        .expirationTime(new Date((now + 3600) * 1000))
+                        .build();
+
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(TEST_KID).build(),
+                        innerClaims);
+        signedJWT.sign(new RSASSASigner(rsaPrivateKey));
+
+        JWEHeader jweHeader =
+                new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                        .contentType("JWT")
+                        .build();
+        JWEObject jweObject = new JWEObject(jweHeader, new Payload(signedJWT));
+        jweObject.encrypt(new RSAEncrypter(rsaPublicKey));
+        return jweObject.serialize();
+    }
+
+    /**
+     * Integration test: when a user's role is changed in the DB, the next bearer token request
+     * (even with a cached, non-expired token) must reflect the new role.
+     */
+    @Test
+    public void testCachedBearerTokenRoleSyncOnDbChange() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        MockedUserService userService = new MockedUserService();
+        recreateFilter();
+        service.setUserService(userService);
+
+        // First request: authenticate with bearer token (auto-creates user as USER)
+        String jwt = createSignedJwt("role-sync@example.com", "sub-role-sync", CLIENT_ID);
+
+        MockHttpServletRequest request1 = createRequest("rest/resources");
+        request1.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request1, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth1 = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth1, "First bearer request should authenticate");
+        User user = (User) auth1.getPrincipal();
+        assertEquals("role-sync@example.com", user.getName());
+        assertEquals(Role.USER, user.getRole(), "Auto-created user should have USER role");
+        assertNotNull(cache.get(jwt), "Token should be in cache after first request");
+
+        // Simulate admin promoting the user to ADMIN in the DB
+        User dbUser = userService.get("role-sync@example.com");
+        dbUser.setRole(Role.ADMIN);
+        userService.update(dbUser);
+
+        // Second request with same bearer token — should pick up the role change
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest request2 = createRequest("rest/resources");
+        request2.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request2, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth2 = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth2, "Second bearer request should authenticate from cache");
+        User user2 = (User) auth2.getPrincipal();
+        assertEquals(
+                Role.ADMIN,
+                user2.getRole(),
+                "Role should be ADMIN after DB promotion, even with cached token");
+        assertTrue(
+                auth2.getAuthorities().stream()
+                        .anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority())),
+                "Granted authority should be ROLE_ADMIN after promotion");
+    }
+
+    /** Integration test: demotion from ADMIN to USER via DB change is reflected immediately. */
+    @Test
+    public void testCachedBearerTokenDemotionReflected() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        MockedUserService userService = new MockedUserService();
+        recreateFilter();
+        service.setUserService(userService);
+
+        // Authenticate as ADMIN via roles claim in JWT
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-demote")
+                        .withClaim("email", "demote@example.com")
+                        .withArrayClaim("roles", new String[] {"ADMIN"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request1 = createRequest("rest/resources");
+        request1.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request1, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth1 = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth1);
+        assertEquals(Role.ADMIN, ((User) auth1.getPrincipal()).getRole());
+
+        // Demote user to USER in DB (simulates admin action)
+        User dbUser = userService.get("demote@example.com");
+        dbUser.setRole(Role.USER);
+        userService.update(dbUser);
+
+        // Second request — should reflect demotion
+        SecurityContextHolder.clearContext();
+        MockHttpServletRequest request2 = createRequest("rest/resources");
+        request2.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request2, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth2 = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth2, "Second request should still authenticate");
+        assertEquals(
+                Role.USER,
+                ((User) auth2.getPrincipal()).getRole(),
+                "Role should be demoted to USER after DB change");
+    }
+
+    /**
+     * Integration test: autoCreateUser creates the user in DB on first bearer token authentication.
+     */
+    @Test
+    public void testAutoCreateUserOnBearerToken() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setAutoCreateUser(true);
+        MockedUserService userService = new MockedUserService();
+        recreateFilter();
+        service.setUserService(userService);
+
+        String jwt = createSignedJwt("newuser@example.com", "sub-autocreate", CLIENT_ID);
+
+        // Verify user does not exist yet
+        try {
+            userService.get("newuser@example.com");
+            fail("User should not exist before first authentication");
+        } catch (NotFoundServiceEx expected) {
+            // expected
+        }
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication, "Bearer token should authenticate via auto-create");
+        User user = (User) authentication.getPrincipal();
+        assertEquals("newuser@example.com", user.getName());
+        assertEquals(Role.USER, user.getRole(), "Auto-created user should default to USER role");
+        assertTrue(user.isEnabled(), "Auto-created user should be enabled");
+
+        // Verify user was persisted in the service
+        User persisted = userService.get("newuser@example.com");
+        assertNotNull(persisted, "User should be persisted after auto-create");
+        assertEquals(Role.USER, persisted.getRole());
+    }
+
+    /**
+     * Integration test: when autoCreateUser=false, OIDC-authenticated users are NOT persisted to
+     * the DB. They can still authenticate but won't appear in the admin UI.
+     */
+    @Test
+    public void testAutoCreateUserDisabledDoesNotPersist() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setAutoCreateUser(false);
+        MockedUserService userService = new MockedUserService();
+        recreateFilter();
+        service.setUserService(userService);
+
+        String jwt = createSignedJwt("transient@example.com", "sub-transient", CLIENT_ID);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            // User should NOT be persisted
+            try {
+                userService.get("transient@example.com");
+                fail("User should not be persisted when autoCreateUser is false");
+            } catch (NotFoundServiceEx expected) {
+                // expected — transient user only
+            }
+        }
+    }
+
+    /**
+     * Integration test: when rolesClaim is configured but the JWT does not contain that claim, an
+     * existing DB user with ADMIN role should be downgraded to authenticatedDefaultRole (USER).
+     * This simulates the Azure AD scenario where the JWT has no "roles" claim.
+     */
+    @Test
+    public void testMissingRolesClaimFallsBackToDefaultRole() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        configuration.setAuthenticatedDefaultRole("USER");
+        MockedUserService userService = new MockedUserService();
+
+        // Pre-create user as ADMIN in the DB (simulates a previously promoted user)
+        User existingUser = new User();
+        existingUser.setName("admin-user@example.com");
+        existingUser.setRole(Role.ADMIN);
+        existingUser.setEnabled(true);
+        existingUser.setNewPassword("");
+        userService.insert(existingUser);
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        // JWT with NO "roles" claim (like Azure AD tokens)
+        String jwt = createSignedJwt("admin-user@example.com", "sub-no-roles", CLIENT_ID);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.USER,
+                principal.getRole(),
+                "Existing ADMIN user should be downgraded to USER when roles claim is missing");
+        assertTrue(
+                auth.getAuthorities().stream().anyMatch(a -> "ROLE_USER".equals(a.getAuthority())),
+                "Granted authority should be ROLE_USER");
+
+        // Verify the role change was persisted to the DB
+        User dbUser = userService.get("admin-user@example.com");
+        assertEquals(
+                Role.USER,
+                dbUser.getRole(),
+                "DB role should be updated to USER after login without roles claim");
+    }
+
+    /**
+     * Integration test: when rolesClaim is configured AND the JWT contains the claim with ADMIN, an
+     * existing DB user with USER role should be promoted to ADMIN.
+     */
+    @Test
+    public void testRolesClaimPresent_PromotesToAdmin() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        configuration.setAuthenticatedDefaultRole("USER");
+        MockedUserService userService = new MockedUserService();
+
+        // Pre-create user as USER in the DB
+        User existingUser = new User();
+        existingUser.setName("promote@example.com");
+        existingUser.setRole(Role.USER);
+        existingUser.setEnabled(true);
+        existingUser.setNewPassword("");
+        userService.insert(existingUser);
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        // JWT WITH "roles" claim containing ADMIN
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-promote")
+                        .withClaim("email", "promote@example.com")
+                        .withArrayClaim("roles", new String[] {"ADMIN"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.ADMIN,
+                principal.getRole(),
+                "USER should be promoted to ADMIN when roles claim contains ADMIN");
+        assertTrue(
+                auth.getAuthorities().stream().anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority())),
+                "Granted authority should be ROLE_ADMIN");
+    }
+
+    /**
+     * When authenticatedDefaultRole is GUEST and the token contains a role that maps to USER via
+     * roleMappings, the user should be elevated to USER (not left as GUEST). This tests that
+     * computeRole has an explicit USER branch.
+     */
+    @Test
+    public void testRoleMappingToUser_OverridesGuestDefault() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("realm_access.roles");
+        configuration.setAuthenticatedDefaultRole("GUEST");
+        configuration.setRoleMappings("demo:USER,realm_admin:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        // JWT with nested realm_access.roles containing "demo" (maps to USER)
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> realmAccess = new java.util.HashMap<>();
+        realmAccess.put(
+                "roles",
+                java.util.Arrays.asList(
+                        "default-roles-ams2", "offline_access", "uma_authorization", "demo"));
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-demo-user")
+                        .withClaim("email", "demo-user@example.com")
+                        .withClaim("realm_access", realmAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.USER,
+                principal.getRole(),
+                "demo role mapped to USER should override GUEST default");
+    }
+
+    /**
+     * When roleMappings are configured, unmapped IdP role names should NOT be compared against
+     * GeoStore role names. An IdP role literally named "admin" (without a mapping) should not grant
+     * ADMIN access.
+     */
+    @Test
+    public void testUnmappedIdpRoleNamedAdmin_DoesNotGrantAdmin() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("roles");
+        configuration.setAuthenticatedDefaultRole("USER");
+        // Only map "realm_admin" to ADMIN — a raw "admin" role should be ignored
+        configuration.setRoleMappings("realm_admin:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        // JWT with a role literally named "admin" but NOT in roleMappings
+        long now = System.currentTimeMillis() / 1000;
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-sneaky")
+                        .withClaim("email", "sneaky@example.com")
+                        .withArrayClaim("roles", new String[] {"admin", "viewer"})
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.USER,
+                principal.getRole(),
+                "Unmapped IdP role named 'admin' should NOT grant ADMIN when roleMappings are set");
+    }
+
+    /**
+     * Deeply nested role claim: resource_access.account.roles — a 3-level Keycloak structure.
+     * Verifies that role mapping to USER works through a deeply nested path.
+     */
+    @Test
+    public void testDeeplyNestedRoles_ResourceAccessAccountRoles() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("resource_access.account.roles");
+        configuration.setAuthenticatedDefaultRole("GUEST");
+        configuration.setRoleMappings("manage-account:USER,manage-realm:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        // Mirrors real Keycloak token: resource_access.account.roles
+        java.util.Map<String, Object> accountAccess = new java.util.HashMap<>();
+        accountAccess.put(
+                "roles",
+                java.util.Arrays.asList("manage-account", "manage-account-links", "view-profile"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("account", accountAccess);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-deep-roles")
+                        .withClaim("email", "deep-roles@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.USER,
+                principal.getRole(),
+                "manage-account mapped to USER should override GUEST default "
+                        + "via resource_access.account.roles");
+    }
+
+    /**
+     * Deeply nested role claim resolving to ADMIN: resource_access.app.roles with a role that maps
+     * to ADMIN. Verifies ADMIN promotion through a 3-level path.
+     */
+    @Test
+    public void testDeeplyNestedRoles_ResourceAccessApp_AdminPromotion() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("resource_access.myapp.roles");
+        configuration.setAuthenticatedDefaultRole("USER");
+        configuration.setRoleMappings("app-admin:ADMIN,app-viewer:GUEST");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> appAccess = new java.util.HashMap<>();
+        appAccess.put("roles", java.util.Arrays.asList("app-admin", "app-viewer"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("myapp", appAccess);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-deep-admin")
+                        .withClaim("email", "deep-admin@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.ADMIN,
+                principal.getRole(),
+                "app-admin mapped to ADMIN should promote via resource_access.myapp.roles");
+    }
+
+    /**
+     * Deeply nested groups claim: resource_access.geostore.groups with group mappings. Verifies
+     * groups are extracted from a 3-level path and mapped correctly.
+     */
+    @Test
+    public void testDeeplyNestedGroups_WithMappings() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("resource_access.geostore.groups");
+        configuration.setGroupMappings("devs:developers,ops:operations");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> geostoreAccess = new java.util.HashMap<>();
+        geostoreAccess.put("groups", java.util.Arrays.asList("devs", "ops", "external"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("geostore", geostoreAccess);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-deep-groups")
+                        .withClaim("email", "deep-groups@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        Set<String> groupNames =
+                principal.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(groupNames.contains("developers"), "devs should be mapped to developers");
+        assertTrue(groupNames.contains("operations"), "ops should be mapped to operations");
+        assertTrue(
+                groupNames.contains("external"),
+                "external should pass through (dropUnmapped=false)");
+    }
+
+    /** Deeply nested groups claim with dropUnmapped=true: only mapped groups survive. */
+    @Test
+    public void testDeeplyNestedGroups_DropUnmapped() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setGroupsClaim("resource_access.geostore.groups");
+        configuration.setGroupMappings("devs:developers");
+        configuration.setDropUnmapped(true);
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> geostoreAccess = new java.util.HashMap<>();
+        geostoreAccess.put("groups", java.util.Arrays.asList("devs", "unmapped-group"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("geostore", geostoreAccess);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-drop-groups")
+                        .withClaim("email", "drop-groups@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        Set<String> groupNames =
+                principal.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(groupNames.contains("developers"), "devs should be mapped to developers");
+        assertFalse(
+                groupNames.contains("unmapped-group"),
+                "unmapped-group should be dropped when dropUnmapped=true");
+    }
+
+    /**
+     * Combined test: deeply nested roles AND groups from the same token, with role mapping to USER.
+     * Mirrors a real Keycloak token structure with both realm_access.roles and a custom groups
+     * claim.
+     */
+    @Test
+    public void testCombinedNestedRolesAndGroups_UserRole() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("realm_access.roles");
+        configuration.setGroupsClaim("resource_access.geostore.groups");
+        configuration.setAuthenticatedDefaultRole("GUEST");
+        configuration.setRoleMappings("demo:USER,realm_admin:ADMIN");
+        configuration.setGroupMappings("analysts:gis-analysts");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        // Build a realistic Keycloak-like JWT
+        java.util.Map<String, Object> realmAccess = new java.util.HashMap<>();
+        realmAccess.put(
+                "roles",
+                java.util.Arrays.asList(
+                        "default-roles-ams2", "offline_access", "uma_authorization", "demo"));
+        java.util.Map<String, Object> geostoreAccess = new java.util.HashMap<>();
+        geostoreAccess.put("groups", java.util.Arrays.asList("analysts", "editors"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("geostore", geostoreAccess);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-combined")
+                        .withClaim("email", "combined@example.com")
+                        .withClaim("realm_access", realmAccess)
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+
+        // Role: "demo" maps to USER, overriding GUEST default
+        assertEquals(
+                Role.USER,
+                principal.getRole(),
+                "demo mapped to USER should override GUEST default");
+
+        // Groups: "analysts" mapped to "gis-analysts", "editors" passes through
+        Set<String> groupNames =
+                principal.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(groupNames.contains("gis-analysts"), "analysts should map to gis-analysts");
+        assertTrue(groupNames.contains("editors"), "editors should pass through unmapped");
+    }
+
+    /**
+     * Wildcard JsonPath for roles: $.resource_access.*.roles collects roles across all resource
+     * clients. Verifies that a role mapped to USER is found even when spread across clients.
+     */
+    @Test
+    public void testWildcardJsonPathRoles_UserMapping() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("$.resource_access.*.roles");
+        configuration.setAuthenticatedDefaultRole("GUEST");
+        configuration.setRoleMappings("view-profile:USER,manage-realm:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> accountAccess = new java.util.HashMap<>();
+        accountAccess.put("roles", java.util.Arrays.asList("manage-account", "view-profile"));
+        java.util.Map<String, Object> appAccess = new java.util.HashMap<>();
+        appAccess.put("roles", java.util.Arrays.asList("app-reader"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("account", accountAccess);
+        resourceAccess.put("myapp", appAccess);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-wildcard-user")
+                        .withClaim("email", "wildcard-user@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.USER,
+                principal.getRole(),
+                "view-profile mapped to USER via wildcard path should override GUEST default");
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue-specific regression tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Regression: an existing ADMIN user must still receive groups from the token. The reported bug
+     * is "se sei admin non ti aggiunge i gruppi" — groups are not synced for ADMIN users.
+     */
+    @Test
+    public void testAdminUser_GroupsStillSynced() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("realm_access.roles");
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultRole("USER");
+        MockedUserService userService = new MockedUserService();
+
+        // Pre-create an ADMIN user in the DB (simulates an existing admin)
+        User adminUser = new User();
+        adminUser.setName("admin@example.com");
+        adminUser.setRole(Role.ADMIN);
+        adminUser.setEnabled(true);
+        adminUser.setNewPassword("");
+        adminUser.setGroups(new java.util.HashSet<>());
+        userService.insert(adminUser);
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> realmAccess = new java.util.HashMap<>();
+        realmAccess.put("roles", java.util.Arrays.asList("ADMIN"));
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-admin-groups")
+                        .withClaim("email", "admin@example.com")
+                        .withClaim("realm_access", realmAccess)
+                        .withClaim(
+                                "groups",
+                                java.util.Arrays.asList("analysts", "editors", "managers"))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(Role.ADMIN, principal.getRole(), "User should remain ADMIN");
+
+        Set<String> groupNames =
+                principal.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(
+                groupNames.contains("analysts"),
+                "ADMIN user should have 'analysts' group from token");
+        assertTrue(
+                groupNames.contains("editors"),
+                "ADMIN user should have 'editors' group from token");
+        assertTrue(
+                groupNames.contains("managers"),
+                "ADMIN user should have 'managers' group from token");
+        assertEquals(3, groupNames.size(), "ADMIN user should have exactly 3 groups from token");
+    }
+
+    /**
+     * Regression: an existing ADMIN user with nested roles (realm_access.roles) AND nested groups
+     * (resource_access.geostore.groups) must get both role and groups synced.
+     */
+    @Test
+    public void testAdminUser_NestedRolesAndGroups() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("realm_access.roles");
+        configuration.setGroupsClaim("resource_access.geostore.groups");
+        configuration.setAuthenticatedDefaultRole("USER");
+        configuration.setRoleMappings("realm_admin:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        // Pre-create ADMIN user
+        User adminUser = new User();
+        adminUser.setName("nested-admin@example.com");
+        adminUser.setRole(Role.ADMIN);
+        adminUser.setEnabled(true);
+        adminUser.setNewPassword("");
+        adminUser.setGroups(new java.util.HashSet<>());
+        userService.insert(adminUser);
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> realmAccess = new java.util.HashMap<>();
+        realmAccess.put("roles", java.util.Arrays.asList("realm_admin", "offline_access"));
+        java.util.Map<String, Object> geostoreAccess = new java.util.HashMap<>();
+        geostoreAccess.put("groups", java.util.Arrays.asList("gis-team", "data-admins"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("geostore", geostoreAccess);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-nested-admin")
+                        .withClaim("email", "nested-admin@example.com")
+                        .withClaim("realm_access", realmAccess)
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(Role.ADMIN, principal.getRole(), "realm_admin should map to ADMIN");
+
+        Set<String> groupNames =
+                principal.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(
+                groupNames.contains("gis-team"),
+                "ADMIN user should have 'gis-team' from nested groups");
+        assertTrue(
+                groupNames.contains("data-admins"),
+                "ADMIN user should have 'data-admins' from nested groups");
+    }
+
+    /**
+     * Regression: rolesClaim=resource_access.account.roles should resolve roles from the deeply
+     * nested Keycloak client-scoped roles. Tests with a realistic Keycloak token structure where
+     * resource_access contains multiple clients.
+     */
+    @Test
+    public void testResourceAccessAccountRoles_RealisticKeycloakToken() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("resource_access.account.roles");
+        configuration.setAuthenticatedDefaultRole("USER");
+        // Map Keycloak's client-level "manage-account" role to ADMIN
+        configuration.setRoleMappings("manage-account:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        // Realistic Keycloak token structure with multiple resource_access clients
+        java.util.Map<String, Object> accountRoles = new java.util.HashMap<>();
+        accountRoles.put(
+                "roles",
+                java.util.Arrays.asList("manage-account", "manage-account-links", "view-profile"));
+        java.util.Map<String, Object> realmMgmtRoles = new java.util.HashMap<>();
+        realmMgmtRoles.put("roles", java.util.Arrays.asList("view-realm", "view-users"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("account", accountRoles);
+        resourceAccess.put("realm-management", realmMgmtRoles);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-resource-access")
+                        .withClaim("email", "resource-user@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.ADMIN,
+                principal.getRole(),
+                "manage-account from resource_access.account.roles should map to ADMIN");
+    }
+
+    /**
+     * Regression: resource_access.account.roles with no matching role mappings should fall back to
+     * authenticatedDefaultRole. Verifies that the deeply nested path resolves correctly even when
+     * no role matches.
+     */
+    @Test
+    public void testResourceAccessAccountRoles_NoMatchFallsBackToDefault() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("resource_access.account.roles");
+        configuration.setAuthenticatedDefaultRole("USER");
+        // Only map something that is NOT in the token
+        configuration.setRoleMappings("super-admin:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> accountRoles = new java.util.HashMap<>();
+        accountRoles.put(
+                "roles",
+                java.util.Arrays.asList("manage-account", "manage-account-links", "view-profile"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("account", accountRoles);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-resource-default")
+                        .withClaim("email", "resource-default@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(
+                Role.USER,
+                principal.getRole(),
+                "No matching role mapping should fall back to USER default");
+    }
+
+    /**
+     * Regression: combined test with resource_access.account.roles for roles AND a separate groups
+     * claim. Verifies both work together correctly, including for ADMIN users.
+     */
+    @Test
+    public void testResourceAccessAccountRoles_WithGroupsCombined() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("resource_access.account.roles");
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultRole("USER");
+        configuration.setRoleMappings("manage-account:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> accountRoles = new java.util.HashMap<>();
+        accountRoles.put(
+                "roles",
+                java.util.Arrays.asList("manage-account", "manage-account-links", "view-profile"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("account", accountRoles);
+
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-combined-resource")
+                        .withClaim("email", "combined-resource@example.com")
+                        .withClaim("resource_access", resourceAccess)
+                        .withClaim("groups", java.util.Arrays.asList("team-a", "team-b"))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(Role.ADMIN, principal.getRole(), "manage-account should map to ADMIN");
+
+        Set<String> groupNames =
+                principal.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(
+                groupNames.contains("team-a"),
+                "ADMIN from resource_access claim should still get groups");
+        assertTrue(
+                groupNames.contains("team-b"),
+                "ADMIN from resource_access claim should still get groups");
+    }
+
+    /**
+     * Regression: a newly auto-created ADMIN user (not pre-existing in DB) must receive groups.
+     * This tests the createUser → addAuthoritiesFromToken flow end-to-end.
+     */
+    @Test
+    public void testNewAdminUser_AutoCreatedWithGroups() throws Exception {
+        configuration.setAllowBearerTokens(true);
+        configuration.setRolesClaim("realm_access.roles");
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultRole("USER");
+        configuration.setAutoCreateUser(true);
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        // User does NOT pre-exist in DB — will be auto-created
+        long now = System.currentTimeMillis() / 1000;
+        java.util.Map<String, Object> realmAccess = new java.util.HashMap<>();
+        realmAccess.put("roles", java.util.Arrays.asList("ADMIN"));
+        String jwt =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-new-admin")
+                        .withClaim("email", "new-admin@example.com")
+                        .withClaim("realm_access", realmAccess)
+                        .withClaim("groups", java.util.Arrays.asList("ops", "infra"))
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000))
+                        .sign(rsaAlgorithm);
+
+        MockHttpServletRequest request = createRequest("rest/resources");
+        request.addHeader("Authorization", "Bearer " + jwt);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "Bearer request should authenticate");
+        User principal = (User) auth.getPrincipal();
+        assertEquals(Role.ADMIN, principal.getRole(), "New user should be ADMIN from token");
+
+        Set<String> groupNames =
+                principal.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(groupNames.contains("ops"), "Auto-created ADMIN should have 'ops' group");
+        assertTrue(groupNames.contains("infra"), "Auto-created ADMIN should have 'infra' group");
+    }
+
+    // -----------------------------------------------------------------------
+    // Keycloak split-token tests: ID token vs access token claim resolution
+    // In real Keycloak, the ID token does NOT contain realm_access,
+    // resource_access, or groups — only the access token does.
+    // -----------------------------------------------------------------------
+
+    /** Helper: creates a minimal Keycloak-like ID token (no realm_access, no groups). */
+    private String createKeycloakIdToken(String email) {
+        long now = System.currentTimeMillis() / 1000;
+        return JWT.create()
+                .withKeyId(TEST_KID)
+                .withIssuer("https://test.issuer/")
+                .withAudience(CLIENT_ID)
+                .withSubject("sub-" + email)
+                .withClaim("email", email)
+                .withClaim("preferred_username", email)
+                .withClaim("name", "Test User")
+                .withClaim("given_name", "Test")
+                .withClaim("family_name", "User")
+                // NO realm_access, NO resource_access, NO groups
+                .withIssuedAt(new Date(now * 1000))
+                .withExpiresAt(new Date((now + 3600) * 1000))
+                .sign(rsaAlgorithm);
+    }
+
+    /**
+     * Helper: creates a Keycloak-like access token WITH realm_access, resource_access, and groups.
+     */
+    private String createKeycloakAccessToken(
+            String email,
+            java.util.List<String> realmRoles,
+            java.util.Map<String, Object> resourceAccess,
+            java.util.List<String> groups) {
+        long now = System.currentTimeMillis() / 1000;
+        com.auth0.jwt.JWTCreator.Builder builder =
+                JWT.create()
+                        .withKeyId(TEST_KID)
+                        .withIssuer("https://test.issuer/")
+                        .withAudience(CLIENT_ID)
+                        .withSubject("sub-" + email)
+                        .withClaim("preferred_username", email)
+                        .withIssuedAt(new Date(now * 1000))
+                        .withExpiresAt(new Date((now + 3600) * 1000));
+        if (realmRoles != null) {
+            java.util.Map<String, Object> realmAccess = new java.util.HashMap<>();
+            realmAccess.put("roles", realmRoles);
+            builder = builder.withClaim("realm_access", realmAccess);
+        }
+        if (resourceAccess != null) {
+            builder = builder.withClaim("resource_access", resourceAccess);
+        }
+        if (groups != null) {
+            builder = builder.withClaim("groups", groups);
+        }
+        return builder.sign(rsaAlgorithm);
+    }
+
+    /**
+     * Scenario 1a: rolesClaim=realm_access.roles, NO roleMappings. Keycloak ID token does NOT
+     * contain realm_access → falls back to access token. Access token has realm_access.roles =
+     * [default-roles-ams2, offline_access, ...]. Without roleMappings, none of these match
+     * ADMIN/USER/GUEST → user stays at defaultRole=USER. Groups claim (groups) is also only in
+     * access token.
+     *
+     * <p>Expected: USER role, but groups SHOULD still be synced from access token. This reproduces
+     * "sarai user e non avrai gruppi" — before the fix, both realm_access.roles and groups would
+     * resolve to null because only the ID token was checked.
+     */
+    @Test
+    public void testKeycloakSplitToken_NoRoleMappings_UserWithGroups() throws Exception {
+        configuration.setRolesClaim("realm_access.roles");
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultRole("USER");
+        // No roleMappings configured
+        configuration.setRoleMappings(null);
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        // Create a user first (simulating auto-create)
+        User user = new User();
+        user.setName("keycloak-user@example.com");
+        user.setRole(Role.USER);
+        user.setEnabled(true);
+        user.setNewPassword("");
+        user.setGroups(new java.util.HashSet<>());
+        userService.insert(user);
+
+        // Simulate what createPreAuthentication does: ID token primary, access token fallback
+        String idToken = createKeycloakIdToken("keycloak-user@example.com");
+        String accessToken =
+                createKeycloakAccessToken(
+                        "keycloak-user@example.com",
+                        java.util.Arrays.asList(
+                                "default-roles-ams2", "offline_access", "uma_authorization"),
+                        null,
+                        java.util.Arrays.asList("analysts", "editors"));
+
+        // Retrieve the user as the filter would
+        User dbUser = userService.get("keycloak-user@example.com");
+
+        // Call addAuthoritiesFromToken with split tokens (the fix)
+        service.addAuthoritiesFromToken(dbUser, idToken, accessToken, null);
+
+        assertEquals(
+                Role.USER,
+                dbUser.getRole(),
+                "No roleMappings → unmapped Keycloak roles should not match → USER");
+
+        Set<String> groupNames =
+                dbUser.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(
+                groupNames.contains("analysts"),
+                "Groups from access token should be synced even when user is USER");
+        assertTrue(
+                groupNames.contains("editors"),
+                "Groups from access token should be synced even when user is USER");
+    }
+
+    /**
+     * Scenario 1b: rolesClaim=realm_access.roles, WITH roleMappings=default-roles-ams2:ADMIN.
+     * Keycloak ID token does NOT contain realm_access → falls back to access token. Access token
+     * has realm_access.roles = [default-roles-ams2, ...]. With the mapping, default-roles-ams2 →
+     * ADMIN.
+     *
+     * <p>Expected: ADMIN role AND groups synced. This reproduces "se metti la riga
+     * roleMappings=default-roles-ams2:ADMIN, sarai admin e avrai i gruppi".
+     */
+    @Test
+    public void testKeycloakSplitToken_WithRoleMappings_AdminWithGroups() throws Exception {
+        configuration.setRolesClaim("realm_access.roles");
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultRole("USER");
+        configuration.setRoleMappings("default-roles-ams2:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        User user = new User();
+        user.setName("keycloak-admin@example.com");
+        user.setRole(Role.USER);
+        user.setEnabled(true);
+        user.setNewPassword("");
+        user.setGroups(new java.util.HashSet<>());
+        userService.insert(user);
+
+        String idToken = createKeycloakIdToken("keycloak-admin@example.com");
+        String accessToken =
+                createKeycloakAccessToken(
+                        "keycloak-admin@example.com",
+                        java.util.Arrays.asList(
+                                "default-roles-ams2", "offline_access", "uma_authorization"),
+                        null,
+                        java.util.Arrays.asList("analysts", "editors", "managers"));
+
+        User dbUser = userService.get("keycloak-admin@example.com");
+        service.addAuthoritiesFromToken(dbUser, idToken, accessToken, null);
+
+        assertEquals(
+                Role.ADMIN,
+                dbUser.getRole(),
+                "default-roles-ams2 mapped to ADMIN via roleMappings");
+
+        Set<String> groupNames =
+                dbUser.getGroups().stream()
+                        .map(UserGroup::getGroupName)
+                        .collect(Collectors.toSet());
+        assertTrue(groupNames.contains("analysts"), "ADMIN should have groups from access token");
+        assertTrue(groupNames.contains("editors"), "ADMIN should have groups from access token");
+        assertTrue(groupNames.contains("managers"), "ADMIN should have groups from access token");
+    }
+
+    /**
+     * Scenario 2: rolesClaim=resource_access.account.roles, WITH roleMappings=manage-account:ADMIN.
+     * The comment "Questo non funziona" in the config refers to this. Keycloak ID token does NOT
+     * contain resource_access → must fall back to access token.
+     *
+     * <p>Expected: ADMIN role (manage-account mapped to ADMIN).
+     */
+    @Test
+    public void testKeycloakSplitToken_ResourceAccessAccountRoles() throws Exception {
+        configuration.setRolesClaim("resource_access.account.roles");
+        configuration.setAuthenticatedDefaultRole("USER");
+        configuration.setRoleMappings("manage-account:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        User user = new User();
+        user.setName("resource-user@example.com");
+        user.setRole(Role.USER);
+        user.setEnabled(true);
+        user.setNewPassword("");
+        user.setGroups(new java.util.HashSet<>());
+        userService.insert(user);
+
+        // ID token: NO resource_access
+        String idToken = createKeycloakIdToken("resource-user@example.com");
+        // Access token: HAS resource_access.account.roles
+        java.util.Map<String, Object> accountRoles = new java.util.HashMap<>();
+        accountRoles.put(
+                "roles",
+                java.util.Arrays.asList("manage-account", "manage-account-links", "view-profile"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("account", accountRoles);
+
+        String accessToken =
+                createKeycloakAccessToken("resource-user@example.com", null, resourceAccess, null);
+
+        User dbUser = userService.get("resource-user@example.com");
+        service.addAuthoritiesFromToken(dbUser, idToken, accessToken, null);
+
+        assertEquals(
+                Role.ADMIN,
+                dbUser.getRole(),
+                "resource_access.account.roles with manage-account:ADMIN mapping "
+                        + "should resolve from access token fallback");
+    }
+
+    /**
+     * Scenario 2b: rolesClaim=resource_access.account.roles, WITHOUT roleMappings. Even though
+     * resource_access.account.roles resolves, none of the values (manage-account,
+     * manage-account-links, view-profile) match GeoStore roles.
+     *
+     * <p>Expected: falls back to authenticatedDefaultRole=USER.
+     */
+    @Test
+    public void testKeycloakSplitToken_ResourceAccessAccountRoles_NoMapping() throws Exception {
+        configuration.setRolesClaim("resource_access.account.roles");
+        configuration.setAuthenticatedDefaultRole("USER");
+        configuration.setRoleMappings(null);
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        User user = new User();
+        user.setName("resource-nomatch@example.com");
+        user.setRole(Role.USER);
+        user.setEnabled(true);
+        user.setNewPassword("");
+        user.setGroups(new java.util.HashSet<>());
+        userService.insert(user);
+
+        String idToken = createKeycloakIdToken("resource-nomatch@example.com");
+        java.util.Map<String, Object> accountRoles = new java.util.HashMap<>();
+        accountRoles.put(
+                "roles",
+                java.util.Arrays.asList("manage-account", "manage-account-links", "view-profile"));
+        java.util.Map<String, Object> resourceAccess = new java.util.HashMap<>();
+        resourceAccess.put("account", accountRoles);
+
+        String accessToken =
+                createKeycloakAccessToken(
+                        "resource-nomatch@example.com", null, resourceAccess, null);
+
+        User dbUser = userService.get("resource-nomatch@example.com");
+        service.addAuthoritiesFromToken(dbUser, idToken, accessToken, null);
+
+        assertEquals(
+                Role.USER,
+                dbUser.getRole(),
+                "No roleMappings and Keycloak client roles don't match GeoStore roles → USER");
+    }
+
+    /**
+     * Scenario 3: Verify that when ONLY the ID token is provided (no access token fallback),
+     * realm_access.roles resolves to null — confirming the pre-fix behavior. This proves the access
+     * token fallback is essential.
+     */
+    @Test
+    public void testKeycloakIdTokenOnly_RealmAccessNotFound() throws Exception {
+        configuration.setRolesClaim("realm_access.roles");
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultRole("USER");
+        configuration.setRoleMappings("default-roles-ams2:ADMIN");
+        MockedUserService userService = new MockedUserService();
+
+        recreateFilter();
+        service.setUserService(userService);
+
+        User user = new User();
+        user.setName("idtoken-only@example.com");
+        user.setRole(Role.USER);
+        user.setEnabled(true);
+        user.setNewPassword("");
+        user.setGroups(new java.util.HashSet<>());
+        userService.insert(user);
+
+        // Only pass ID token, NO access token fallback (simulates the pre-fix behavior)
+        String idToken = createKeycloakIdToken("idtoken-only@example.com");
+
+        User dbUser = userService.get("idtoken-only@example.com");
+        service.addAuthoritiesFromToken(dbUser, idToken, null, null);
+
+        // Without access token fallback, realm_access.roles is not in ID token → USER
+        assertEquals(
+                Role.USER,
+                dbUser.getRole(),
+                "ID token alone should NOT contain realm_access → falls back to USER");
+        assertTrue(
+                dbUser.getGroups().isEmpty(), "ID token alone should NOT contain groups → empty");
+    }
+
+    /** Recreates the filter with current configuration (picks up JWE config changes). */
+    private void recreateFilter() {
+        OpenIdConnectRestClient restClient = new OpenIdConnectRestClient(configuration);
+        JwksRsaKeyProvider jwksKeyProvider = new JwksRsaKeyProvider(authService + "/certs");
+        this.cache =
+                new TokenAuthenticationCache(
+                        configuration.getCacheSize(), configuration.getCacheExpirationMinutes());
+        MultiTokenValidator validator =
+                new MultiTokenValidator(
+                        java.util.Arrays.asList(
+                                new AudienceAccessTokenValidator(), new SubjectTokenValidator()));
+        this.service =
+                new OpenIdConnectAuthenticationService(
+                        this.cache, null, null, configuration, validator, jwksKeyProvider);
+        this.filter = new OpenIdConnectFilter(configuration, this.service, restClient);
+    }
+
+    /** Creates a properly RSA-signed JWT with email, sub, and aud claims. */
+    private String createSignedJwt(String email, String sub, String aud) {
+        long now = System.currentTimeMillis() / 1000;
+        return JWT.create()
+                .withKeyId(TEST_KID)
+                .withIssuer("https://test.issuer/")
+                .withAudience(aud)
+                .withSubject(sub)
+                .withClaim("email", email)
+                .withIssuedAt(new Date(now * 1000))
+                .withExpiresAt(new Date((now + 3600) * 1000))
+                .sign(rsaAlgorithm);
+    }
+
+    /** Builds a JWKS JSON string from the given RSA public key with the specified kid. */
+    private static String buildJwksJson(RSAPublicKey publicKey, String kid) {
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        String n = encoder.encodeToString(publicKey.getModulus().toByteArray());
+        String e = encoder.encodeToString(publicKey.getPublicExponent().toByteArray());
+        return "{\"keys\":[{"
+                + "\"kty\":\"RSA\","
+                + "\"use\":\"sig\","
+                + "\"alg\":\"RS256\","
+                + "\"kid\":\""
+                + kid
+                + "\","
+                + "\"n\":\""
+                + n
+                + "\","
+                + "\"e\":\""
+                + e
+                + "\""
+                + "}]}";
+    }
+
+    private MockHttpServletRequest createRequest(String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        request.setContextPath("/geostore");
+        request.setRequestURI("/geostore/" + path);
+        request.setRemoteAddr("127.0.0.1");
+        request.setServletPath("/geostore");
+        request.setPathInfo(path);
+        request.addHeader("Host", "localhost:8080");
+        ServletRequestAttributes attributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attributes);
+        return request;
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectIntegrationTest.java
@@ -167,7 +167,7 @@ public class OpenIdConnectIntegrationTest {
                                                 "Content-Type", MediaType.APPLICATION_JSON_VALUE)
                                         .withBody(tokenResponseJson)));
         openIdConnectService.stubFor(
-                any(urlPathEqualTo("/userinfo"))
+                WireMock.get(urlPathEqualTo("/userinfo"))
                         .willReturn(
                                 aResponse()
                                         .withStatus(200)

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
@@ -1,0 +1,769 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import it.geosolutions.geostore.services.rest.model.SessionToken;
+import it.geosolutions.geostore.services.rest.security.TokenAuthenticationCache;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2SessionServiceDelegate;
+import it.geosolutions.geostore.services.rest.security.oauth2.TokenDetails;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.*;
+import org.junit.jupiter.api.*;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.*;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/** Test class for OAuth2SessionServiceDelegate token refresh. */
+class RefreshTokenServiceTest {
+
+    private TestOAuth2SessionServiceDelegate serviceDelegate;
+    private OAuth2Configuration configuration;
+    private RestTemplate restTemplate;
+    private MockHttpServletRequest mockRequest;
+    private MockHttpServletResponse mockResponse;
+    private OAuth2AccessToken mockOAuth2AccessToken;
+
+    @Mock private TokenAuthenticationCache authenticationCache;
+
+    /** Builds an immutable Spring Security 7 access token with the given value and expiry. */
+    private static OAuth2AccessToken accessToken(String value, long expiresInMillisFromNow) {
+        Instant expiresAt = Instant.now().plusMillis(expiresInMillisFromNow);
+        // issuedAt must be strictly before expiresAt (SS7 constraint), even for expired tokens.
+        Instant issuedAt = expiresAt.minusSeconds(3600);
+        return new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER, value, issuedAt, expiresAt);
+    }
+
+    /** Builds an OAuth2AccessTokenResponse as deserialized from a token-endpoint reply. */
+    private static OAuth2AccessTokenResponse tokenResponse(
+            String access, String refresh, long expiresInSeconds) {
+        OAuth2AccessTokenResponse.Builder b =
+                OAuth2AccessTokenResponse.withToken(access)
+                        .tokenType(OAuth2AccessToken.TokenType.BEARER)
+                        .expiresIn(expiresInSeconds);
+        if (refresh != null) {
+            b.refreshToken(refresh);
+        }
+        return b.build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        configuration = mock(OAuth2Configuration.class);
+        restTemplate = mock(RestTemplate.class);
+        authenticationCache = mock(TokenAuthenticationCache.class);
+
+        serviceDelegate = spy(new TestOAuth2SessionServiceDelegate());
+        serviceDelegate.setRefreshRestTemplate(restTemplate);
+        serviceDelegate.setConfiguration(configuration);
+        serviceDelegate.authenticationCache = authenticationCache;
+
+        mockRequest = new MockHttpServletRequest();
+        mockResponse = new MockHttpServletResponse();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockRequest));
+
+        when(configuration.isEnabled()).thenReturn(true);
+        when(configuration.getMaxRetries()).thenReturn(3);
+        when(configuration.getClientId()).thenReturn("testClientId");
+        when(configuration.getClientSecret()).thenReturn("testClientSecret");
+        when(configuration.getAccessTokenUri()).thenReturn("https://example.com/oauth2/token");
+        when(configuration.getInitialBackoffDelay()).thenReturn(1000L);
+        when(configuration.getBackoffMultiplier()).thenReturn(2.0);
+        when(configuration.getProvider()).thenReturn("oidc");
+
+        // Current cached access token (the refresh token is supplied separately, as a
+        // param/cookie).
+        mockOAuth2AccessToken = accessToken("providedAccessToken", 3600 * 1000);
+        serviceDelegate.currentAccessToken = mockOAuth2AccessToken;
+
+        Authentication mockAuthentication = mock(Authentication.class);
+        TokenDetails mockTokenDetails = mock(TokenDetails.class);
+        when(mockTokenDetails.getIdToken()).thenReturn("mockIdToken");
+        // The existing refresh token is carried on the cached TokenDetails (SS7 keeps it separate
+        // from the access token, where 2.6.x stored it).
+        when(mockTokenDetails.getRefreshToken())
+                .thenReturn(new OAuth2RefreshToken("existingRefreshToken", null));
+        when(mockAuthentication.getDetails()).thenReturn(mockTokenDetails);
+        when(authenticationCache.get("providedAccessToken")).thenReturn(mockAuthentication);
+
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(mockAuthentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+        // Clear the SecurityContext set in setUp so this test does not leak a mock authentication
+        // into other test classes sharing the same JVM fork (the token/header filters skip
+        // authentication when a context authentication is already present).
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void testRefreshWithValidTokens() {
+        String refreshToken = "providedRefreshToken";
+        String accessToken = "providedAccessToken";
+
+        ResponseEntity<OAuth2AccessTokenResponse> responseEntity =
+                new ResponseEntity<>(
+                        tokenResponse("newAccessToken", "newRefreshToken", 7200), HttpStatus.OK);
+
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenReturn(responseEntity);
+
+        when(serviceDelegate.getRequest()).thenReturn(mockRequest);
+        when(serviceDelegate.getResponse()).thenReturn(mockResponse);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNotNull(sessionToken, "SessionToken should not be null");
+        assertEquals(
+                "newAccessToken", sessionToken.getAccessToken(), "Access token should be updated");
+        assertNull(
+                sessionToken.getRefreshToken(),
+                "Refresh token should not be in the JSON response body");
+        assertTrue(
+                sessionToken.getExpires() > System.currentTimeMillis(),
+                "Token expiration should be in the future");
+        assertEquals("bearer", sessionToken.getTokenType(), "Token type should be 'bearer'");
+
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        assertEquals("newRefreshToken", refreshCookie.getValue());
+        assertTrue(refreshCookie.isHttpOnly(), "Cookie should be HttpOnly");
+        assertEquals("/", refreshCookie.getPath());
+        assertEquals(604800, refreshCookie.getMaxAge());
+
+        verify(authenticationCache).putCacheEntry(eq("newAccessToken"), any(Authentication.class));
+        verify(serviceDelegate, never())
+                .handleRefreshFailure(anyString(), anyString(), any(OAuth2Configuration.class));
+    }
+
+    @Test
+    void testRefreshWithInvalidRefreshToken() {
+        String refreshToken = "invalidRefreshToken";
+        String accessToken = "providedAccessToken";
+
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNotNull(sessionToken, "SessionToken should not be null even when refresh fails");
+        assertEquals(
+                "providedAccessToken",
+                sessionToken.getAccessToken(),
+                "Access token should remain unchanged");
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertTrue(refreshCookie.isHttpOnly(), "Cookie should be HttpOnly");
+        assertNotNull(sessionToken.getWarning(), "Warning message should be set");
+        assertTrue(
+                sessionToken.getWarning().contains("Using existing access token."),
+                "Expected warning message in SessionToken");
+    }
+
+    @Test
+    void testRefreshWithServerError() {
+        String refreshToken = "providedRefreshToken";
+        String accessToken = "providedAccessToken";
+
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNotNull(sessionToken, "SessionToken should not be null even when refresh fails");
+        assertEquals(
+                "providedAccessToken",
+                sessionToken.getAccessToken(),
+                "Access token should remain unchanged after server error");
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertNotNull(sessionToken.getWarning(), "Warning message should be set");
+        assertTrue(
+                sessionToken.getWarning().contains("Using existing access token."),
+                "Expected warning message in SessionToken");
+        verify(restTemplate, times(3))
+                .exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class));
+    }
+
+    @Test
+    void testRefreshWithNullResponse() {
+        String refreshToken = "providedRefreshToken";
+        String accessToken = "providedAccessToken";
+
+        ResponseEntity<OAuth2AccessTokenResponse> responseEntity =
+                new ResponseEntity<>((OAuth2AccessTokenResponse) null, HttpStatus.OK);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenReturn(responseEntity);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNotNull(sessionToken, "SessionToken should not be null even when response is null");
+        assertEquals(
+                "providedAccessToken",
+                sessionToken.getAccessToken(),
+                "Access token should remain unchanged");
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertNotNull(sessionToken.getWarning(), "Warning message should be set");
+        assertTrue(
+                sessionToken.getWarning().contains("Using existing access token."),
+                "Expected warning message in SessionToken");
+    }
+
+    @Test
+    void testRefreshWhenConfigurationDisabled() {
+        String refreshToken = "providedRefreshToken";
+        String accessToken = "providedAccessToken";
+
+        when(configuration.isEnabled()).thenReturn(false);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNotNull(
+                sessionToken, "SessionToken should not be null when configuration is disabled");
+        assertEquals(
+                "providedAccessToken",
+                sessionToken.getAccessToken(),
+                "Access token should remain unchanged");
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        verify(restTemplate, never())
+                .exchange(
+                        anyString(),
+                        any(HttpMethod.class),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class));
+    }
+
+    @Test
+    void testRefreshWithMissingAccessToken() {
+        String refreshToken = "providedRefreshToken";
+        String accessToken = null;
+
+        Exception exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> serviceDelegate.refresh(refreshToken, accessToken));
+
+        assertTrue(
+                exception
+                        .getMessage()
+                        .contains("Either the accessToken or the refresh token are missing"),
+                "Expected exception message");
+    }
+
+    @Test
+    void testRefreshWhenCacheReturnsNullAuthentication() {
+        String refreshToken = "providedRefreshToken";
+        String accessToken = "providedAccessToken";
+
+        when(authenticationCache.get("providedAccessToken")).thenReturn(null);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNotNull(
+                sessionToken,
+                "SessionToken should not be null even when authentication is not found in cache");
+        assertEquals(
+                "providedAccessToken",
+                sessionToken.getAccessToken(),
+                "Access token should remain unchanged");
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        // No cached session -> the supplied param refresh token is used (SS7 sources the existing
+        // refresh token from the cached TokenDetails, which is absent here).
+        assertEquals("providedRefreshToken", refreshCookie.getValue());
+    }
+
+    @Test
+    void testRefreshWhenAuthenticationIsAnonymous() {
+        String refreshToken = "providedRefreshToken";
+        String accessToken = "providedAccessToken";
+
+        Authentication anonymousAuthentication =
+                mock(
+                        org.springframework.security.authentication.AnonymousAuthenticationToken
+                                .class);
+        when(authenticationCache.get("providedAccessToken")).thenReturn(anonymousAuthentication);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNotNull(
+                sessionToken,
+                "SessionToken should not be null even when authentication is anonymous");
+        assertEquals(
+                "providedAccessToken",
+                sessionToken.getAccessToken(),
+                "Access token should remain unchanged");
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        // Anonymous/un-cached session -> the supplied param refresh token is used.
+        assertEquals("providedRefreshToken", refreshCookie.getValue());
+    }
+
+    @Test
+    void testRefreshWithExpiredAccessToken() {
+        String refreshToken = "providedRefreshToken";
+        String accessToken = "expiredAccessToken";
+
+        // Current access token expired in the past.
+        serviceDelegate.currentAccessToken = accessToken("providedAccessToken", -1000);
+
+        ResponseEntity<OAuth2AccessTokenResponse> responseEntity =
+                new ResponseEntity<>(
+                        tokenResponse("newAccessToken", "newRefreshToken", 7200), HttpStatus.OK);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenReturn(responseEntity);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNotNull(sessionToken, "SessionToken should not be null");
+        assertEquals(
+                "newAccessToken", sessionToken.getAccessToken(), "Access token should be updated");
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        assertEquals("newRefreshToken", refreshCookie.getValue());
+        assertTrue(refreshCookie.isHttpOnly(), "Cookie should be HttpOnly");
+        assertTrue(
+                sessionToken.getExpires() > System.currentTimeMillis(),
+                "Token expiration should be in the future");
+    }
+
+    @Test
+    void testRefreshWithExpiredTokenAndUnsuccessfulRefresh() {
+        String refreshToken = "expiredRefreshToken";
+        String accessToken = "expiredAccessToken";
+
+        // Current access token expired 5 minutes ago.
+        serviceDelegate.currentAccessToken = accessToken("providedAccessToken", -5 * 60 * 1000);
+
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNull(
+                sessionToken,
+                "SessionToken should be null when the token is expired and cannot be refreshed");
+        verify(restTemplate, times(3))
+                .exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class));
+    }
+
+    @Test
+    void testRefreshUpdatesChangedAccessToken() {
+        String oldAccessToken = "oldAccessToken";
+        String refreshToken = "validRefreshToken";
+
+        serviceDelegate.currentAccessToken = accessToken(oldAccessToken, 3600 * 1000);
+
+        Authentication mockAuthentication = mock(Authentication.class);
+        when(authenticationCache.get(oldAccessToken)).thenReturn(mockAuthentication);
+
+        String refreshedAccessTokenValue = "completelyNewAccessToken";
+        ResponseEntity<OAuth2AccessTokenResponse> responseEntity =
+                new ResponseEntity<>(
+                        tokenResponse(refreshedAccessTokenValue, "brandNewRefreshToken", 7200),
+                        HttpStatus.OK);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenReturn(responseEntity);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, oldAccessToken);
+
+        assertNotNull(sessionToken, "SessionToken should not be null after a successful refresh.");
+        assertEquals(
+                refreshedAccessTokenValue,
+                sessionToken.getAccessToken(),
+                "The SessionToken's accessToken must be updated to the new value.");
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set");
+        assertEquals(
+                "brandNewRefreshToken",
+                refreshCookie.getValue(),
+                "Cookie must contain the new refresh token value.");
+        assertTrue(refreshCookie.isHttpOnly(), "Cookie should be HttpOnly");
+
+        verify(authenticationCache).removeEntry(eq(oldAccessToken));
+        verify(authenticationCache)
+                .putCacheEntry(eq(refreshedAccessTokenValue), any(Authentication.class));
+
+        assertEquals(
+                refreshedAccessTokenValue,
+                serviceDelegate.currentAccessToken.getTokenValue(),
+                "Service delegate must store the new access token internally.");
+        assertEquals(
+                "brandNewRefreshToken",
+                serviceDelegate.currentRefreshToken.getTokenValue(),
+                "Service delegate must store the new refresh token internally.");
+    }
+
+    @Test
+    void testRefreshReadsCookieWhenNoRefreshTokenInParams() {
+        String accessToken = "providedAccessToken";
+
+        // No refresh token cached for this token -> the delegate must read it from the cookie.
+        when(authenticationCache.get("providedAccessToken")).thenReturn(mock(Authentication.class));
+
+        // Refresh token only present as a cookie.
+        mockRequest.setCookies(new Cookie("refresh_token", "cookieRefreshToken"));
+
+        ResponseEntity<OAuth2AccessTokenResponse> responseEntity =
+                new ResponseEntity<>(
+                        tokenResponse("newAccessToken", "newRefreshToken", 7200), HttpStatus.OK);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenReturn(responseEntity);
+
+        when(serviceDelegate.getRequest()).thenReturn(mockRequest);
+        when(serviceDelegate.getResponse()).thenReturn(mockResponse);
+
+        SessionToken sessionToken = serviceDelegate.refresh(null, accessToken);
+
+        assertNotNull(sessionToken, "SessionToken should not be null");
+        assertEquals("newAccessToken", sessionToken.getAccessToken());
+        assertNull(sessionToken.getRefreshToken(), "Refresh token should not be in JSON body");
+
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "Refresh token cookie should be set on response");
+        assertEquals("newRefreshToken", refreshCookie.getValue());
+        assertTrue(refreshCookie.isHttpOnly(), "Cookie should be HttpOnly");
+    }
+
+    @Test
+    void testRefreshSkippedWhenTokenStillValid() {
+        long now = System.currentTimeMillis();
+        long iat = (now - 60_000) / 1000; // 1 minute ago
+        long exp = (now + 9 * 60_000) / 1000; // 9 minutes from now
+        String jwtToken = buildFakeJwt(iat, exp);
+
+        serviceDelegate.currentAccessToken = accessToken(jwtToken, 9 * 60_000);
+
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(true);
+        when(configuration.getRefreshTokenLifetimeFraction()).thenReturn(0.8);
+
+        SessionToken sessionToken = serviceDelegate.refresh(null, jwtToken);
+
+        assertNotNull(sessionToken);
+        assertEquals(jwtToken, sessionToken.getAccessToken());
+        assertNotNull(sessionToken.getWarning());
+        assertTrue(sessionToken.getWarning().contains("Token still valid; refresh skipped."));
+
+        verify(restTemplate, never())
+                .exchange(
+                        anyString(),
+                        any(HttpMethod.class),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class));
+    }
+
+    @Test
+    void testRefreshProceedsWhenTokenNearExpiry() {
+        String refreshToken = "providedRefreshToken";
+        long now = System.currentTimeMillis();
+        long iat = (now - 9 * 60_000) / 1000; // 9 minutes ago
+        long exp = (now + 60_000) / 1000; // 1 minute from now
+        String jwtToken = buildFakeJwt(iat, exp);
+
+        serviceDelegate.currentAccessToken = accessToken(jwtToken, 60_000);
+
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(true);
+        when(configuration.getRefreshTokenLifetimeFraction()).thenReturn(0.8);
+
+        ResponseEntity<OAuth2AccessTokenResponse> responseEntity =
+                new ResponseEntity<>(
+                        tokenResponse("newAccessToken", "newRefreshToken", 7200), HttpStatus.OK);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenReturn(responseEntity);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, jwtToken);
+
+        assertNotNull(sessionToken);
+        assertEquals("newAccessToken", sessionToken.getAccessToken());
+
+        verify(restTemplate, atLeastOnce())
+                .exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class));
+    }
+
+    @Test
+    void testRefreshSkipDisabledByConfig() {
+        String refreshToken = "providedRefreshToken";
+        long now = System.currentTimeMillis();
+        long iat = (now - 60_000) / 1000;
+        long exp = (now + 9 * 60_000) / 1000;
+        String jwtToken = buildFakeJwt(iat, exp);
+
+        serviceDelegate.currentAccessToken = accessToken(jwtToken, 9 * 60_000);
+
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(false);
+
+        ResponseEntity<OAuth2AccessTokenResponse> responseEntity =
+                new ResponseEntity<>(
+                        tokenResponse("newAccessToken", "newRefreshToken", 7200), HttpStatus.OK);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenReturn(responseEntity);
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, jwtToken);
+
+        assertNotNull(sessionToken);
+        assertEquals("newAccessToken", sessionToken.getAccessToken());
+        verify(restTemplate, atLeastOnce())
+                .exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class));
+    }
+
+    @Test
+    void testRefreshSkipFallbackWithoutIat() {
+        long now = System.currentTimeMillis();
+        long exp = (now + 10 * 60_000) / 1000; // 10 minutes from now
+        String jwtToken = buildFakeJwtExpOnly(exp);
+
+        serviceDelegate.currentAccessToken = accessToken(jwtToken, 10 * 60_000);
+
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(true);
+        when(configuration.getRefreshTokenLifetimeFraction()).thenReturn(0.8);
+
+        SessionToken sessionToken = serviceDelegate.refresh(null, jwtToken);
+
+        assertNotNull(sessionToken);
+        assertEquals(jwtToken, sessionToken.getAccessToken());
+        assertNotNull(sessionToken.getWarning());
+        assertTrue(sessionToken.getWarning().contains("Token still valid; refresh skipped."));
+        verify(restTemplate, never())
+                .exchange(
+                        anyString(),
+                        any(HttpMethod.class),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class));
+    }
+
+    /** Builds a fake unsigned JWT with iat and exp claims (decodable by JWTHelper). */
+    private String buildFakeJwt(long iatEpochSeconds, long expEpochSeconds) {
+        String header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
+        String payload =
+                "{\"sub\":\"testuser\",\"iat\":"
+                        + iatEpochSeconds
+                        + ",\"exp\":"
+                        + expEpochSeconds
+                        + "}";
+        return Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(header.getBytes(StandardCharsets.UTF_8))
+                + "."
+                + Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(payload.getBytes(StandardCharsets.UTF_8))
+                + ".";
+    }
+
+    /** Builds a fake unsigned JWT with only an exp claim (no iat). */
+    private String buildFakeJwtExpOnly(long expEpochSeconds) {
+        String header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
+        String payload = "{\"sub\":\"testuser\",\"exp\":" + expEpochSeconds + "}";
+        return Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(header.getBytes(StandardCharsets.UTF_8))
+                + "."
+                + Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(payload.getBytes(StandardCharsets.UTF_8))
+                + ".";
+    }
+
+    private Cookie getRefreshTokenCookie(MockHttpServletResponse response) {
+        Cookie[] cookies = response.getCookies();
+        Cookie result = null;
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh_token".equalsIgnoreCase(cookie.getName())) {
+                    result = cookie;
+                }
+            }
+        }
+        return result;
+    }
+
+    /** Test subclass of OAuth2SessionServiceDelegate for testing purposes. */
+    class TestOAuth2SessionServiceDelegate extends OAuth2SessionServiceDelegate {
+
+        private RestTemplate refreshRestTemplate;
+        private OAuth2Configuration configuration;
+        private OAuth2AccessToken currentAccessToken;
+        private OAuth2RefreshToken currentRefreshToken;
+        protected TokenAuthenticationCache authenticationCache;
+
+        public TestOAuth2SessionServiceDelegate() {
+            super(null, null); // Mocked dependencies
+        }
+
+        public void setRefreshRestTemplate(RestTemplate refreshRestTemplate) {
+            this.refreshRestTemplate = refreshRestTemplate;
+        }
+
+        public void setConfiguration(OAuth2Configuration configuration) {
+            this.configuration = configuration;
+        }
+
+        @Override
+        protected RestTemplate createRefreshRestTemplate() {
+            return refreshRestTemplate;
+        }
+
+        @Override
+        protected OAuth2Configuration configuration() {
+            return configuration;
+        }
+
+        @Override
+        protected HttpServletRequest getRequest() {
+            return mockRequest;
+        }
+
+        @Override
+        protected HttpServletResponse getResponse() {
+            return mockResponse;
+        }
+
+        @Override
+        protected OAuth2AccessToken retrieveAccessToken(String accessToken, Long expires) {
+            return currentAccessToken;
+        }
+
+        @Override
+        protected TokenAuthenticationCache cache() {
+            return authenticationCache; // Return the mocked cache
+        }
+
+        @Override
+        protected void updateAuthToken(
+                String oldAccessToken,
+                OAuth2AccessToken newAccessToken,
+                OAuth2RefreshToken newRefreshToken,
+                OAuth2Configuration configuration) {
+            // Track the new tokens internally (the real implementation stores them on
+            // TokenDetails).
+            this.currentAccessToken = newAccessToken;
+            this.currentRefreshToken = newRefreshToken;
+
+            authenticationCache.removeEntry(oldAccessToken);
+            authenticationCache.putCacheEntry(
+                    newAccessToken.getTokenValue(), mock(Authentication.class));
+        }
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
@@ -653,6 +653,79 @@ class RefreshTokenServiceTest {
                         eq(OAuth2AccessTokenResponse.class));
     }
 
+    @Test
+    void testRefreshFailureRespondsWith401InsteadOfRedirect() throws Exception {
+        // The access token is already expired and the IdP rejects the refresh: the XHR
+        // client must receive a clean 401 (a 302 to the login page cannot be followed by the
+        // client and was observed live as a 302 -> 404 chain that wiped the session).
+        serviceDelegate.currentAccessToken = accessToken("providedAccessToken", -10 * 60 * 1000);
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessTokenResponse.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        SessionToken sessionToken =
+                serviceDelegate.refresh("expiredRefreshToken", "providedAccessToken");
+
+        assertNull(sessionToken, "A failed refresh of an expired session returns no token");
+        assertEquals(401, mockResponse.getStatus(), "The client must receive a 401");
+        assertNull(mockResponse.getRedirectedUrl(), "The refresh endpoint must never redirect");
+        String content = mockResponse.getContentAsString();
+        assertTrue(content.contains("session_expired"), "The error code is reported: " + content);
+        assertTrue(
+                content.contains("/openid/oidc/login"),
+                "The login URL is reported so the client can start a new flow: " + content);
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "The refresh token cookie is cleared");
+        assertEquals(0, refreshCookie.getMaxAge());
+    }
+
+    @Test
+    void testShouldSkipRefreshFalseWhenRefreshTokenNearExpiry() {
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(true);
+        long nowSeconds = System.currentTimeMillis() / 1000;
+
+        // Access token still fresh for one hour: the legacy logic alone would skip.
+        OAuth2AccessToken freshToken = accessToken("opaque-at", 3600 * 1000);
+
+        // Refresh token (JWT, as Keycloak's) expiring within the safety window: refresh
+        // tokens only slide when actually used, so the skip must be bypassed.
+        String nearExpiryRt = buildFakeJwtExpOnly(nowSeconds + 60);
+        assertFalse(
+                serviceDelegate.callShouldSkipRefresh(freshToken, nearExpiryRt, configuration),
+                "A refresh token close to its own expiry must force a real IdP refresh");
+
+        // A long-lived refresh token keeps the legacy skip behavior.
+        String longLivedRt = buildFakeJwtExpOnly(nowSeconds + 1800);
+        assertTrue(
+                serviceDelegate.callShouldSkipRefresh(freshToken, longLivedRt, configuration),
+                "A healthy refresh token keeps the skip in place");
+
+        // An opaque (non-JWT) refresh token carries no expiry info: legacy behavior.
+        assertTrue(
+                serviceDelegate.callShouldSkipRefresh(
+                        freshToken, "opaque-refresh-token", configuration),
+                "Opaque refresh tokens keep the legacy skip behavior");
+    }
+
+    @Test
+    void testClearCookiesExpiresRefreshTokenCookie() {
+        // Max-Age 0 actually deletes the cookie: the previous -1 ("session cookie")
+        // RE-INSTATED the refresh token on the logout response (observed live as a logout
+        // carrying both the clearing Set-Cookie and a full refresh_token one).
+        mockRequest.setCookies(
+                new Cookie("refresh_token", "leftoverRt"), new Cookie("JSESSIONID", "xyz"));
+
+        serviceDelegate.callClearCookies(mockRequest, mockResponse);
+
+        Cookie cleared = getRefreshTokenCookie(mockResponse);
+        assertNotNull(cleared, "The refresh token cookie must be re-emitted for deletion");
+        assertEquals(0, cleared.getMaxAge(), "Max-Age must be 0 (deletion), not -1 (session)");
+        assertEquals("", cleared.getValue(), "The cookie value must be blanked");
+    }
+
     /** Builds a fake unsigned JWT with iat and exp claims (decodable by JWTHelper). */
     private String buildFakeJwt(long iatEpochSeconds, long expEpochSeconds) {
         String header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
@@ -718,6 +791,16 @@ class RefreshTokenServiceTest {
 
         public void setConfiguration(OAuth2Configuration configuration) {
             this.configuration = configuration;
+        }
+
+        // Bridges for protected superclass members living in a different package.
+        boolean callShouldSkipRefresh(
+                OAuth2AccessToken token, String refreshToken, OAuth2Configuration config) {
+            return shouldSkipRefresh(token, refreshToken, config);
+        }
+
+        void callClearCookies(HttpServletRequest request, HttpServletResponse response) {
+            clearCookies(request, response);
         }
 
         @Override

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/JweTokenDecryptorTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/JweTokenDecryptorTest.java
@@ -1,0 +1,239 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.ECDHEncrypter;
+import com.nimbusds.jose.crypto.RSAEncrypter;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class JweTokenDecryptorTest {
+
+    private static RSAPublicKey rsaPublicKey;
+    private static RSAPrivateKey rsaPrivateKey;
+    private static RSAPublicKey wrongPublicKey;
+    private static RSAPrivateKey wrongPrivateKey;
+    private static ECPublicKey ecPublicKey;
+    private static ECPrivateKey ecPrivateKey;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+
+        KeyPair keyPair = keyGen.generateKeyPair();
+        rsaPublicKey = (RSAPublicKey) keyPair.getPublic();
+        rsaPrivateKey = (RSAPrivateKey) keyPair.getPrivate();
+
+        KeyPair wrongKeyPair = keyGen.generateKeyPair();
+        wrongPublicKey = (RSAPublicKey) wrongKeyPair.getPublic();
+        wrongPrivateKey = (RSAPrivateKey) wrongKeyPair.getPrivate();
+
+        KeyPairGenerator ecKeyGen = KeyPairGenerator.getInstance("EC");
+        ecKeyGen.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair ecKeyPair = ecKeyGen.generateKeyPair();
+        ecPublicKey = (ECPublicKey) ecKeyPair.getPublic();
+        ecPrivateKey = (ECPrivateKey) ecKeyPair.getPrivate();
+    }
+
+    @Test
+    public void testIsJweToken() {
+        // JWE tokens have 5 dot-separated parts
+        assertTrue(JweTokenDecryptor.isJweToken("a.b.c.d.e"));
+        assertTrue(JweTokenDecryptor.isJweToken("header.key.iv.ciphertext.tag"));
+
+        // JWS tokens have 3 dot-separated parts
+        assertFalse(JweTokenDecryptor.isJweToken("a.b.c"));
+        assertFalse(JweTokenDecryptor.isJweToken("header.payload.signature"));
+
+        // Other cases
+        assertFalse(JweTokenDecryptor.isJweToken("no-dots-here"));
+        assertFalse(JweTokenDecryptor.isJweToken("a.b"));
+        assertFalse(JweTokenDecryptor.isJweToken("a.b.c.d"));
+        assertFalse(JweTokenDecryptor.isJweToken("a.b.c.d.e.f"));
+        assertFalse(JweTokenDecryptor.isJweToken(""));
+        assertFalse(JweTokenDecryptor.isJweToken(null));
+    }
+
+    @Test
+    public void testDecryptRsaOaep() throws Exception {
+        // Create a plain JWT, encrypt it with RSA-OAEP + A256GCM
+        JWTClaimsSet claims =
+                new JWTClaimsSet.Builder()
+                        .subject("test-user")
+                        .issuer("https://test.issuer/")
+                        .audience("test-client")
+                        .claim("email", "user@example.com")
+                        .expirationTime(new Date(System.currentTimeMillis() + 3600_000))
+                        .build();
+
+        JWEHeader header =
+                new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM).build();
+        EncryptedJWT encryptedJWT = new EncryptedJWT(header, claims);
+        encryptedJWT.encrypt(new RSAEncrypter(rsaPublicKey));
+        String jweToken = encryptedJWT.serialize();
+
+        // Verify it's detected as JWE
+        assertTrue(JweTokenDecryptor.isJweToken(jweToken));
+
+        // Decrypt and verify inner claims
+        JweTokenDecryptor decryptor = new JweTokenDecryptor(rsaPrivateKey);
+        String decrypted = decryptor.decrypt(jweToken);
+        assertNotNull(decrypted);
+        assertTrue(decrypted.contains("test-user"));
+        assertTrue(decrypted.contains("user@example.com"));
+    }
+
+    @Test
+    public void testDecryptNestedJws() throws Exception {
+        // Create a signed JWT (JWS)
+        JWTClaimsSet claims =
+                new JWTClaimsSet.Builder()
+                        .subject("nested-user")
+                        .issuer("https://test.issuer/")
+                        .audience("test-client")
+                        .claim("email", "nested@example.com")
+                        .expirationTime(new Date(System.currentTimeMillis() + 3600_000))
+                        .build();
+
+        SignedJWT signedJWT =
+                new SignedJWT(
+                        new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("test-kid").build(),
+                        claims);
+        signedJWT.sign(new RSASSASigner(rsaPrivateKey));
+        String jwsToken = signedJWT.serialize();
+
+        // Wrap the signed JWT inside a JWE (nested JWS inside JWE)
+        JWEHeader jweHeader =
+                new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                        .contentType("JWT")
+                        .build();
+        JWEObject jweObject = new JWEObject(jweHeader, new Payload(signedJWT));
+        jweObject.encrypt(new RSAEncrypter(rsaPublicKey));
+        String nestedJweToken = jweObject.serialize();
+
+        // Verify it's detected as JWE
+        assertTrue(JweTokenDecryptor.isJweToken(nestedJweToken));
+
+        // Decrypt — should return the inner JWS token string
+        JweTokenDecryptor decryptor = new JweTokenDecryptor(rsaPrivateKey);
+        String decrypted = decryptor.decrypt(nestedJweToken);
+        assertNotNull(decrypted);
+
+        // The decrypted content should be parseable as a signed JWT (3-part)
+        assertFalse(JweTokenDecryptor.isJweToken(decrypted));
+        String[] parts = decrypted.split("\\.");
+        assertEquals(3, parts.length, "Nested JWS should have 3 parts after decryption");
+    }
+
+    @Test
+    public void testDecryptJweWithEcKey() throws Exception {
+        // Create a plain JWT, encrypt with ECDH-ES+A256KW + A256GCM using EC P-256 key
+        JWTClaimsSet claims =
+                new JWTClaimsSet.Builder()
+                        .subject("ec-user")
+                        .issuer("https://test.issuer/")
+                        .audience("test-client")
+                        .claim("email", "ecuser@example.com")
+                        .expirationTime(new Date(System.currentTimeMillis() + 3600_000))
+                        .build();
+
+        JWEHeader header =
+                new JWEHeader.Builder(JWEAlgorithm.ECDH_ES_A256KW, EncryptionMethod.A256GCM)
+                        .build();
+        EncryptedJWT encryptedJWT = new EncryptedJWT(header, claims);
+        encryptedJWT.encrypt(new ECDHEncrypter(ecPublicKey));
+        String jweToken = encryptedJWT.serialize();
+
+        assertTrue(JweTokenDecryptor.isJweToken(jweToken));
+
+        // Decrypt with EC private key
+        JweTokenDecryptor decryptor = new JweTokenDecryptor(ecPrivateKey);
+        String decrypted = decryptor.decrypt(jweToken);
+        assertNotNull(decrypted);
+        assertTrue(decrypted.contains("ec-user"));
+        assertTrue(decrypted.contains("ecuser@example.com"));
+    }
+
+    @Test
+    public void testDecryptWithWrongKey() throws Exception {
+        // Encrypt with one key pair
+        JWTClaimsSet claims =
+                new JWTClaimsSet.Builder()
+                        .subject("wrong-key-user")
+                        .expirationTime(new Date(System.currentTimeMillis() + 3600_000))
+                        .build();
+
+        JWEHeader header =
+                new JWEHeader.Builder(JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM).build();
+        EncryptedJWT encryptedJWT = new EncryptedJWT(header, claims);
+        encryptedJWT.encrypt(new RSAEncrypter(rsaPublicKey));
+        String jweToken = encryptedJWT.serialize();
+
+        // Attempt to decrypt with a different private key — should throw
+        JweTokenDecryptor decryptor = new JweTokenDecryptor(wrongPrivateKey);
+        assertThrows(IOException.class, () -> decryptor.decrypt(jweToken));
+    }
+
+    @Test
+    public void testNullAndEmpty() {
+        assertFalse(JweTokenDecryptor.isJweToken(null));
+        assertFalse(JweTokenDecryptor.isJweToken(""));
+        assertFalse(JweTokenDecryptor.isJweToken("   "));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new JweTokenDecryptor(null),
+                "Constructor should reject null private key");
+    }
+
+    @Test
+    public void testDecryptInvalidToken() {
+        JweTokenDecryptor decryptor = new JweTokenDecryptor(rsaPrivateKey);
+        assertThrows(
+                IOException.class,
+                () -> decryptor.decrypt("not.a.valid.jwe.token"),
+                "Should throw IOException for invalid JWE token");
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/MicrosoftGraphClientTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/bearer/MicrosoftGraphClientTest.java
@@ -1,0 +1,236 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.bearer;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+public class MicrosoftGraphClientTest {
+
+    private static WireMockServer graphService;
+    private static MicrosoftGraphClient client;
+    private static final String TEST_TOKEN = "test-access-token-12345";
+
+    @BeforeAll
+    static void beforeAll() {
+        graphService = new WireMockServer(wireMockConfig().dynamicPort());
+        graphService.start();
+
+        String graphEndpoint = "http://localhost:" + graphService.port();
+        client = new MicrosoftGraphClient(graphEndpoint);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        graphService.stop();
+    }
+
+    @Test
+    public void testFetchMemberOfGroups() {
+        // Response with mixed types: groups + service principals
+        graphService.stubFor(
+                WireMock.get(urlPathEqualTo("/me/memberOf"))
+                        .withHeader("Authorization", equalTo("Bearer " + TEST_TOKEN))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"GIS Analysts\","
+                                                        + "\"id\":\"g1\"},"
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"Map Editors\","
+                                                        + "\"id\":\"g2\"},"
+                                                        + "{\"@odata.type\":\"#microsoft.graph.servicePrincipal\","
+                                                        + "\"displayName\":\"Some SP\","
+                                                        + "\"id\":\"sp1\"}"
+                                                        + "]}")));
+
+        List<String> groups = client.fetchMemberOfGroups(TEST_TOKEN);
+
+        assertEquals(2, groups.size());
+        assertTrue(groups.contains("GIS Analysts"));
+        assertTrue(groups.contains("Map Editors"));
+        // Service principals should be filtered out
+        assertFalse(groups.contains("Some SP"));
+    }
+
+    @Test
+    public void testFetchMemberOfGroupsPagination() {
+        String page2Url =
+                "http://localhost:" + graphService.port() + "/me/memberOf?$skiptoken=page2";
+
+        // Page 1 with nextLink
+        graphService.stubFor(
+                WireMock.get(urlPathEqualTo("/me/memberOf"))
+                        .withQueryParam("$select", containing("displayName"))
+                        .withHeader("Authorization", equalTo("Bearer " + TEST_TOKEN))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"@odata.nextLink\":\""
+                                                        + page2Url
+                                                        + "\","
+                                                        + "\"value\":["
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"Group A\",\"id\":\"g1\"}"
+                                                        + "]}")));
+
+        // Page 2 without nextLink
+        graphService.stubFor(
+                WireMock.get(urlPathEqualTo("/me/memberOf"))
+                        .withQueryParam("$skiptoken", equalTo("page2"))
+                        .withHeader("Authorization", equalTo("Bearer " + TEST_TOKEN))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"@odata.type\":\"#microsoft.graph.group\","
+                                                        + "\"displayName\":\"Group B\",\"id\":\"g2\"}"
+                                                        + "]}")));
+
+        List<String> groups = client.fetchMemberOfGroups(TEST_TOKEN);
+
+        assertEquals(2, groups.size());
+        assertTrue(groups.contains("Group A"));
+        assertTrue(groups.contains("Group B"));
+    }
+
+    @Test
+    public void testFetchMemberOfGroupsHttpError() {
+        // Clear stubs from other tests
+        graphService.resetMappings();
+
+        // Return 403 Forbidden
+        graphService.stubFor(
+                WireMock.get(urlPathEqualTo("/me/memberOf"))
+                        .willReturn(aResponse().withStatus(403).withBody("Forbidden")));
+
+        List<String> groups = client.fetchMemberOfGroups(TEST_TOKEN);
+
+        assertTrue(groups.isEmpty(), "HTTP error should return empty list");
+    }
+
+    @Test
+    public void testFetchAppRoleAssignments() {
+        graphService.stubFor(
+                WireMock.get(urlPathEqualTo("/me/appRoleAssignments"))
+                        .withHeader("Authorization", equalTo("Bearer " + TEST_TOKEN))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"appRoleId\":\"role-guid-001\","
+                                                        + "\"resourceId\":\"sp-guid-001\"},"
+                                                        + "{\"appRoleId\":\"role-guid-002\","
+                                                        + "\"resourceId\":\"sp-guid-001\"}"
+                                                        + "]}")));
+
+        List<MicrosoftGraphClient.AppRoleAssignment> assignments =
+                client.fetchAppRoleAssignments(TEST_TOKEN);
+
+        assertEquals(2, assignments.size());
+        assertEquals("role-guid-001", assignments.get(0).getAppRoleId());
+        assertEquals("sp-guid-001", assignments.get(0).getResourceId());
+        assertEquals("role-guid-002", assignments.get(1).getAppRoleId());
+    }
+
+    @Test
+    public void testResolveAppRoleNames() {
+        graphService.stubFor(
+                WireMock.get(urlPathEqualTo("/servicePrincipals/sp-guid-001/appRoles"))
+                        .withHeader("Authorization", equalTo("Bearer " + TEST_TOKEN))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                "Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(
+                                                "{\"value\":["
+                                                        + "{\"id\":\"role-guid-001\","
+                                                        + "\"value\":\"Admin\","
+                                                        + "\"displayName\":\"Administrator\"},"
+                                                        + "{\"id\":\"role-guid-002\","
+                                                        + "\"value\":\"Viewer\","
+                                                        + "\"displayName\":\"Viewer\"}"
+                                                        + "]}")));
+
+        List<MicrosoftGraphClient.AppRoleAssignment> assignments =
+                Arrays.asList(
+                        new MicrosoftGraphClient.AppRoleAssignment("role-guid-001", "sp-guid-001"),
+                        new MicrosoftGraphClient.AppRoleAssignment("role-guid-002", "sp-guid-001"));
+
+        List<String> roleNames = client.resolveAppRoleNames(TEST_TOKEN, assignments);
+
+        assertEquals(2, roleNames.size());
+        assertTrue(roleNames.contains("Admin"));
+        assertTrue(roleNames.contains("Viewer"));
+    }
+
+    @Test
+    public void testEmptyAndNullToken() {
+        // Null token
+        List<String> groups1 = client.fetchMemberOfGroups(null);
+        assertTrue(groups1.isEmpty(), "Null token should return empty list");
+
+        // Empty token
+        List<String> groups2 = client.fetchMemberOfGroups("");
+        assertTrue(groups2.isEmpty(), "Empty token should return empty list");
+
+        // Null token for assignments
+        List<MicrosoftGraphClient.AppRoleAssignment> assignments =
+                client.fetchAppRoleAssignments(null);
+        assertTrue(assignments.isEmpty(), "Null token should return empty assignments");
+
+        // Null/empty for resolve
+        List<String> roles = client.resolveAppRoleNames(null, java.util.Collections.emptyList());
+        assertTrue(roles.isEmpty(), "Null token should return empty role names");
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/ClientSecretRequestEnhancerTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/ClientSecretRequestEnhancerTest.java
@@ -1,0 +1,80 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.enancher;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public class ClientSecretRequestEnhancerTest {
+
+    @Test
+    public void testEnhanceAddsClientSecret() {
+        ClientSecretRequestEnhancer enhancer = new ClientSecretRequestEnhancer();
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+
+        enhancer.enhance(form, "my-secret-value");
+
+        assertTrue(form.containsKey("client_secret"), "Form should contain client_secret");
+        assertEquals(
+                "my-secret-value",
+                form.getFirst("client_secret"),
+                "client_secret should match the supplied secret");
+    }
+
+    @Test
+    public void testEnhanceOverwritesExistingSecret() {
+        ClientSecretRequestEnhancer enhancer = new ClientSecretRequestEnhancer();
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("client_secret", "old-secret");
+
+        enhancer.enhance(form, "new-secret");
+
+        assertEquals(
+                1, form.get("client_secret").size(), "Should have exactly one client_secret value");
+        assertEquals(
+                "new-secret",
+                form.getFirst("client_secret"),
+                "client_secret should be overwritten with the new value");
+    }
+
+    @Test
+    public void testEnhanceSkipsBlankSecret() {
+        ClientSecretRequestEnhancer enhancer = new ClientSecretRequestEnhancer();
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+
+        enhancer.enhance(form, null);
+        enhancer.enhance(form, "");
+
+        assertFalse(
+                form.containsKey("client_secret"),
+                "client_secret should not be added for a blank secret");
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/PKCERequestEnhancerTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/enancher/PKCERequestEnhancerTest.java
@@ -1,0 +1,110 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2024-2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.enancher;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public class PKCERequestEnhancerTest {
+
+    @Test
+    public void testEnhanceAddsCodeVerifierFromSession() {
+        OpenIdConnectConfiguration config = new OpenIdConnectConfiguration();
+        config.setUsePKCE(true);
+        config.setSendClientSecret(false);
+
+        PKCERequestEnhancer enhancer = new PKCERequestEnhancer(config);
+
+        MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+        httpRequest
+                .getSession(true)
+                .setAttribute(
+                        OpenIdConnectConfiguration.PKCE_CODE_VERIFIER_SESSION_ATTR,
+                        "session-verifier-99");
+
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        enhancer.enhance(form, httpRequest);
+
+        assertTrue(form.containsKey(PkceParameterNames.CODE_VERIFIER));
+        assertEquals("session-verifier-99", form.getFirst(PkceParameterNames.CODE_VERIFIER));
+        assertFalse(form.containsKey("client_secret"), "client_secret should not be added");
+
+        // Verify the session attribute was consumed (removed) after retrieval.
+        assertNull(
+                httpRequest
+                        .getSession()
+                        .getAttribute(OpenIdConnectConfiguration.PKCE_CODE_VERIFIER_SESSION_ATTR),
+                "Session verifier should be consumed (removed) after use");
+    }
+
+    @Test
+    public void testEnhanceAddsClientSecretWhenEnabled() {
+        OpenIdConnectConfiguration config = new OpenIdConnectConfiguration();
+        config.setUsePKCE(true);
+        config.setSendClientSecret(true);
+        config.setClientSecret("dual-secret");
+
+        PKCERequestEnhancer enhancer = new PKCERequestEnhancer(config);
+
+        MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+        httpRequest
+                .getSession(true)
+                .setAttribute(
+                        OpenIdConnectConfiguration.PKCE_CODE_VERIFIER_SESSION_ATTR, "verifier-abc");
+
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        enhancer.enhance(form, httpRequest);
+
+        assertTrue(form.containsKey("client_secret"), "client_secret should be added");
+        assertEquals("dual-secret", form.getFirst("client_secret"));
+        assertTrue(form.containsKey(PkceParameterNames.CODE_VERIFIER));
+        assertEquals("verifier-abc", form.getFirst(PkceParameterNames.CODE_VERIFIER));
+    }
+
+    @Test
+    public void testEnhanceSkipsPkceWhenDisabled() {
+        OpenIdConnectConfiguration config = new OpenIdConnectConfiguration();
+        config.setUsePKCE(false);
+        config.setSendClientSecret(false);
+
+        PKCERequestEnhancer enhancer = new PKCERequestEnhancer(config);
+
+        MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        enhancer.enhance(form, httpRequest);
+
+        assertFalse(form.containsKey(PkceParameterNames.CODE_VERIFIER));
+        assertFalse(form.containsKey("client_secret"));
+    }
+}

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -39,6 +39,7 @@
 # oidcOAuth2Config.clientSecret=
 # oidcOAuth2Config.sendClientSecret=true
 # oidcOAuth2Config.discoveryUrl=https://<idp-host>/.well-known/openid-configuration
+# Auto-create the user in the local DB on first OIDC login. Group and role sync requires this.
 # oidcOAuth2Config.autoCreateUser=true
 # oidcOAuth2Config.redirectUri=
 # oidcOAuth2Config.internalRedirectUri=../../mapstore/
@@ -48,7 +49,7 @@
 # oidcOAuth2Config.rolesClaim=roles
 # oidcOAuth2Config.groupsClaim=groups
 # oidcOAuth2Config.roleMappings=admin:ADMIN,user:USER
-# oidcOAuth2Config.groupMappings=
+# oidcOAuth2Config.groupMappings=devs:DEVS,qa:QA
 # oidcOAuth2Config.dropUnmapped=false
 # Optional comma-separated groups ALWAYS assigned to the authenticated user, in addition
 # to the claim-derived ones (not subject to groupMappings/dropUnmapped). Created on the

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -37,6 +37,7 @@
 # oidcOAuth2Config.enabled=false
 # oidcOAuth2Config.clientId=
 # oidcOAuth2Config.clientSecret=
+# oidcOAuth2Config.sendClientSecret=true
 # oidcOAuth2Config.discoveryUrl=https://<idp-host>/.well-known/openid-configuration
 # oidcOAuth2Config.autoCreateUser=true
 # oidcOAuth2Config.redirectUri=

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -49,6 +49,9 @@
 # oidcOAuth2Config.roleMappings=admin:ADMIN,user:USER
 # oidcOAuth2Config.groupMappings=
 # oidcOAuth2Config.dropUnmapped=false
+# Optional fallback group when NO group could be derived from the claims (claim missing,
+# or every value dropped by groupMappings/dropUnmapped). Created on the fly when missing.
+# oidcOAuth2Config.authenticatedDefaultGroup=
 # oidcOAuth2Config.usePKCE=false
 #
 # Access type for authorization (set to "offline" for refresh token support, e.g. Google)

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -1,12 +1,12 @@
 #
-# Uncomment the following to auto create unrecognized users. 
+# Uncomment the following to auto create unrecognized users.
 #
-/src/modules/rest/impl/src/main/resources/applicationContext.xml:
-#         
+# NOTE: You need to uncomment the interceptor on /src/modules/rest/impl/src/main/resources/applicationContext.xml:
+#
 #	<jaxrs:inInterceptors>
 #      <!-- Auto create users interceptor (uncomment to allow users auto-creation for /users requests) -->
 #      <ref bean="autoCreateUsersInterceptor"/>
-# 
+#
 #autoCreateUsersInterceptor.autoCreateUsers=true
 #
 # Role to assign to automatically created users

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -49,9 +49,10 @@
 # oidcOAuth2Config.roleMappings=admin:ADMIN,user:USER
 # oidcOAuth2Config.groupMappings=
 # oidcOAuth2Config.dropUnmapped=false
-# Optional fallback group when NO group could be derived from the claims (claim missing,
-# or every value dropped by groupMappings/dropUnmapped). Created on the fly when missing.
-# oidcOAuth2Config.authenticatedDefaultGroup=
+# Optional comma-separated groups ALWAYS assigned to the authenticated user, in addition
+# to the claim-derived ones (not subject to groupMappings/dropUnmapped). Created on the
+# fly when missing.
+# oidcOAuth2Config.defaultGroups=
 # oidcOAuth2Config.usePKCE=false
 #
 # Access type for authorization (set to "offline" for refresh token support, e.g. Google)

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -1,7 +1,7 @@
 #
 # Uncomment the following to auto create unrecognized users. 
 #
-# NOTE: You need to uncomment the interceptor on /src/modules/resp/impl/src/main/resources/applicationContext.xml:
+/src/modules/rest/impl/src/main/resources/applicationContext.xml:
 #         
 #	<jaxrs:inInterceptors>
 #      <!-- Auto create users interceptor (uncomment to allow users auto-creation for /users requests) -->

--- a/src/web/app/src/main/resources/geostore-spring-security.xml
+++ b/src/web/app/src/main/resources/geostore-spring-security.xml
@@ -25,7 +25,7 @@
 		<security:csrf disabled="true"/>
 		<security:custom-filter ref="authenticationTokenProcessingFilter" before="FORM_LOGIN_FILTER"/>
 		<security:custom-filter ref="sessionTokenProcessingFilter" after="FORM_LOGIN_FILTER"/>
-<!--		<security:custom-filter ref="compositeOpenIdFilter" before="OPENID_FILTER"/>-->
+		<security:custom-filter ref="compositeOpenIdFilter" before="BASIC_AUTH_FILTER"/>
 		<security:anonymous />
 		<security:intercept-url pattern="/**" access="permitAll" />
 	</security:http>
@@ -44,11 +44,11 @@
 	<!-- OAuth2 beans -->
 	<context:annotation-config/>
 
-<!--	<bean id="oidcSecurityConfiguration" class="it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectSecurityConfiguration"/>-->
+	<bean id="oidcSecurityConfiguration" class="it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectSecurityConfiguration"/>
 
-<!--	<bean id="oidcProviderRegistrar" class="it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectProviderRegistrar"/>-->
+	<bean id="oidcProviderRegistrar" class="it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectProviderRegistrar"/>
 
-<!--	<bean id="compositeOpenIdFilter" class="it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.CompositeOpenIdConnectFilter"/>-->
+	<bean id="compositeOpenIdFilter" class="it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.CompositeOpenIdConnectFilter"/>
 
 	<!-- END OAuth2 beans-->
 

--- a/src/web/app/src/main/resources/log4j2.properties
+++ b/src/web/app/src/main/resources/log4j2.properties
@@ -12,6 +12,8 @@ rootLogger.appenderRef.console.ref = LogToConsole
 
 logger.restsrv.name=it.geosolutions.geostore.services.rest
 logger.restsrv.level=  INFO
+logger.cxf_services.name=org.apache.cxf.services
+logger.cxf_services.level=WARN
 logger.hibernate1.name=org.hibernate
 logger.hibernate1.level=INFO
 logger.trg1.name=com.trg


### PR DESCRIPTION
These changes are related to this MapStore task
- https://github.com/geosolutions-it/support/issues/6035

This PR forward-ports the changes from #551 to the master branch.

## Context

The Spring 7 / Spring Security 7 / Jakarta EE 10 migration removed GeoStore's entire **OAuth2 + OIDC** implementation, because it was built on the now-removed `org.springframework.security.oauth:spring-security-oauth2` 2.x library (and `spring-security-jwt`). What survived on `master` was only scaffolding plus an intact-but-disabled LDAP stack — logging in via Keycloak / Google / Azure AD / Entra was impossible.

This PR **faithfully restores the `2.6.x` security feature set on Spring Security 7's native `oauth2-client` / `oauth2-resource-server` APIs** (+ nimbus-jose-jwt / auth0 java-jwt), preserving every configuration property key, the `/openid` REST contract, the filter-chain shape, and observable behavior. Where dead Spring APIs had no equivalent, they were replaced with SS7 idioms; the architecture and behavior are otherwise unchanged.

## What's restored

- **Generic OAuth2** — `OAuth2GeoStoreAuthenticationService` (principal resolution with introspection→JWT fallbacks, role/group sync from claims, auto-user-creation, Caffeine token cache) + a thin bearer `OAuth2GeoStoreAuthenticationFilter`.
- **OIDC** — `OpenIdConnectAuthenticationService` (bearer JWT signature verification via JWKS, JWE decryption, RFC 7662 introspection, audience/subject validation, Microsoft-Graph group/role overage), `CompositeOpenIdConnectFilter` (multi-provider routing + `/openid/{provider}/{login,callback}`), `OpenIdConnectRestClient` (authorization-code + refresh-token exchange), PKCE / client-secret request enhancers, dynamic provider registrar, OIDC discovery.
- **Session** — refresh with retry/backoff, refresh-token rotation, skip-if-still-valid, HttpOnly refresh cookie, RP-initiated logout / token revoke.
- **LDAP** — code intact; re-enablement remains opt-in (unchanged from `master`/`2.6.x`).

## Key Spring Security 7 adaptations

- `OAuth2RestTemplate` / `RemoteTokenServices` → `RestClient`/`RestTemplate` + Map introspection; the auth-code/refresh exchange deserializes into SS7 `OAuth2AccessTokenResponse` (fixes the legacy "no Jackson mixin" issue).
- legacy `common.OAuth2AccessToken`/`DefaultOAuth2*` → immutable `core.OAuth2AccessToken`/`OAuth2RefreshToken`; refresh token now carried on `TokenDetails`.
- SS7 dropped the `OPENID_FILTER` security-filter alias → custom filter retargeted `before="BASIC_AUTH_FILTER"` (verified at runtime: order 2799, just before basic-auth at 2800).
- java-jwt 4.x `NullClaim` removal → `Claim.isMissing()`/`isNull()`.

## Verification

- ✅ Full reactor `mvn install` — BUILD SUCCESS, WAR built, SpotBugs/PMD clean.
- ✅ Spring context boots (jetty:9191) — all OIDC beans wire, `/openid` published, no wiring errors.
- ✅ **49/49** GeoStore tests in the MapStore↔GeoStore REST regression suite (anon/basic/bearer auth, sessions, resource CRUD + ACLs).
- ✅ **9 OAuth2/OIDC JUnit test files restored + adapted (66 tests)** incl. the refresh/`sendClientSecret` suite, plus the pre-existing security tests — all green together (no regression).

## Remaining (follow-up)

5 large end-to-end OIDC integration tests still to adapt onto the new service-based design: `OpenIdConnectIntegrationTest`, `OpenIdIntegrationTest`, `MultiProviderIntegrationTest`, `AzureAdWireMockLifecycleTest` (WireMock), `KeycloakLifecycleTest` (Testcontainers). Live Keycloak/OIDC integration testing + CI Testcontainers coverage is planned next.
