### PR TITLE
OAuth2 config: escaped separators in role/group mappings, secret masking, log hygiene

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -29,8 +29,10 @@
 package it.geosolutions.geostore.services.rest.security.oauth2;
 
 import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -242,7 +244,7 @@ public class OAuth2Configuration extends IdPConfiguration {
             loginUri.append("&access_type=").append(accessType);
         }
 
-        LOGGER.info("Authorization endpoint URI built: {}", loginUri);
+        LOGGER.debug("Authorization endpoint URI built: {}", loginUri);
         return loginUri.toString();
     }
 
@@ -694,17 +696,73 @@ public class OAuth2Configuration extends IdPConfiguration {
         this.logSensitiveInfo = logSensitiveInfo;
     }
 
+    /**
+     * Parses comma-separated {@code key:value} mappings. Literal colons or commas inside a key or
+     * value can be escaped with a backslash, e.g. {@code landscape\:read:mapped-name} maps the IdP
+     * role {@code landscape:read}. Note that in .properties files the backslash itself must be
+     * doubled ({@code landscape\\:read}) because the properties format consumes one level of
+     * escaping.
+     */
     static Map<String, String> parseMappings(String mappings) {
         if (mappings == null || mappings.trim().isEmpty()) return null;
-        String[] pairs = mappings.split(",");
-        Map<String, String> map = new HashMap<>(pairs.length);
-        for (String pair : pairs) {
-            String[] parts = pair.split(":", 2);
-            if (parts.length == 2) {
-                map.put(parts[0].trim().toUpperCase(Locale.ROOT), parts[1].trim());
+        Map<String, String> map = new HashMap<>();
+        for (String pair : splitUnescaped(mappings, ',', 0)) {
+            List<String> parts = splitUnescaped(pair, ':', 2);
+            if (parts.size() == 2) {
+                String key = unescape(parts.get(0).trim());
+                String value = unescape(parts.get(1).trim());
+                if (!key.isEmpty()) {
+                    map.put(key.toUpperCase(Locale.ROOT), value);
+                }
             }
         }
         return map.isEmpty() ? null : map;
+    }
+
+    /**
+     * Splits on the separator character, honoring backslash escaping: an escaped separator does not
+     * split and is kept (still escaped) in the resulting part. With {@code limit > 0} at most
+     * {@code limit} parts are produced (the remainder is left unsplit, like {@code
+     * String.split(regex, limit)}).
+     */
+    private static List<String> splitUnescaped(String input, char separator, int limit) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaped = false;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (escaped) {
+                current.append('\\').append(c);
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == separator && (limit <= 0 || result.size() < limit - 1)) {
+                result.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        if (escaped) current.append('\\');
+        result.add(current.toString());
+        return result;
+    }
+
+    /** Removes one level of backslash escaping ({@code \x} becomes {@code x}). */
+    private static String unescape(String input) {
+        StringBuilder sb = new StringBuilder(input.length());
+        boolean escaped = false;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (!escaped && c == '\\') {
+                escaped = true;
+                continue;
+            }
+            sb.append(c);
+            escaped = false;
+        }
+        if (escaped) sb.append('\\');
+        return sb.toString();
     }
 
     @Override
@@ -782,7 +840,7 @@ public class OAuth2Configuration extends IdPConfiguration {
                 + clientId
                 + '\''
                 + ", clientSecret='"
-                + clientSecret
+                + (clientSecret != null && !clientSecret.isEmpty() ? "***" : null)
                 + '\''
                 + ", accessTokenUri='"
                 + accessTokenUri

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -244,7 +244,9 @@ public class OAuth2Configuration extends IdPConfiguration {
             loginUri.append("&access_type=").append(accessType);
         }
 
-        LOGGER.debug("Authorization endpoint URI built: {}", loginUri);
+        if (isLogSensitiveInfo()) {
+            LOGGER.debug("Authorization endpoint URI built: {}", loginUri);
+        }
         return loginUri.toString();
     }
 

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2ConfigurationMappingsTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2ConfigurationMappingsTest.java
@@ -1,0 +1,123 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OAuth2Configuration#parseMappings(String)}, in particular the backslash escaping
+ * needed for IdP role/group names that contain the {@code :} separator (e.g. Keycloak
+ * permission-style roles like {@code landscape:read}).
+ */
+public class OAuth2ConfigurationMappingsTest {
+
+    @Test
+    void parsesSimpleMappings() {
+        Map<String, String> map = OAuth2Configuration.parseMappings("admin:ADMIN,user:USER");
+        assertEquals(2, map.size());
+        assertEquals("ADMIN", map.get("ADMIN"));
+        assertEquals("USER", map.get("USER"));
+    }
+
+    @Test
+    void keysAreCaseInsensitive() {
+        Map<String, String> map = OAuth2Configuration.parseMappings("Manage-Users:ADMIN");
+        assertEquals("ADMIN", map.get("MANAGE-USERS"));
+    }
+
+    @Test
+    void escapedColonInKey() {
+        Map<String, String> map =
+                OAuth2Configuration.parseMappings(
+                        "landscape\\:read:landscape_con_due_punti,manage-users:manage-users");
+        assertEquals(2, map.size());
+        assertEquals("landscape_con_due_punti", map.get("LANDSCAPE:READ"));
+        assertEquals("manage-users", map.get("MANAGE-USERS"));
+    }
+
+    @Test
+    void escapedColonInValue() {
+        Map<String, String> map =
+                OAuth2Configuration.parseMappings("active-product\\:read:active-product\\:read");
+        assertEquals(1, map.size());
+        assertEquals("active-product:read", map.get("ACTIVE-PRODUCT:READ"));
+    }
+
+    @Test
+    void unescapedValueKeepsTrailingColons() {
+        // value is everything after the first unescaped colon
+        Map<String, String> map = OAuth2Configuration.parseMappings("key:a:b");
+        assertEquals("a:b", map.get("KEY"));
+    }
+
+    @Test
+    void escapedCommaInKey() {
+        Map<String, String> map = OAuth2Configuration.parseMappings("a\\,b:VALUE,c:D");
+        assertEquals(2, map.size());
+        assertEquals("VALUE", map.get("A,B"));
+        assertEquals("D", map.get("C"));
+    }
+
+    @Test
+    void malformedPairsAreSkipped() {
+        Map<String, String> map = OAuth2Configuration.parseMappings("noseparator,ok:GOOD");
+        assertEquals(1, map.size());
+        assertEquals("GOOD", map.get("OK"));
+    }
+
+    @Test
+    void nullAndEmptyReturnNull() {
+        assertNull(OAuth2Configuration.parseMappings(null));
+        assertNull(OAuth2Configuration.parseMappings("  "));
+        assertNull(OAuth2Configuration.parseMappings("nopairs"));
+    }
+
+    @Test
+    void mappingsRoundTripThroughSetters() {
+        OAuth2Configuration config = new OAuth2Configuration();
+        config.setRoleMappings("manage-users:ADMIN");
+        config.setGroupMappings(
+                "manage-users:manage-users,landscape\\:read:landscape_con_due_punti,default-roles-portal:infragri");
+        assertEquals("ADMIN", config.getRoleMappings().get("MANAGE-USERS"));
+        assertEquals("landscape_con_due_punti", config.getGroupMappings().get("LANDSCAPE:READ"));
+        assertEquals("infragri", config.getGroupMappings().get("DEFAULT-ROLES-PORTAL"));
+    }
+
+    @Test
+    void clientSecretIsMaskedInToString() {
+        OAuth2Configuration config = new OAuth2Configuration();
+        config.setClientId("client");
+        config.setClientSecret("super-secret-value");
+        assertFalse(
+                config.toString().contains("super-secret-value"),
+                "clientSecret must not appear in toString()");
+    }
+}

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -48,6 +48,9 @@
 # oidcOAuth2Config.groupsClaim=groups
 # oidcOAuth2Config.roleMappings=admin:ADMIN,user:USER
 # oidcOAuth2Config.groupMappings=
+# If an IdP role/group name contains ':' or ',', escape it with a backslash.
+# In this .properties file the backslash must be doubled (properties escaping):
+# oidcOAuth2Config.groupMappings=landscape\\:read:landscape_read,manage-users:admins
 # oidcOAuth2Config.dropUnmapped=false
 # oidcOAuth2Config.usePKCE=false
 #


### PR DESCRIPTION
These changes are related to this MapStore task
- https://github.com/geosolutions-it/support/issues/6035

This PR forward-ports the changes from #546 to the master branch.

## What this does

Subset of the OIDC fixes applicable to current master (after the Spring 7 migration removed the legacy `openid_connect` implementation). The full fix set is in the companion 2.6.x PR.

- **Escaped separators in mappings**: `roleMappings` / `groupMappings` now support backslash-escaped `:` and `,` so IdP role/group names like Keycloak permission-style roles (`landscape:read`) can be mapped, e.g. `landscape\:read:mapped-name` (double the backslash in `.properties` files because the properties format consumes one level of escaping). Previously such entries were silently mis-parsed at the first colon.
- **Secret masking**: `clientSecret` is masked in `OAuth2Configuration.toString()` so it can no longer leak into logs or diagnostics output.
- **Log hygiene**: the built authorization URI (contains `client_id`) is logged at DEBUG instead of INFO.

## Testing

New `OAuth2ConfigurationMappingsTest` (10 tests) covering simple/escaped/malformed mappings and the secret masking.