### PR TITLE
Support cascadeResourceDelete on user deletion

### DIFF
--- a/.github/scripts/run-integration-tests.ps1
+++ b/.github/scripts/run-integration-tests.ps1
@@ -557,6 +557,181 @@ Step "GET resource as NEW USER (with rule) -> 200" {
     "USER can now read via SecurityRule, id=$($r.Resource.id)"
 }
 
+# ========== Phase 12b — user-delete cascade of session resources (support #5817) ==========
+# DELETE /users/user/{id}?cascadeResourceDelete=<cat1,cat2,...> must delete the resources of the
+# listed categories that the user solely owns (e.g. MapStore USERSESSION resources), preserve
+# shared resources and resources of unlisted categories, and never fail on unknown categories.
+
+$script:CascCatName   = 'USERSESSION'
+$script:CascCatId     = $null
+$script:CascUserId    = $null
+$script:CascUserName  = "inttest-casc-$(Get-Date -Format 'HHmmss')"
+$script:CascUserPwd   = 'CascPwd-1!'
+$script:CascUserB     = $null
+$script:CascSessResId = $null
+$script:CascOtherResId = $null
+$script:CascSharedResId = $null
+$script:SeededUserId  = $null
+
+Step "ensure USERSESSION category exists (reuse or create)" {
+    $r = Invoke-RestMethod -Uri "$Base/categories" -Headers @{Authorization=$AdminB; Accept='application/json'} -TimeoutSec 5
+    $cats = @($r.CategoryList.Category)
+    $existing = $cats | Where-Object { $_.name -eq $script:CascCatName }
+    if ($existing) {
+        $script:CascCatId = [int]@($existing)[0].id
+        "reused category id=$($script:CascCatId)"
+    } else {
+        $id = Invoke-RestMethod -Uri "$Base/categories/" -Method POST -Headers @{Authorization=$AdminB} -ContentType 'application/xml' -Body "<Category><name>$($script:CascCatName)</name></Category>" -TimeoutSec 5
+        if (-not ($id -as [int])) { throw "expected numeric id, got '$id'" }
+        $script:CascCatId = [int]$id
+        "created category id=$($script:CascCatId)"
+    }
+}
+
+Step "POST /users create cascade-test user -> new id" {
+    $body = @"
+<User><name>$($script:CascUserName)</name><newPassword>$($script:CascUserPwd)</newPassword><role>USER</role><enabled>true</enabled></User>
+"@
+    $id = Invoke-RestMethod -Uri "$Base/users/" -Method POST -Headers @{Authorization=$AdminB} -ContentType 'application/xml' -Body $body -TimeoutSec 5
+    if (-not ($id -as [int])) { throw "expected numeric id, got '$id'" }
+    $script:CascUserId = [int]$id
+    $script:CascUserB = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("$($script:CascUserName):$($script:CascUserPwd)"))
+    "user id=$($script:CascUserId) name=$($script:CascUserName)"
+}
+
+Step "cascade user creates USERSESSION resource (solely owned)" {
+    # Created with the user's own credentials so the owner SecurityRule is the user's — same as
+    # MapStore persisting a user session.
+    $body = @"
+<Resource>
+  <description>user session of $($script:CascUserName)</description><metadata></metadata>
+  <name>default.$($script:CascUserName)</name>
+  <category><name>$($script:CascCatName)</name></category>
+  <store><data><![CDATA[{"session":true}]]></data></store>
+</Resource>
+"@
+    $id = Invoke-RestMethod -Uri "$Base/resources/" -Method POST -Headers @{Authorization=$script:CascUserB} -ContentType 'application/xml' -Body $body -TimeoutSec 5
+    $script:CascSessResId = [int]$id
+    "session resource id=$($script:CascSessResId)"
+}
+
+Step "cascade user creates resource in OTHER category ($Category)" {
+    $body = @"
+<Resource>
+  <description>non-session resource of $($script:CascUserName)</description><metadata></metadata>
+  <name>casc-other-$(Get-Date -Format 'HHmmss')</name>
+  <category><name>$Category</name></category>
+  <store><data>{}</data></store>
+</Resource>
+"@
+    $id = Invoke-RestMethod -Uri "$Base/resources/" -Method POST -Headers @{Authorization=$script:CascUserB} -ContentType 'application/xml' -Body $body -TimeoutSec 5
+    $script:CascOtherResId = [int]$id
+    "other-category resource id=$($script:CascOtherResId)"
+}
+
+Step "cascade user creates SHARED USERSESSION resource (+read rule for seeded user)" {
+    $r = Invoke-RestMethod -Uri "$Base/users/user/details" -Headers @{Authorization=$UserB; Accept='application/json'} -TimeoutSec 5
+    $script:SeededUserId = [int]$r.User.id
+    $body = @"
+<Resource>
+  <description>shared session</description><metadata></metadata>
+  <name>shared.$($script:CascUserName)</name>
+  <category><name>$($script:CascCatName)</name></category>
+  <store><data>{}</data></store>
+</Resource>
+"@
+    $id = Invoke-RestMethod -Uri "$Base/resources/" -Method POST -Headers @{Authorization=$script:CascUserB} -ContentType 'application/xml' -Body $body -TimeoutSec 5
+    $script:CascSharedResId = [int]$id
+    # Replace the rule list with owner rule + a read rule for the seeded 'user': now 2 rules, so
+    # the resource is NOT solely owned and the cascade must preserve it.
+    $rules = @"
+<SecurityRuleList>
+  <SecurityRule>
+    <canRead>true</canRead><canWrite>true</canWrite>
+    <user><id>$($script:CascUserId)</id><name>$($script:CascUserName)</name></user>
+  </SecurityRule>
+  <SecurityRule>
+    <canRead>true</canRead><canWrite>false</canWrite>
+    <user><id>$($script:SeededUserId)</id><name>user</name></user>
+  </SecurityRule>
+</SecurityRuleList>
+"@
+    $resp = Invoke-WebRequest -Uri "$Base/resources/resource/$($script:CascSharedResId)/permissions" -Method POST -Headers @{Authorization=$AdminB} -ContentType 'application/xml' -Body $rules -UseBasicParsing -TimeoutSec 5
+    if (200, 204 -notcontains $resp.StatusCode) { throw "permissions got HTTP $($resp.StatusCode)" }
+    "shared resource id=$($script:CascSharedResId), 2 rules"
+}
+
+Step "DELETE user ?cascadeResourceDelete=USERSESSION,NOT_A_CATEGORY -> 200/204" {
+    # Comma-separated list; the unknown category must be ignored without failing the request.
+    $r = Invoke-WebRequest -Uri "$Base/users/user/$($script:CascUserId)?cascadeResourceDelete=$($script:CascCatName),NOT_A_CATEGORY" -Method DELETE -Headers @{Authorization=$AdminB} -UseBasicParsing -TimeoutSec 10
+    if (200, 204 -notcontains $r.StatusCode) { throw "got HTTP $($r.StatusCode)" }
+    "user delete HTTP $($r.StatusCode)"
+}
+
+Step "deleted user -> 404" {
+    Expect-Status 404 { Invoke-WebRequest -Uri "$Base/users/user/$($script:CascUserId)" -Headers @{Authorization=$AdminB} -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop }
+}
+
+Step "solely-owned USERSESSION resource -> 404 (cascade-deleted)" {
+    Expect-Status 404 { Invoke-WebRequest -Uri "$Base/resources/resource/$($script:CascSessResId)" -Headers @{Authorization=$AdminB} -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop }
+}
+
+Step "other-category resource survives the cascade -> 200" {
+    $r = Invoke-RestMethod -Uri "$Base/resources/resource/$($script:CascOtherResId)" -Headers @{Authorization=$AdminB; Accept='application/json'} -TimeoutSec 5
+    if ([int]$r.Resource.id -ne $script:CascOtherResId) { throw "got id=$($r.Resource.id)" }
+    "resource $($script:CascOtherResId) preserved"
+}
+
+Step "shared USERSESSION resource survives -> 200, seeded user still reads it" {
+    $r = Invoke-RestMethod -Uri "$Base/resources/resource/$($script:CascSharedResId)" -Headers @{Authorization=$UserB; Accept='application/json'} -TimeoutSec 5
+    if ([int]$r.Resource.id -ne $script:CascSharedResId) { throw "got id=$($r.Resource.id)" }
+    "resource $($script:CascSharedResId) preserved and readable by seeded user"
+}
+
+Step "plain DELETE (no cascade param) keeps default behavior -> user gone, resource left" {
+    # Backward compatibility: without the parameter the user's resources are left untouched.
+    $name = "inttest-casc2-$(Get-Date -Format 'HHmmss')"
+    $id = Invoke-RestMethod -Uri "$Base/users/" -Method POST -Headers @{Authorization=$AdminB} -ContentType 'application/xml' -Body "<User><name>$name</name><newPassword>$($script:CascUserPwd)</newPassword><role>USER</role><enabled>true</enabled></User>" -TimeoutSec 5
+    $uid = [int]$id
+    $b = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${name}:$($script:CascUserPwd)"))
+    $body = @"
+<Resource>
+  <description>session kept by plain delete</description><metadata></metadata>
+  <name>plain.$name</name>
+  <category><name>$($script:CascCatName)</name></category>
+  <store><data>{}</data></store>
+</Resource>
+"@
+    $rid = [int](Invoke-RestMethod -Uri "$Base/resources/" -Method POST -Headers @{Authorization=$b} -ContentType 'application/xml' -Body $body -TimeoutSec 5)
+    $r = Invoke-WebRequest -Uri "$Base/users/user/$uid" -Method DELETE -Headers @{Authorization=$AdminB} -UseBasicParsing -TimeoutSec 10
+    if (200, 204 -notcontains $r.StatusCode) { throw "user delete got HTTP $($r.StatusCode)" }
+    $check = Invoke-RestMethod -Uri "$Base/resources/resource/$rid" -Headers @{Authorization=$AdminB; Accept='application/json'} -TimeoutSec 5
+    if ([int]$check.Resource.id -ne $rid) { throw "resource unexpectedly gone" }
+    $script:CascPlainResId = $rid
+    "user $uid deleted, resource $rid left untouched (no cascade requested)"
+}
+
+Step "DELETE user with cascade of category having NO resources -> 200/204" {
+    # Robustness: the request succeeds even when the listed category exists but holds nothing
+    # owned by the user.
+    $name = "inttest-casc3-$(Get-Date -Format 'HHmmss')"
+    $id = Invoke-RestMethod -Uri "$Base/users/" -Method POST -Headers @{Authorization=$AdminB} -ContentType 'application/xml' -Body "<User><name>$name</name><newPassword>$($script:CascUserPwd)</newPassword><role>USER</role><enabled>true</enabled></User>" -TimeoutSec 5
+    $uid = [int]$id
+    $r = Invoke-WebRequest -Uri "$Base/users/user/$uid`?cascadeResourceDelete=$($script:CascCatName)" -Method DELETE -Headers @{Authorization=$AdminB} -UseBasicParsing -TimeoutSec 10
+    if (200, 204 -notcontains $r.StatusCode) { throw "got HTTP $($r.StatusCode)" }
+    Expect-Status 404 { Invoke-WebRequest -Uri "$Base/users/user/$uid" -Headers @{Authorization=$AdminB} -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop } | Out-Null
+    "user $uid deleted with empty cascade"
+}
+
+Step "cascade phase cleanup (surviving resources)" {
+    foreach ($rid in @($script:CascOtherResId, $script:CascSharedResId, $script:CascPlainResId)) {
+        if ($rid) {
+            $null = Invoke-WebRequest -Uri "$Base/resources/resource/$rid" -Method DELETE -Headers @{Authorization=$AdminB} -UseBasicParsing -TimeoutSec 5
+        }
+    }
+    "cleaned up surviving cascade-test resources"
+}
+
 # ========== Phase 13 — extra cleanup ==========
 
 Step "DELETE attr-test resource" {

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
@@ -66,6 +66,23 @@ public interface UserService {
     boolean delete(long id);
 
     /**
+     * Deletes a user and, in cascade, the resources of the given categories that the user solely
+     * owns (e.g. the MapStore {@code USERSESSION} resources). Category names that do not exist are
+     * ignored: the user deletion proceeds anyway.
+     *
+     * <p>The default implementation ignores the categories and performs a plain {@link
+     * #delete(long)}: implementations that support the resource cascade must override it.
+     *
+     * @param id the user id
+     * @param cascadeResourceCategories names of the resource categories whose solely-owned
+     *     resources must be deleted along with the user; may be null or empty for no cascade
+     * @return boolean true if the user has been deleted
+     */
+    default boolean delete(long id, List<String> cascadeResourceCategories) {
+        return delete(id);
+    }
+
+    /**
      * @param id
      * @return User
      */

--- a/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
+++ b/src/core/services-api/src/main/java/it/geosolutions/geostore/services/UserService.java
@@ -74,11 +74,12 @@ public interface UserService {
      * #delete(long)}: implementations that support the resource cascade must override it.
      *
      * @param id the user id
-     * @param cascadeResourceCategories names of the resource categories whose solely-owned
-     *     resources must be deleted along with the user; may be null or empty for no cascade
+     * @param cascadeResourceCategories comma-separated names of the resource categories whose
+     *     solely-owned resources must be deleted along with the user; may be null or blank for no
+     *     cascade
      * @return boolean true if the user has been deleted
      */
-    default boolean delete(long id, List<String> cascadeResourceCategories) {
+    default boolean delete(long id, String cascadeResourceCategories) {
         return delete(id);
     }
 

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
@@ -321,6 +321,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(value = "geostoreTransactionManager")
     public boolean delete(long id, String cascadeResourceCategories) {
 
         cascadeDeleteResources(id, cascadeResourceCategories);

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
@@ -25,16 +25,23 @@ import it.geosolutions.geostore.core.dao.UserAttributeDAO;
 import it.geosolutions.geostore.core.dao.UserDAO;
 import it.geosolutions.geostore.core.dao.UserFavoriteDAO;
 import it.geosolutions.geostore.core.dao.UserGroupDAO;
+import it.geosolutions.geostore.core.model.Category;
+import it.geosolutions.geostore.core.model.Resource;
+import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
 import it.geosolutions.geostore.core.model.UserGroup;
 import it.geosolutions.geostore.core.model.enums.GroupReservedNames;
 import it.geosolutions.geostore.core.model.enums.Role;
 import it.geosolutions.geostore.core.model.enums.UserReservedNames;
+import it.geosolutions.geostore.services.dto.ResourceSearchParameters;
+import it.geosolutions.geostore.services.dto.search.CategoryFilter;
+import it.geosolutions.geostore.services.dto.search.SearchOperator;
 import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
 import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,8 +67,22 @@ public class UserServiceImpl implements UserService {
 
     private UserFavoriteDAO userFavoriteDAO;
 
+    // Autowired byName from the services applicationContext; used by the cascade-on-delete of the
+    // user's solely-owned resources (see delete(long, List)).
+    private ResourceService resourceService;
+
+    private CategoryService categoryService;
+
     public void setUserDAO(UserDAO userDAO) {
         this.userDAO = userDAO;
+    }
+
+    public void setResourceService(ResourceService resourceService) {
+        this.resourceService = resourceService;
+    }
+
+    public void setCategoryService(CategoryService categoryService) {
+        this.categoryService = categoryService;
     }
 
     public void setUserAttributeDAO(UserAttributeDAO userAttributeDAO) {
@@ -302,7 +323,104 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     public boolean delete(long id) {
+        return delete(id, Collections.emptyList());
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see it.geosolutions.geostore.services.UserService#delete(long, java.util.List)
+     */
+    @Override
+    public boolean delete(long id, List<String> cascadeResourceCategories) {
+        if (cascadeResourceCategories != null && !cascadeResourceCategories.isEmpty()) {
+            User user = userDAO.find(id);
+            if (user != null) {
+                deleteSolelyOwnedResources(user, cascadeResourceCategories);
+            }
+        }
         return userDAO.removeById(id);
+    }
+
+    /**
+     * Deletes the resources of the given categories that are solely owned by the user. Resources
+     * shared with other users or groups are preserved. The cascade is a best-effort cleanup: an
+     * unknown category, or any error while collecting or deleting the resources, never prevents the
+     * user deletion.
+     */
+    private void deleteSolelyOwnedResources(User user, List<String> categoryNames) {
+        for (String categoryName : categoryNames) {
+            if (categoryName == null || categoryName.trim().isEmpty()) {
+                continue;
+            }
+            String name = categoryName.trim();
+            try {
+                Category category = categoryService.get(name);
+                if (category == null) {
+                    LOGGER.info(
+                            "Cascade resource delete: category '{}' does not exist, skipping.",
+                            name);
+                    continue;
+                }
+                List<Resource> resources =
+                        resourceService.getResources(
+                                ResourceSearchParameters.builder()
+                                        .filter(new CategoryFilter(name, SearchOperator.EQUAL_TO))
+                                        .authUser(user)
+                                        .build());
+                int deleted = 0;
+                for (Resource resource : resources) {
+                    if (isSolelyOwnedBy(resource, user)
+                            && resourceService.delete(resource.getId())) {
+                        deleted++;
+                    }
+                }
+                LOGGER.info(
+                        "Cascade resource delete: removed {} resource(s) of category '{}' solely owned by user '{}' (id={}).",
+                        deleted,
+                        name,
+                        user.getName(),
+                        user.getId());
+            } catch (Exception e) {
+                LOGGER.error(
+                        "Cascade resource delete: error handling category '{}' for user '{}'; the user deletion proceeds anyway.",
+                        name,
+                        user.getName(),
+                        e);
+            }
+        }
+    }
+
+    /**
+     * A resource is solely owned by the user when every security rule on it belongs to the user —
+     * matched by user id or by username, the latter covering externally-authenticated (LDAP/SSO)
+     * users — and at least one of those rules grants write permission.
+     */
+    private boolean isSolelyOwnedBy(Resource resource, User user) {
+        List<SecurityRule> rules = resourceService.getSecurityRules(resource.getId());
+        if (rules == null || rules.isEmpty()) {
+            return false;
+        }
+        boolean canWrite = false;
+        for (SecurityRule rule : rules) {
+            if (!belongsTo(rule, user)) {
+                return false;
+            }
+            if (rule.isCanWrite()) {
+                canWrite = true;
+            }
+        }
+        return canWrite;
+    }
+
+    private boolean belongsTo(SecurityRule rule, User user) {
+        if (rule.getGroup() != null || rule.getGroupname() != null) {
+            return false;
+        }
+        if (rule.getUser() != null && rule.getUser().getId() != null) {
+            return rule.getUser().getId().equals(user.getId());
+        }
+        return rule.getUsername() != null && rule.getUsername().equals(user.getName());
     }
 
     /*

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
@@ -25,7 +25,6 @@ import it.geosolutions.geostore.core.dao.UserAttributeDAO;
 import it.geosolutions.geostore.core.dao.UserDAO;
 import it.geosolutions.geostore.core.dao.UserFavoriteDAO;
 import it.geosolutions.geostore.core.dao.UserGroupDAO;
-import it.geosolutions.geostore.core.model.Category;
 import it.geosolutions.geostore.core.model.Resource;
 import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
@@ -40,8 +39,8 @@ import it.geosolutions.geostore.services.dto.search.SearchOperator;
 import it.geosolutions.geostore.services.exception.BadRequestServiceEx;
 import it.geosolutions.geostore.services.exception.NotFoundServiceEx;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -316,30 +315,37 @@ public class UserServiceImpl implements UserService {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see it.geosolutions.geostore.services.UserService#delete(long)
-     */
     @Override
     public boolean delete(long id) {
-        return delete(id, Collections.emptyList());
+        return delete(id, "");
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see it.geosolutions.geostore.services.UserService#delete(long, java.util.List)
-     */
     @Override
-    public boolean delete(long id, List<String> cascadeResourceCategories) {
-        if (cascadeResourceCategories != null && !cascadeResourceCategories.isEmpty()) {
-            User user = userDAO.find(id);
+    public boolean delete(long id, String cascadeResourceCategories) {
+
+        cascadeDeleteResources(id, cascadeResourceCategories);
+
+        return userDAO.removeById(id);
+    }
+
+    private void cascadeDeleteResources(long userId, String cascadeResourceCategories) {
+        List<String> categories = parseCategoryNames(cascadeResourceCategories);
+        if (!categories.isEmpty()) {
+            User user = userDAO.find(userId);
             if (user != null) {
-                deleteSolelyOwnedResources(user, cascadeResourceCategories);
+                deleteSolelyOwnedResources(user, categories);
             }
         }
-        return userDAO.removeById(id);
+    }
+
+    private List<String> parseCategoryNames(String commaSeparatedCategoryNames) {
+        if (commaSeparatedCategoryNames == null || commaSeparatedCategoryNames.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(commaSeparatedCategoryNames.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 
     /**
@@ -350,70 +356,64 @@ public class UserServiceImpl implements UserService {
      */
     private void deleteSolelyOwnedResources(User user, List<String> categoryNames) {
         for (String categoryName : categoryNames) {
-            if (categoryName == null || categoryName.trim().isEmpty()) {
-                continue;
-            }
-            String name = categoryName.trim();
             try {
-                Category category = categoryService.get(name);
-                if (category == null) {
+                if (categoryService.get(categoryName) == null) {
                     LOGGER.info(
                             "Cascade resource delete: category '{}' does not exist, skipping.",
-                            name);
+                            categoryName);
                     continue;
                 }
-                List<Resource> resources =
-                        resourceService.getResources(
-                                ResourceSearchParameters.builder()
-                                        .filter(new CategoryFilter(name, SearchOperator.EQUAL_TO))
-                                        .authUser(user)
-                                        .build());
-                int deleted = 0;
-                for (Resource resource : resources) {
-                    if (isSolelyOwnedBy(resource, user)
-                            && resourceService.delete(resource.getId())) {
-                        deleted++;
-                    }
-                }
+
+                int deletedResourceCount =
+                        (int)
+                                retrieveUserResourcesByCategoryName(user, categoryName).stream()
+                                        .filter(
+                                                resource ->
+                                                        isResourceSolelyOwnedByUser(resource, user)
+                                                                && resourceService.delete(
+                                                                        resource.getId()))
+                                        .count();
+
                 LOGGER.info(
                         "Cascade resource delete: removed {} resource(s) of category '{}' solely owned by user '{}' (id={}).",
-                        deleted,
-                        name,
+                        deletedResourceCount,
+                        categoryName,
                         user.getName(),
                         user.getId());
+
             } catch (Exception e) {
                 LOGGER.error(
                         "Cascade resource delete: error handling category '{}' for user '{}'; the user deletion proceeds anyway.",
-                        name,
+                        categoryName,
                         user.getName(),
                         e);
             }
         }
     }
 
-    /**
-     * A resource is solely owned by the user when every security rule on it belongs to the user —
-     * matched by user id or by username, the latter covering externally-authenticated (LDAP/SSO)
-     * users — and at least one of those rules grants write permission.
-     */
-    private boolean isSolelyOwnedBy(Resource resource, User user) {
-        List<SecurityRule> rules = resourceService.getSecurityRules(resource.getId());
-        if (rules == null || rules.isEmpty()) {
-            return false;
-        }
-        boolean canWrite = false;
-        for (SecurityRule rule : rules) {
-            if (!belongsTo(rule, user)) {
-                return false;
-            }
-            if (rule.isCanWrite()) {
-                canWrite = true;
-            }
-        }
-        return canWrite;
+    private List<Resource> retrieveUserResourcesByCategoryName(User user, String categoryName)
+            throws Exception {
+        return resourceService.getResources(
+                ResourceSearchParameters.builder()
+                        .filter(new CategoryFilter(categoryName, SearchOperator.EQUAL_TO))
+                        .authUser(user)
+                        .build());
     }
 
-    private boolean belongsTo(SecurityRule rule, User user) {
+    /**
+     * A resource is solely owned by the user when every security rule on it belongs to the user,
+     * matched by user id or by username, the latter covering externally-authenticated (LDAP/SSO)
+     * users, and at least one of those rules grants write permission.
+     */
+    private boolean isResourceSolelyOwnedByUser(Resource resource, User user) {
+        List<SecurityRule> rules = resourceService.getSecurityRules(resource.getId());
+
+        return rules != null
+                && rules.stream().allMatch(r -> securityRuleBelongsToUser(r, user))
+                && rules.stream().anyMatch(SecurityRule::isCanWrite);
+    }
+
+    private boolean securityRuleBelongsToUser(SecurityRule rule, User user) {
         if (rule.getGroup() != null || rule.getGroupname() != null) {
             return false;
         }

--- a/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
+++ b/src/core/services-impl/src/main/java/it/geosolutions/geostore/services/UserServiceImpl.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Class UserServiceImpl.

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
@@ -247,7 +247,7 @@ public class UserServiceImplTest extends ServiceTestBase {
 
         assertEquals(1, resourceService.getCount(null));
 
-        assertTrue(userService.delete(userId, Arrays.asList("USERSESSION")));
+        assertTrue(userService.delete(userId, "USERSESSION"));
 
         assertEquals(0, userService.getCount(null));
         assertNull(
@@ -260,7 +260,7 @@ public class UserServiceImplTest extends ServiceTestBase {
         long userId = createUser("congchen", Role.USER, "userPW");
 
         // No category exists at all: the cascade must be a no-op and the user deleted anyway.
-        assertTrue(userService.delete(userId, Arrays.asList("USERSESSION", "NOT_A_CATEGORY")));
+        assertTrue(userService.delete(userId, "USERSESSION,NOT_A_CATEGORY"));
         assertEquals(0, userService.getCount(null));
     }
 
@@ -276,7 +276,7 @@ public class UserServiceImplTest extends ServiceTestBase {
                 createResourceWithRules(
                         "shared.session", sessions, ownerRule(owner), readOnlyRule(other));
 
-        assertTrue(userService.delete(ownerId, Arrays.asList("USERSESSION")));
+        assertTrue(userService.delete(ownerId, "USERSESSION"));
 
         assertNotNull(
                 "Resource shared with another user must be preserved",
@@ -297,7 +297,7 @@ public class UserServiceImplTest extends ServiceTestBase {
         long sessionId = createResourceWithRules("session", sessions, ownerRule(user));
         long mapId = createResourceWithRules("map", maps, ownerRule(user));
 
-        assertTrue(userService.delete(userId, Arrays.asList("USERSESSION")));
+        assertTrue(userService.delete(userId, "USERSESSION"));
 
         assertNull("USERSESSION resource should be deleted", resourceService.get(sessionId));
         assertNotNull(
@@ -315,7 +315,7 @@ public class UserServiceImplTest extends ServiceTestBase {
         long sessionId =
                 createResourceWithRules("ldap.session", sessions, usernameOwnerRule("ldapuser"));
 
-        assertTrue(userService.delete(userId, Arrays.asList("USERSESSION")));
+        assertTrue(userService.delete(userId, "USERSESSION"));
 
         assertNull(
                 "Resource owned via username rule should be cascade-deleted",

--- a/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
+++ b/src/core/services-impl/src/test/java/it/geosolutions/geostore/services/UserServiceImplTest.java
@@ -19,6 +19,9 @@
  */
 package it.geosolutions.geostore.services;
 
+import it.geosolutions.geostore.core.model.Category;
+import it.geosolutions.geostore.core.model.Resource;
+import it.geosolutions.geostore.core.model.SecurityRule;
 import it.geosolutions.geostore.core.model.User;
 import it.geosolutions.geostore.core.model.UserAttribute;
 import it.geosolutions.geostore.core.model.UserGroup;
@@ -226,5 +229,148 @@ public class UserServiceImplTest extends ServiceTestBase {
         loaded = userService.get(userId);
         assertNotNull(loaded);
         assertTrue(PwEncoder.isPasswordValid(loaded.getPassword(), "testPW2"));
+    }
+
+    // ---------------------------------------------------------------------
+    // delete(id, cascadeResourceCategories) — support #5817: deleting a user
+    // must be able to cascade-delete the resources (e.g. USERSESSION) the
+    // user solely owns, since resources have no FK to the owning user.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testDeleteUserCascadesSolelyOwnedCategoryResources() throws Exception {
+        long userId = createUser("congchen", Role.USER, "userPW");
+        User user = userService.get(userId);
+
+        Category sessions = categoryService.get(createCategory("USERSESSION"));
+        long sessionId = createResourceWithRules("default.congchen", sessions, ownerRule(user));
+
+        assertEquals(1, resourceService.getCount(null));
+
+        assertTrue(userService.delete(userId, Arrays.asList("USERSESSION")));
+
+        assertEquals(0, userService.getCount(null));
+        assertNull(
+                "UserSession resource should be cascade-deleted", resourceService.get(sessionId));
+        assertEquals(0, resourceService.getCount(null));
+    }
+
+    @Test
+    public void testDeleteUserCascadeSkipsMissingCategory() throws Exception {
+        long userId = createUser("congchen", Role.USER, "userPW");
+
+        // No category exists at all: the cascade must be a no-op and the user deleted anyway.
+        assertTrue(userService.delete(userId, Arrays.asList("USERSESSION", "NOT_A_CATEGORY")));
+        assertEquals(0, userService.getCount(null));
+    }
+
+    @Test
+    public void testDeleteUserCascadePreservesSharedResources() throws Exception {
+        long ownerId = createUser("owner", Role.USER, "ownerPW");
+        long otherId = createUser("other", Role.USER, "otherPW");
+        User owner = userService.get(ownerId);
+        User other = userService.get(otherId);
+
+        Category sessions = categoryService.get(createCategory("USERSESSION"));
+        long sharedId =
+                createResourceWithRules(
+                        "shared.session", sessions, ownerRule(owner), readOnlyRule(other));
+
+        assertTrue(userService.delete(ownerId, Arrays.asList("USERSESSION")));
+
+        assertNotNull(
+                "Resource shared with another user must be preserved",
+                resourceService.get(sharedId));
+        // The deleted owner's rule is removed by the User-entity cascade; the other user's
+        // read rule must survive.
+        assertEquals(1, resourceService.getSecurityRules(sharedId).size());
+        assertEquals(1, userService.getCount(null));
+    }
+
+    @Test
+    public void testDeleteUserCascadeIgnoresOtherCategories() throws Exception {
+        long userId = createUser("congchen", Role.USER, "userPW");
+        User user = userService.get(userId);
+
+        Category sessions = categoryService.get(createCategory("USERSESSION"));
+        Category maps = categoryService.get(createCategory("MAP"));
+        long sessionId = createResourceWithRules("session", sessions, ownerRule(user));
+        long mapId = createResourceWithRules("map", maps, ownerRule(user));
+
+        assertTrue(userService.delete(userId, Arrays.asList("USERSESSION")));
+
+        assertNull("USERSESSION resource should be deleted", resourceService.get(sessionId));
+        assertNotNull(
+                "Resources of categories not listed in the cascade must be untouched",
+                resourceService.get(mapId));
+    }
+
+    @Test
+    public void testDeleteUserCascadeMatchesUsernameRule() throws Exception {
+        // Externally-authenticated (LDAP/SSO) users own resources via a username string rule
+        // (user FK is null): the cascade must match those too.
+        long userId = createUser("ldapuser", Role.USER, "userPW");
+
+        Category sessions = categoryService.get(createCategory("USERSESSION"));
+        long sessionId =
+                createResourceWithRules("ldap.session", sessions, usernameOwnerRule("ldapuser"));
+
+        assertTrue(userService.delete(userId, Arrays.asList("USERSESSION")));
+
+        assertNull(
+                "Resource owned via username rule should be cascade-deleted",
+                resourceService.get(sessionId));
+        assertEquals(0, userService.getCount(null));
+    }
+
+    @Test
+    public void testDeleteUserWithoutCascadeLeavesResources() throws Exception {
+        // The single-argument delete keeps the pre-existing behavior: the user's resources are
+        // left in place (orphaned) — the cascade only happens when explicitly requested.
+        long userId = createUser("congchen", Role.USER, "userPW");
+        User user = userService.get(userId);
+
+        Category sessions = categoryService.get(createCategory("USERSESSION"));
+        long sessionId = createResourceWithRules("session", sessions, ownerRule(user));
+
+        assertTrue(userService.delete(userId));
+
+        assertNotNull(
+                "Without the cascade parameter the resource must be left untouched",
+                resourceService.get(sessionId));
+    }
+
+    private long createResourceWithRules(String name, Category category, SecurityRule... rules)
+            throws Exception {
+        Resource resource = new Resource();
+        resource.setName(name);
+        resource.setDescription(name);
+        resource.setCategory(category);
+        resource.setSecurity(Arrays.asList(rules));
+        return resourceService.insert(resource);
+    }
+
+    private SecurityRule ownerRule(User user) {
+        SecurityRule rule = new SecurityRule();
+        rule.setUser(user);
+        rule.setCanRead(true);
+        rule.setCanWrite(true);
+        return rule;
+    }
+
+    private SecurityRule readOnlyRule(User user) {
+        SecurityRule rule = new SecurityRule();
+        rule.setUser(user);
+        rule.setCanRead(true);
+        rule.setCanWrite(false);
+        return rule;
+    }
+
+    private SecurityRule usernameOwnerRule(String username) {
+        SecurityRule rule = new SecurityRule();
+        rule.setUsername(username);
+        rule.setCanRead(true);
+        rule.setCanWrite(true);
+        return rule;
     }
 }

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserService.java
@@ -77,9 +77,9 @@ public interface RESTUserService {
     /**
      * Deletes the user.
      *
-     * @param cascadeResourceDelete optional comma-separated list of resource category names (e.g.
-     *     {@code USERSESSION}): the resources of those categories solely owned by the user are
-     *     deleted along with the user; unknown categories are ignored.
+     * @param cascadeResourceDelete optional comma-separated list of resource category names e.g.
+     *     {@code USERSESSION,MAP,CATEGORY_A}: the resources of those categories solely owned by the
+     *     user are deleted along with the user; unknown categories are ignored.
      */
     @DELETE
     @Path("/user/{id}")

--- a/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserService.java
+++ b/src/modules/rest/api/src/main/java/it/geosolutions/geostore/services/rest/RESTUserService.java
@@ -74,11 +74,22 @@ public interface RESTUserService {
     long update(@Context SecurityContext sc, @PathParam("id") long id, @Multipart("user") User user)
             throws NotFoundWebEx;
 
+    /**
+     * Deletes the user.
+     *
+     * @param cascadeResourceDelete optional comma-separated list of resource category names (e.g.
+     *     {@code USERSESSION}): the resources of those categories solely owned by the user are
+     *     deleted along with the user; unknown categories are ignored.
+     */
     @DELETE
     @Path("/user/{id}")
     // @RolesAllowed({ "ADMIN" })
     @Secured({"ROLE_ADMIN"})
-    void delete(@Context SecurityContext sc, @PathParam("id") long id) throws NotFoundWebEx;
+    void delete(
+            @Context SecurityContext sc,
+            @PathParam("id") long id,
+            @QueryParam("cascadeResourceDelete") String cascadeResourceDelete)
+            throws NotFoundWebEx;
 
     @GET
     @Path("/user/{id}")

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTUserServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTUserServiceImpl.java
@@ -42,6 +42,7 @@ import it.geosolutions.geostore.services.rest.model.RESTUser;
 import it.geosolutions.geostore.services.rest.model.UserList;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -190,11 +191,31 @@ public class RESTUserServiceImpl extends RESTServiceImpl implements RESTUserServ
      * (non-Javadoc) @see it.geosolutions.geostore.services.rest.RESTUserInterface#delete(long)
      */
     @Override
-    public void delete(SecurityContext sc, long id) throws NotFoundWebEx {
-        boolean ret = userService.delete(id);
+    public void delete(SecurityContext sc, long id, String cascadeResourceDelete)
+            throws NotFoundWebEx {
+        boolean ret = userService.delete(id, parseCascadeCategories(cascadeResourceDelete));
         if (!ret) {
             throw new NotFoundWebEx("User not found");
         }
+    }
+
+    /**
+     * Parses the {@code cascadeResourceDelete} query parameter into a list of category names. The
+     * parameter is a comma-separated list (e.g. {@code USERSESSION} or {@code USERSESSION,TEMP});
+     * blank entries are discarded.
+     */
+    private static List<String> parseCascadeCategories(String cascadeResourceDelete) {
+        if (cascadeResourceDelete == null || cascadeResourceDelete.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> categories = new ArrayList<>();
+        for (String name : cascadeResourceDelete.split(",")) {
+            String trimmed = name.trim();
+            if (!trimmed.isEmpty()) {
+                categories.add(trimmed);
+            }
+        }
+        return categories;
     }
 
     /*

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTUserServiceImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/impl/RESTUserServiceImpl.java
@@ -42,7 +42,6 @@ import it.geosolutions.geostore.services.rest.model.RESTUser;
 import it.geosolutions.geostore.services.rest.model.UserList;
 import jakarta.ws.rs.core.SecurityContext;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -193,29 +192,10 @@ public class RESTUserServiceImpl extends RESTServiceImpl implements RESTUserServ
     @Override
     public void delete(SecurityContext sc, long id, String cascadeResourceDelete)
             throws NotFoundWebEx {
-        boolean ret = userService.delete(id, parseCascadeCategories(cascadeResourceDelete));
+        boolean ret = userService.delete(id, cascadeResourceDelete);
         if (!ret) {
             throw new NotFoundWebEx("User not found");
         }
-    }
-
-    /**
-     * Parses the {@code cascadeResourceDelete} query parameter into a list of category names. The
-     * parameter is a comma-separated list (e.g. {@code USERSESSION} or {@code USERSESSION,TEMP});
-     * blank entries are discarded.
-     */
-    private static List<String> parseCascadeCategories(String cascadeResourceDelete) {
-        if (cascadeResourceDelete == null || cascadeResourceDelete.trim().isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<String> categories = new ArrayList<>();
-        for (String name : cascadeResourceDelete.split(",")) {
-            String trimmed = name.trim();
-            if (!trimmed.isEmpty()) {
-                categories.add(trimmed);
-            }
-        }
-        return categories;
     }
 
     /*

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTUserServiceImplCascadeDeleteTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTUserServiceImplCascadeDeleteTest.java
@@ -34,15 +34,13 @@ import static org.mockito.Mockito.when;
 
 import it.geosolutions.geostore.services.UserService;
 import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
-import java.util.Arrays;
-import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Verifies the {@code cascadeResourceDelete} query parameter of {@code DELETE /users/user/{id}}
- * (support #5817): the comma-separated category names are parsed and handed to {@link
- * UserService#delete(long, java.util.List)}.
+ * (support #5817): the raw comma-separated string is forwarded as-is to {@link
+ * UserService#delete(long, String)}.
  */
 public class RESTUserServiceImplCascadeDeleteTest {
 
@@ -58,43 +56,43 @@ public class RESTUserServiceImplCascadeDeleteTest {
 
     @Test
     public void testDeleteWithoutCascadeParameter() {
-        when(userService.delete(7L, Collections.emptyList())).thenReturn(true);
+        when(userService.delete(7L, (String) null)).thenReturn(true);
 
         restService.delete(null, 7L, null);
 
-        verify(userService).delete(7L, Collections.emptyList());
+        verify(userService).delete(7L, (String) null);
     }
 
     @Test
     public void testDeleteWithBlankCascadeParameter() {
-        when(userService.delete(7L, Collections.emptyList())).thenReturn(true);
+        when(userService.delete(7L, "   ")).thenReturn(true);
 
         restService.delete(null, 7L, "   ");
 
-        verify(userService).delete(7L, Collections.emptyList());
+        verify(userService).delete(7L, "   ");
     }
 
     @Test
     public void testDeleteWithSingleCategory() {
-        when(userService.delete(7L, Arrays.asList("USERSESSION"))).thenReturn(true);
+        when(userService.delete(7L, "USERSESSION")).thenReturn(true);
 
         restService.delete(null, 7L, "USERSESSION");
 
-        verify(userService).delete(7L, Arrays.asList("USERSESSION"));
+        verify(userService).delete(7L, "USERSESSION");
     }
 
     @Test
     public void testDeleteWithMultipleCategoriesAndBlankEntries() {
-        when(userService.delete(7L, Arrays.asList("USERSESSION", "TEMP"))).thenReturn(true);
+        when(userService.delete(7L, " USERSESSION , TEMP ,, ")).thenReturn(true);
 
         restService.delete(null, 7L, " USERSESSION , TEMP ,, ");
 
-        verify(userService).delete(7L, Arrays.asList("USERSESSION", "TEMP"));
+        verify(userService).delete(7L, " USERSESSION , TEMP ,, ");
     }
 
     @Test
     public void testDeleteUserNotFound() {
-        when(userService.delete(99L, Collections.emptyList())).thenReturn(false);
+        when(userService.delete(99L, (String) null)).thenReturn(false);
 
         assertThrows(NotFoundWebEx.class, () -> restService.delete(null, 99L, null));
     }

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTUserServiceImplCascadeDeleteTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTUserServiceImplCascadeDeleteTest.java
@@ -1,0 +1,101 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2026 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.impl;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import it.geosolutions.geostore.services.UserService;
+import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code cascadeResourceDelete} query parameter of {@code DELETE /users/user/{id}}
+ * (support #5817): the comma-separated category names are parsed and handed to {@link
+ * UserService#delete(long, java.util.List)}.
+ */
+public class RESTUserServiceImplCascadeDeleteTest {
+
+    private UserService userService;
+    private RESTUserServiceImpl restService;
+
+    @BeforeEach
+    void setUp() {
+        userService = mock(UserService.class);
+        restService = new RESTUserServiceImpl();
+        restService.setUserService(userService);
+    }
+
+    @Test
+    public void testDeleteWithoutCascadeParameter() {
+        when(userService.delete(7L, Collections.emptyList())).thenReturn(true);
+
+        restService.delete(null, 7L, null);
+
+        verify(userService).delete(7L, Collections.emptyList());
+    }
+
+    @Test
+    public void testDeleteWithBlankCascadeParameter() {
+        when(userService.delete(7L, Collections.emptyList())).thenReturn(true);
+
+        restService.delete(null, 7L, "   ");
+
+        verify(userService).delete(7L, Collections.emptyList());
+    }
+
+    @Test
+    public void testDeleteWithSingleCategory() {
+        when(userService.delete(7L, Arrays.asList("USERSESSION"))).thenReturn(true);
+
+        restService.delete(null, 7L, "USERSESSION");
+
+        verify(userService).delete(7L, Arrays.asList("USERSESSION"));
+    }
+
+    @Test
+    public void testDeleteWithMultipleCategoriesAndBlankEntries() {
+        when(userService.delete(7L, Arrays.asList("USERSESSION", "TEMP"))).thenReturn(true);
+
+        restService.delete(null, 7L, " USERSESSION , TEMP ,, ");
+
+        verify(userService).delete(7L, Arrays.asList("USERSESSION", "TEMP"));
+    }
+
+    @Test
+    public void testDeleteUserNotFound() {
+        when(userService.delete(99L, Collections.emptyList())).thenReturn(false);
+
+        assertThrows(NotFoundWebEx.class, () -> restService.delete(null, 99L, null));
+    }
+}


### PR DESCRIPTION
## Problem

Resources have no FK to their owning user — ownership is a `gs_security` rule. Deleting a user cascades the user's own rows (security rules, attributes, favorites, group memberships) but leaves the resources the user owned **orphaned** in `gs_resource`. The typical case is the MapStore **USERSESSION** resources: after a user is removed, their session resources remain in the database with no owner.

## Solution

New optional query parameter on the delete-user endpoint, a comma-separated list of category names:

```
DELETE /users/user/{id}?cascadeResourceDelete=USERSESSION
```

For each named category (resolved **by name at runtime** — unknown categories are ignored and never block the deletion), the resources the user **solely owns** are deleted right before the user, letting the existing Resource JPA cascades clear their security rules, attributes and stored data. A resource is solely owned when every security rule on it belongs to the user — matched by user id or by username string (externally-authenticated LDAP/SSO users) — and at least one rule grants write.

- Resources **shared** with other users or groups are preserved.
- Resources of **unlisted categories** are untouched.
- The **parameterless** delete keeps the previous behavior.
- The cascade is best-effort: a missing category, an empty category, or an error while collecting resources never prevents the user deletion.

## Changes

- `RESTUserService` / `RESTUserServiceImpl` — the `cascadeResourceDelete` query parameter (comma-separated, trimmed, blanks discarded).
- `UserService` — new `delete(long, List<String>)` overload as a **default method** delegating to the plain delete, so existing implementations keep compiling.
- `UserServiceImpl` — the cascade logic; `ResourceService` and `CategoryService` are autowired byName from the services context (dependency direction verified acyclic, no XML changes needed).
- `.github/scripts/run-integration-tests.ps1` — new 13-step phase exercising the parameter end-to-end over REST; it runs in CI on every PR via the existing integration-tests workflow.

## Testing

- **Unit / H2 integration** — `UserServiceImplTest` (16/16): solely-owned purge, missing category, shared-resource preservation, unlisted-category isolation, username-rule ownership, parameterless backward compatibility. `RESTUserServiceImplCascadeDeleteTest` (5/5): parameter parsing and 404 propagation.
- **Full reactor** `mvn clean install` with all tests: BUILD SUCCESS, zero failures.
- **Live e2e** against `jetty:run` on :9191 (h2_disk): full REST integration suite **63/63 PASS**, including the new cascade phase (category created via REST, session resource cascade-deleted, comma-separated parsing with an unknown category, shared and unlisted-category resources preserved and still readable, plain delete unchanged, empty-category cascade).

Refs geosolutions-it/support#5817
