### PR TITLE
[2.6.x] Fix OIDC logout, stale token reuse, sensitive logging and mapping escaping

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/TokenAuthenticationCache.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/TokenAuthenticationCache.java
@@ -113,7 +113,15 @@ public class TokenAuthenticationCache implements ApplicationContextAware {
             if (exp != null) {
                 long remainingMs = exp.getTime() - System.currentTimeMillis();
                 if (remainingMs > 0) {
-                    return TimeUnit.MILLISECONDS.toNanos(remainingMs);
+                    // Keep the entry at least for the configured cache lifetime: the
+                    // authentication filter re-validates expired access tokens anyway, and
+                    // the logout flow needs the cached TokenDetails (ID token) to terminate
+                    // the IdP session even when the user logs out after the access token
+                    // expired. Evicting exactly at token expiry made RP-initiated logout
+                    // silently ineffective for idle sessions and was sensitive to IdP
+                    // clock skew.
+                    return Math.max(
+                            TimeUnit.MILLISECONDS.toNanos(remainingMs), defaultExpirationNanos);
                 }
             }
         }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -29,8 +29,10 @@
 package it.geosolutions.geostore.services.rest.security.oauth2;
 
 import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -242,7 +244,7 @@ public class OAuth2Configuration extends IdPConfiguration {
             loginUri.append("&access_type=").append(accessType);
         }
 
-        LOGGER.info("Authorization endpoint URI built: {}", loginUri);
+        LOGGER.debug("Authorization endpoint URI built: {}", loginUri);
         return loginUri.toString();
     }
 
@@ -694,17 +696,73 @@ public class OAuth2Configuration extends IdPConfiguration {
         this.logSensitiveInfo = logSensitiveInfo;
     }
 
+    /**
+     * Parses comma-separated {@code key:value} mappings. Literal colons or commas inside a key or
+     * value can be escaped with a backslash, e.g. {@code landscape\:read:mapped-name} maps the IdP
+     * role {@code landscape:read}. Note that in .properties files the backslash itself must be
+     * doubled ({@code landscape\\:read}) because the properties format consumes one level of
+     * escaping.
+     */
     static Map<String, String> parseMappings(String mappings) {
         if (mappings == null || mappings.trim().isEmpty()) return null;
-        String[] pairs = mappings.split(",");
-        Map<String, String> map = new HashMap<>(pairs.length);
-        for (String pair : pairs) {
-            String[] parts = pair.split(":", 2);
-            if (parts.length == 2) {
-                map.put(parts[0].trim().toUpperCase(Locale.ROOT), parts[1].trim());
+        Map<String, String> map = new HashMap<>();
+        for (String pair : splitUnescaped(mappings, ',', 0)) {
+            List<String> parts = splitUnescaped(pair, ':', 2);
+            if (parts.size() == 2) {
+                String key = unescape(parts.get(0).trim());
+                String value = unescape(parts.get(1).trim());
+                if (!key.isEmpty()) {
+                    map.put(key.toUpperCase(Locale.ROOT), value);
+                }
             }
         }
         return map.isEmpty() ? null : map;
+    }
+
+    /**
+     * Splits on the separator character, honoring backslash escaping: an escaped separator does not
+     * split and is kept (still escaped) in the resulting part. With {@code limit > 0} at most
+     * {@code limit} parts are produced (the remainder is left unsplit, like {@code
+     * String.split(regex, limit)}).
+     */
+    private static List<String> splitUnescaped(String input, char separator, int limit) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaped = false;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (escaped) {
+                current.append('\\').append(c);
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == separator && (limit <= 0 || result.size() < limit - 1)) {
+                result.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        if (escaped) current.append('\\');
+        result.add(current.toString());
+        return result;
+    }
+
+    /** Removes one level of backslash escaping ({@code \x} becomes {@code x}). */
+    private static String unescape(String input) {
+        StringBuilder sb = new StringBuilder(input.length());
+        boolean escaped = false;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (!escaped && c == '\\') {
+                escaped = true;
+                continue;
+            }
+            sb.append(c);
+            escaped = false;
+        }
+        if (escaped) sb.append('\\');
+        return sb.toString();
     }
 
     @Override
@@ -782,7 +840,7 @@ public class OAuth2Configuration extends IdPConfiguration {
                 + clientId
                 + '\''
                 + ", clientSecret='"
-                + clientSecret
+                + (clientSecret != null && !clientSecret.isEmpty() ? "***" : null)
                 + '\''
                 + ", accessTokenUri='"
                 + accessTokenUri

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2Configuration.java
@@ -244,7 +244,9 @@ public class OAuth2Configuration extends IdPConfiguration {
             loginUri.append("&access_type=").append(accessType);
         }
 
-        LOGGER.debug("Authorization endpoint URI built: {}", loginUri);
+        if (isLogSensitiveInfo()) {
+            LOGGER.debug("Authorization endpoint URI built: {}", loginUri);
+        }
         return loginUri.toString();
     }
 

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -208,6 +208,11 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             } else {
                 TokenDetails details = tokenDetails(authentication);
                 if (details != null) {
+                    // Expose the cached tokens and provider to downstream handlers (the
+                    // logout endpoint above all) BEFORE any re-authentication: once the
+                    // access token has expired, the cached details are the only reliable
+                    // source for the ID token and the provider selection.
+                    exposeTokenDetails(request, token, details);
                     OAuth2AccessToken accessToken = details.getAccessToken();
                     if (accessToken.isExpired()) {
                         authentication =
@@ -259,6 +264,26 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
     private TokenDetails tokenDetails(Authentication authentication) {
         Object details = authentication != null ? authentication.getDetails() : null;
         return (details instanceof TokenDetails) ? (TokenDetails) details : null;
+    }
+
+    /**
+     * Publishes the cached token details as request attributes so that downstream handlers (the
+     * session/logout endpoint in particular) can resolve the provider, the ID token and the refresh
+     * token even when the access token is expired and re-authentication fails.
+     */
+    private void exposeTokenDetails(
+            HttpServletRequest request, String token, TokenDetails details) {
+        request.setAttribute(PROVIDER_KEY, details.getProvider());
+        request.setAttribute(ACCESS_TOKEN_PARAM, token);
+        if (details.getIdToken() != null) {
+            request.setAttribute(ID_TOKEN_PARAM, details.getIdToken());
+        }
+        OAuth2AccessToken cached = details.getAccessToken();
+        if (cached != null
+                && cached.getRefreshToken() != null
+                && cached.getRefreshToken().getValue() != null) {
+            request.setAttribute(REFRESH_TOKEN_PARAM, cached.getRefreshToken().getValue());
+        }
     }
 
     /**

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -333,6 +333,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             HttpServletResponse response,
             String token,
             OAuth2AccessToken accessToken) {
+        final String requestToken = token;
         Authentication authentication = performOAuthAuthentication(request, response, accessToken);
         if (authentication != null) {
             SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -361,6 +362,13 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
                 cache.putCacheEntry(token, authentication);
             } else {
                 LOGGER.info("Skipping cache insert: no access token available yet.");
+            }
+            // Also cache under the token the client actually presented when it differs from
+            // the one resolved from the rest template context: bearer requests always look up
+            // the cache with the token they hold, so a key mismatch would force a remote
+            // re-authentication on every request and break logout (no cached TokenDetails).
+            if (requestToken != null && !requestToken.equals(token)) {
+                cache.putCacheEntry(requestToken, authentication);
             }
         }
         Objects.requireNonNull(RequestContextHolder.getRequestAttributes())

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -363,6 +363,11 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             accessTokenRequest.setStateKey(null);
             accessTokenRequest.setPreservedState(null);
             accessTokenRequest.setAuthorizationCode(code);
+            // Drop any token left in the shared client context by a previous session:
+            // OAuth2RestTemplate would return it instead of exchanging the fresh code
+            // (or, once expired, attempt a refresh with a dead refresh token, failing
+            // every login until restart).
+            clientContext.setAccessToken(null);
             // Set currentUri to the configured redirect URI (not the actual request URL)
             // so the token exchange sends the correct redirect_uri to the IdP.
             // The actual request URL may differ due to reverse proxy or path rewriting.
@@ -378,6 +383,9 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
 
     private void clearState() {
         OAuth2ClientContext clientContext = restTemplate.getOAuth2ClientContext();
+        // The client context is shared across requests: a token left behind by a previous
+        // session must not be reused for a new unauthenticated login attempt.
+        clientContext.setAccessToken(null);
         final AccessTokenRequest accessTokenRequest = clientContext.getAccessTokenRequest();
         if (accessTokenRequest != null && accessTokenRequest.getStateKey() != null) {
             clientContext.removePreservedState(accessTokenRequest.getStateKey());
@@ -406,7 +414,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             HttpServletResponse response,
             OAuth2AccessToken accessToken) {
         LOGGER.info("About to perform remote authentication.");
-        LOGGER.info("Access Token: {}", accessToken);
+        LOGGER.debug("Access Token: {}", accessToken);
         String principal = null;
         PreAuthenticatedAuthenticationToken result = null;
         try {
@@ -827,7 +835,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // 1) Try primary token (usually ID token)
             if (primaryHelper != null) {
                 rawRoles = primaryHelper.getClaim(rolesClaimName, Object.class);
-                LOGGER.info(
+                LOGGER.debug(
                         "Roles claim '{}' from primary token: {} (type={})",
                         rolesClaimName,
                         rawRoles,
@@ -836,7 +844,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // 2) Fallback: access token (Keycloak puts realm_access here)
             if (rawRoles == null && accessHelper != null) {
                 rawRoles = accessHelper.getClaim(rolesClaimName, Object.class);
-                LOGGER.info(
+                LOGGER.debug(
                         "Roles claim '{}' from access token (fallback): {} (type={})",
                         rolesClaimName,
                         rawRoles,
@@ -845,7 +853,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // 3) Fallback: userinfo map
             if (rawRoles == null && userinfoMap != null) {
                 rawRoles = ClaimPathResolver.resolveIgnoreCase(userinfoMap, rolesClaimName);
-                LOGGER.info(
+                LOGGER.debug(
                         "Roles claim '{}' from userinfo: {} (type={})",
                         rolesClaimName,
                         rawRoles,
@@ -858,7 +866,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         if (rawRoles != null) {
             List<String> oidcRoles = ClaimPathResolver.toStringList(rawRoles);
             if (oidcRoles == null) oidcRoles = Collections.emptyList();
-            LOGGER.info(
+            LOGGER.debug(
                     "Resolved role strings from token: {} (roleMappings={})",
                     oidcRoles,
                     configuration.getRoleMappings());
@@ -894,12 +902,12 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // 1) Try primary token
             if (primaryHelper != null) {
                 fromJwt = primaryHelper.getClaimAsList(groupsClaimName, String.class);
-                LOGGER.info("Groups from primary token claim '{}': {}", groupsClaimName, fromJwt);
+                LOGGER.debug("Groups from primary token claim '{}': {}", groupsClaimName, fromJwt);
             }
             // 2) Fallback: access token
             if ((fromJwt == null || fromJwt.isEmpty()) && accessHelper != null) {
                 fromJwt = accessHelper.getClaimAsList(groupsClaimName, String.class);
-                LOGGER.info(
+                LOGGER.debug(
                         "Groups from access token claim '{}' (fallback): {}",
                         groupsClaimName,
                         fromJwt);
@@ -910,12 +918,12 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
                 // 3) Fallback: userinfo map
                 List<String> fromUserinfo =
                         ClaimPathResolver.resolveAsListIgnoreCase(userinfoMap, groupsClaimName);
-                LOGGER.info("Groups from userinfo claim '{}': {}", groupsClaimName, fromUserinfo);
+                LOGGER.debug("Groups from userinfo claim '{}': {}", groupsClaimName, fromUserinfo);
                 if (fromUserinfo != null) {
                     oidcGroups = fromUserinfo;
                 }
             }
-            LOGGER.info("Groups resolved from token/userinfo: {}", oidcGroups);
+            LOGGER.debug("Groups resolved from token/userinfo: {}", oidcGroups);
         } else {
             LOGGER.info("No groupsClaim configured -> skipping group sync.");
         }
@@ -939,7 +947,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             oidcGroups = mapped;
         }
 
-        LOGGER.info(
+        LOGGER.debug(
                 "Final groups to reconcile: {} (user.role={}, user.id={})",
                 oidcGroups,
                 user.getRole(),
@@ -949,7 +957,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         // ----- Persist user after role & group sync -----
         try {
             if (userService != null) {
-                LOGGER.info(
+                LOGGER.debug(
                         "Persisting user '{}' (id={}, role={}, groups={})",
                         user.getName(),
                         user.getId(),
@@ -974,7 +982,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
                     e.getMessage(),
                     e);
         } finally {
-            LOGGER.info(
+            LOGGER.debug(
                     "User '{}' after sync: role={}, groups={}",
                     user.getName(),
                     user.getRole(),
@@ -987,7 +995,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
     // ---------------------------------------------------------------------
 
     private Role computeRole(List<String> rolesFromToken, Role defaultRole) {
-        LOGGER.info(
+        LOGGER.debug(
                 "computeRole: rolesFromToken={}, defaultRole={}, roleMappings={}, dropUnmapped={}",
                 rolesFromToken,
                 defaultRole,
@@ -995,7 +1003,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
                 configuration.isDropUnmapped());
         if (rolesFromToken == null || rolesFromToken.isEmpty()) {
             Role result = (defaultRole != null) ? defaultRole : Role.USER;
-            LOGGER.info("computeRole: no roles in token -> returning {}", result);
+            LOGGER.debug("computeRole: no roles in token -> returning {}", result);
             return result;
         }
         Map<String, String> roleMappings = configuration.getRoleMappings();
@@ -1008,15 +1016,15 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             if (roleMappings != null) {
                 String mapped = roleMappings.get(rr.toUpperCase(Locale.ROOT));
                 if (mapped != null) {
-                    LOGGER.info("computeRole: '{}' mapped to '{}' via roleMappings", rr, mapped);
+                    LOGGER.debug("computeRole: '{}' mapped to '{}' via roleMappings", rr, mapped);
                     rr = mapped;
                     wasMapped = true;
                 } else if (dropUnmapped) {
-                    LOGGER.info(
+                    LOGGER.debug(
                             "computeRole: '{}' not in roleMappings, dropping (dropUnmapped)", rr);
                     continue;
                 } else {
-                    LOGGER.info(
+                    LOGGER.debug(
                             "computeRole: '{}' not in roleMappings, keeping (dropUnmapped=false)",
                             rr);
                 }
@@ -1026,21 +1034,21 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // (e.g. "guest", "admin") should not accidentally match GeoStore roles.
             if (wasMapped || roleMappings == null || roleMappings.isEmpty()) {
                 if (rr.equalsIgnoreCase(Role.ADMIN.name())) {
-                    LOGGER.info("computeRole: '{}' matches ADMIN -> returning ADMIN", rr);
+                    LOGGER.debug("computeRole: '{}' matches ADMIN -> returning ADMIN", rr);
                     return Role.ADMIN;
                 }
                 if (rr.equalsIgnoreCase(Role.USER.name())) {
-                    LOGGER.info("computeRole: '{}' matches USER", rr);
+                    LOGGER.debug("computeRole: '{}' matches USER", rr);
                     resolved = Role.USER;
                     continue;
                 }
                 if (rr.equalsIgnoreCase(Role.GUEST.name())) {
-                    LOGGER.info("computeRole: '{}' matches GUEST", rr);
+                    LOGGER.debug("computeRole: '{}' matches GUEST", rr);
                     resolved = Role.GUEST;
                 }
             }
         }
-        LOGGER.info("computeRole: final resolved role = {}", resolved);
+        LOGGER.debug("computeRole: final resolved role = {}", resolved);
         return resolved;
     }
 
@@ -1080,7 +1088,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             return;
         }
 
-        LOGGER.info(
+        LOGGER.debug(
                 "reconcileRemoteGroups: user='{}' (id={}, role={}), "
                         + "provider='{}', newGroupNames={}, "
                         + "currentGroups={} (type={})",

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -414,7 +414,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             HttpServletResponse response,
             OAuth2AccessToken accessToken) {
         LOGGER.info("About to perform remote authentication.");
-        LOGGER.debug("Access Token: {}", accessToken);
+        debugSensitive("Access Token: {}", accessToken);
         String principal = null;
         PreAuthenticatedAuthenticationToken result = null;
         try {
@@ -688,6 +688,18 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         }
     }
 
+    /**
+     * Logs potentially sensitive details (token values, claim contents, resolved roles/groups) only
+     * when the provider explicitly enables {@code logSensitiveInfo}. Raising the logger level alone
+     * is not enough: this prevents tokens and claims from leaking into DEBUG logs enabled for
+     * ordinary troubleshooting.
+     */
+    private void debugSensitive(String message, Object... args) {
+        if (configuration != null && configuration.isLogSensitiveInfo()) {
+            LOGGER.debug(message, args);
+        }
+    }
+
     protected List<String> parseScopes(String commaSeparatedScopes) {
         List<String> scopes = newArrayList();
         if (StringUtils.isBlank(commaSeparatedScopes)) return scopes;
@@ -835,7 +847,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // 1) Try primary token (usually ID token)
             if (primaryHelper != null) {
                 rawRoles = primaryHelper.getClaim(rolesClaimName, Object.class);
-                LOGGER.debug(
+                debugSensitive(
                         "Roles claim '{}' from primary token: {} (type={})",
                         rolesClaimName,
                         rawRoles,
@@ -844,7 +856,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // 2) Fallback: access token (Keycloak puts realm_access here)
             if (rawRoles == null && accessHelper != null) {
                 rawRoles = accessHelper.getClaim(rolesClaimName, Object.class);
-                LOGGER.debug(
+                debugSensitive(
                         "Roles claim '{}' from access token (fallback): {} (type={})",
                         rolesClaimName,
                         rawRoles,
@@ -853,7 +865,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // 3) Fallback: userinfo map
             if (rawRoles == null && userinfoMap != null) {
                 rawRoles = ClaimPathResolver.resolveIgnoreCase(userinfoMap, rolesClaimName);
-                LOGGER.debug(
+                debugSensitive(
                         "Roles claim '{}' from userinfo: {} (type={})",
                         rolesClaimName,
                         rawRoles,
@@ -866,7 +878,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         if (rawRoles != null) {
             List<String> oidcRoles = ClaimPathResolver.toStringList(rawRoles);
             if (oidcRoles == null) oidcRoles = Collections.emptyList();
-            LOGGER.debug(
+            debugSensitive(
                     "Resolved role strings from token: {} (roleMappings={})",
                     oidcRoles,
                     configuration.getRoleMappings());
@@ -902,12 +914,13 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // 1) Try primary token
             if (primaryHelper != null) {
                 fromJwt = primaryHelper.getClaimAsList(groupsClaimName, String.class);
-                LOGGER.debug("Groups from primary token claim '{}': {}", groupsClaimName, fromJwt);
+                debugSensitive(
+                        "Groups from primary token claim '{}': {}", groupsClaimName, fromJwt);
             }
             // 2) Fallback: access token
             if ((fromJwt == null || fromJwt.isEmpty()) && accessHelper != null) {
                 fromJwt = accessHelper.getClaimAsList(groupsClaimName, String.class);
-                LOGGER.debug(
+                debugSensitive(
                         "Groups from access token claim '{}' (fallback): {}",
                         groupsClaimName,
                         fromJwt);
@@ -918,12 +931,13 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
                 // 3) Fallback: userinfo map
                 List<String> fromUserinfo =
                         ClaimPathResolver.resolveAsListIgnoreCase(userinfoMap, groupsClaimName);
-                LOGGER.debug("Groups from userinfo claim '{}': {}", groupsClaimName, fromUserinfo);
+                debugSensitive(
+                        "Groups from userinfo claim '{}': {}", groupsClaimName, fromUserinfo);
                 if (fromUserinfo != null) {
                     oidcGroups = fromUserinfo;
                 }
             }
-            LOGGER.debug("Groups resolved from token/userinfo: {}", oidcGroups);
+            debugSensitive("Groups resolved from token/userinfo: {}", oidcGroups);
         } else {
             LOGGER.info("No groupsClaim configured -> skipping group sync.");
         }
@@ -947,7 +961,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             oidcGroups = mapped;
         }
 
-        LOGGER.debug(
+        debugSensitive(
                 "Final groups to reconcile: {} (user.role={}, user.id={})",
                 oidcGroups,
                 user.getRole(),
@@ -957,7 +971,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         // ----- Persist user after role & group sync -----
         try {
             if (userService != null) {
-                LOGGER.debug(
+                debugSensitive(
                         "Persisting user '{}' (id={}, role={}, groups={})",
                         user.getName(),
                         user.getId(),
@@ -982,7 +996,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
                     e.getMessage(),
                     e);
         } finally {
-            LOGGER.debug(
+            debugSensitive(
                     "User '{}' after sync: role={}, groups={}",
                     user.getName(),
                     user.getRole(),
@@ -995,7 +1009,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
     // ---------------------------------------------------------------------
 
     private Role computeRole(List<String> rolesFromToken, Role defaultRole) {
-        LOGGER.debug(
+        debugSensitive(
                 "computeRole: rolesFromToken={}, defaultRole={}, roleMappings={}, dropUnmapped={}",
                 rolesFromToken,
                 defaultRole,
@@ -1003,7 +1017,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
                 configuration.isDropUnmapped());
         if (rolesFromToken == null || rolesFromToken.isEmpty()) {
             Role result = (defaultRole != null) ? defaultRole : Role.USER;
-            LOGGER.debug("computeRole: no roles in token -> returning {}", result);
+            debugSensitive("computeRole: no roles in token -> returning {}", result);
             return result;
         }
         Map<String, String> roleMappings = configuration.getRoleMappings();
@@ -1016,15 +1030,15 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             if (roleMappings != null) {
                 String mapped = roleMappings.get(rr.toUpperCase(Locale.ROOT));
                 if (mapped != null) {
-                    LOGGER.debug("computeRole: '{}' mapped to '{}' via roleMappings", rr, mapped);
+                    debugSensitive("computeRole: '{}' mapped to '{}' via roleMappings", rr, mapped);
                     rr = mapped;
                     wasMapped = true;
                 } else if (dropUnmapped) {
-                    LOGGER.debug(
+                    debugSensitive(
                             "computeRole: '{}' not in roleMappings, dropping (dropUnmapped)", rr);
                     continue;
                 } else {
-                    LOGGER.debug(
+                    debugSensitive(
                             "computeRole: '{}' not in roleMappings, keeping (dropUnmapped=false)",
                             rr);
                 }
@@ -1034,21 +1048,21 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             // (e.g. "guest", "admin") should not accidentally match GeoStore roles.
             if (wasMapped || roleMappings == null || roleMappings.isEmpty()) {
                 if (rr.equalsIgnoreCase(Role.ADMIN.name())) {
-                    LOGGER.debug("computeRole: '{}' matches ADMIN -> returning ADMIN", rr);
+                    debugSensitive("computeRole: '{}' matches ADMIN -> returning ADMIN", rr);
                     return Role.ADMIN;
                 }
                 if (rr.equalsIgnoreCase(Role.USER.name())) {
-                    LOGGER.debug("computeRole: '{}' matches USER", rr);
+                    debugSensitive("computeRole: '{}' matches USER", rr);
                     resolved = Role.USER;
                     continue;
                 }
                 if (rr.equalsIgnoreCase(Role.GUEST.name())) {
-                    LOGGER.debug("computeRole: '{}' matches GUEST", rr);
+                    debugSensitive("computeRole: '{}' matches GUEST", rr);
                     resolved = Role.GUEST;
                 }
             }
         }
-        LOGGER.debug("computeRole: final resolved role = {}", resolved);
+        debugSensitive("computeRole: final resolved role = {}", resolved);
         return resolved;
     }
 
@@ -1088,7 +1102,7 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             return;
         }
 
-        LOGGER.debug(
+        debugSensitive(
                 "reconcileRemoteGroups: user='{}' (id={}, role={}), "
                         + "provider='{}', newGroupNames={}, "
                         + "currentGroups={} (type={})",

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -519,7 +519,10 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
             if (refreshToken != null) {
                 accessToken.setRefreshToken(refreshToken);
             }
-            LOGGER.debug("Creating new details. AccessToken: {} IdToken: {}", accessToken, idToken);
+            if (conf != null && conf.isLogSensitiveInfo()) {
+                LOGGER.debug(
+                        "Creating new details. AccessToken: {} IdToken: {}", accessToken, idToken);
+            }
             updated.setDetails(new TokenDetails(accessToken, idToken, conf.getBeanName()));
             cache().putCacheEntry(newToken.getValue(), updated);
             SecurityContextHolder.getContext().setAuthentication(updated);

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -519,7 +519,7 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
             if (refreshToken != null) {
                 accessToken.setRefreshToken(refreshToken);
             }
-            LOGGER.info("Creating new details. AccessToken: {} IdToken: {}", accessToken, idToken);
+            LOGGER.debug("Creating new details. AccessToken: {} IdToken: {}", accessToken, idToken);
             updated.setDetails(new TokenDetails(accessToken, idToken, conf.getBeanName()));
             cache().putCacheEntry(newToken.getValue(), updated);
             SecurityContextHolder.getContext().setAuthentication(updated);
@@ -636,22 +636,26 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
                     && !accessToken.isEmpty()) {
                 if (configuration.isGlobalLogoutEnabled())
                     doLogoutInternal(token, configuration, accessToken);
-                if (configuration.getRevokeEndpoint() != null) clearSession(restTemplate, request);
             } else {
-                LOGGER.debug("Unable to retrieve access token. Remote logout was not executed.");
+                LOGGER.warn(
+                        "Unable to retrieve the tokens for the current session. Remote logout was not executed.");
             }
+            // Always clear the local Spring OAuth2 state: the rest template's client context
+            // is shared across requests, and a leftover token would shadow the next
+            // authorization-code exchange once it expires.
+            if (restTemplate != null) clearSession(restTemplate, request);
             if (response != null) clearCookies(request, response);
         }
     }
 
     // clears any state a Spring OAuth2 object might preserve.
     private void clearSession(OAuth2RestTemplate restTemplate, HttpServletRequest request) {
-        final AccessTokenRequest accessTokenRequest =
-                restTemplate.getOAuth2ClientContext().getAccessTokenRequest();
+        final OAuth2ClientContext clientContext = restTemplate.getOAuth2ClientContext();
+        if (clientContext == null) return;
+        clientContext.setAccessToken(null);
+        final AccessTokenRequest accessTokenRequest = clientContext.getAccessTokenRequest();
         if (accessTokenRequest != null && accessTokenRequest.getStateKey() != null) {
-            restTemplate
-                    .getOAuth2ClientContext()
-                    .removePreservedState(accessTokenRequest.getStateKey());
+            clientContext.removePreservedState(accessTokenRequest.getStateKey());
         }
         try {
             if (accessTokenRequest != null) {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -613,6 +613,16 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
                                 RequestContextHolder.getRequestAttributes()
                                         .getAttribute(REFRESH_TOKEN_PARAM, 0);
             }
+            if (token == null && RequestContextHolder.getRequestAttributes() != null) {
+                // Last resort: the ID token published by the authentication filter from the
+                // cached token details. Reached when the access token is expired (cache entry
+                // already consumed by the failed re-authentication) — the ID token is exactly
+                // what the OIDC logout endpoint needs as id_token_hint.
+                token =
+                        (String)
+                                RequestContextHolder.getRequestAttributes()
+                                        .getAttribute(OAuth2Utils.ID_TOKEN_PARAM, 0);
+            }
         }
 
         if (accessToken == null) {

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -40,7 +40,8 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                     provider + CONFIG_NAME_SUFFIX);
             throw new RuntimeException("No OAuth2Configuration found for provider: " + provider);
         }
-        LOGGER.debug(
+        debugSensitive(
+                configuration,
                 "Provider '{}' config: enabled={}, clientId={}, authorizationUri={}, "
                         + "accessTokenUri={}, discoveryUrl={}, redirectUri={}, scopes={}",
                 provider,
@@ -60,7 +61,7 @@ public abstract class Oauth2LoginService implements IdPLoginService {
         String login = configuration.buildLoginUri();
         try {
             LOGGER.info("Redirecting to login URI for provider '{}'", provider);
-            LOGGER.debug("Login URI: {}", login);
+            debugSensitive(configuration, "Login URI: {}", login);
             resp.sendRedirect(login);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -90,7 +91,7 @@ public abstract class Oauth2LoginService implements IdPLoginService {
             throw new RuntimeException(
                     "No IdPConfiguration found for callback provider: " + provider);
         }
-        LOGGER.debug("Token: {}", token);
+        debugSensitive(configuration, "Token: {}", token);
         LOGGER.info("Redirect uri: {}", configuration.getRedirectUri());
         LOGGER.info("Internal redirect uri: {}", configuration.getInternalRedirectUri());
         if (token != null) {
@@ -100,11 +101,11 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                 result =
                         result.status(302)
                                 .location(new URI(configuration.getInternalRedirectUri()));
-                LOGGER.debug("AccessToken: {}", token);
+                debugSensitive(configuration, "AccessToken: {}", token);
                 sessionToken.setAccessToken(token);
                 sessionToken.setTokenType(BEARER_TYPE);
                 if (refreshToken != null) {
-                    LOGGER.debug("RefreshToken: {}", refreshToken);
+                    debugSensitive(configuration, "RefreshToken: {}", refreshToken);
                     result.header("Set-Cookie", refreshTokenCookie(refreshToken).toString());
                 }
                 TokenStorage tokenStorage = tokenStorage();
@@ -141,6 +142,19 @@ public abstract class Oauth2LoginService implements IdPLoginService {
 
     protected TokenStorage tokenStorage() {
         return GeoStoreContext.bean(TokenStorage.class);
+    }
+
+    /**
+     * Logs potentially sensitive details (token values, provider configuration) only when the
+     * provider explicitly enables {@code logSensitiveInfo}. Raising the logger level alone is not
+     * enough to print them.
+     */
+    private static void debugSensitive(
+            IdPConfiguration configuration, String message, Object... args) {
+        if (configuration instanceof OAuth2Configuration
+                && ((OAuth2Configuration) configuration).isLogSensitiveInfo()) {
+            LOGGER.debug(message, args);
+        }
     }
 
     protected Response buildCallbackResponse(

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -40,7 +40,7 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                     provider + CONFIG_NAME_SUFFIX);
             throw new RuntimeException("No OAuth2Configuration found for provider: " + provider);
         }
-        LOGGER.info(
+        LOGGER.debug(
                 "Provider '{}' config: enabled={}, clientId={}, authorizationUri={}, "
                         + "accessTokenUri={}, discoveryUrl={}, redirectUri={}, scopes={}",
                 provider,
@@ -59,7 +59,8 @@ public abstract class Oauth2LoginService implements IdPLoginService {
         }
         String login = configuration.buildLoginUri();
         try {
-            LOGGER.info("Redirecting to login URI for provider '{}': {}", provider, login);
+            LOGGER.info("Redirecting to login URI for provider '{}'", provider);
+            LOGGER.debug("Login URI: {}", login);
             resp.sendRedirect(login);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -89,7 +90,7 @@ public abstract class Oauth2LoginService implements IdPLoginService {
             throw new RuntimeException(
                     "No IdPConfiguration found for callback provider: " + provider);
         }
-        LOGGER.info("Token: {}", token);
+        LOGGER.debug("Token: {}", token);
         LOGGER.info("Redirect uri: {}", configuration.getRedirectUri());
         LOGGER.info("Internal redirect uri: {}", configuration.getInternalRedirectUri());
         if (token != null) {
@@ -99,11 +100,11 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                 result =
                         result.status(302)
                                 .location(new URI(configuration.getInternalRedirectUri()));
-                LOGGER.info("AccessToken: {}", token);
+                LOGGER.debug("AccessToken: {}", token);
                 sessionToken.setAccessToken(token);
                 sessionToken.setTokenType(BEARER_TYPE);
                 if (refreshToken != null) {
-                    LOGGER.info("RefreshToken: {}", refreshToken);
+                    LOGGER.debug("RefreshToken: {}", refreshToken);
                     result.header("Set-Cookie", refreshTokenCookie(refreshToken).toString());
                 }
                 TokenStorage tokenStorage = tokenStorage();

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/CompositeOpenIdConnectFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/CompositeOpenIdConnectFilter.java
@@ -156,19 +156,22 @@ public class CompositeOpenIdConnectFilter extends GenericFilterBean
                     new OpenIdConnectFilter(
                             tokenServices, restTemplate, config, cache, validator, jwksKeyProvider);
 
-            // Log configuration state after discovery has run (inside the filter constructor)
-            LOGGER.debug(
-                    "Provider '{}' config after discovery: authorizationUri={}, accessTokenUri={}, "
-                            + "discoveryUrl={}, clientId={}, redirectUri={}, scopes={}, "
-                            + "isInvalid={}",
-                    providerName,
-                    config.getAuthorizationUri(),
-                    config.getAccessTokenUri(),
-                    config.getDiscoveryUrl(),
-                    config.getClientId(),
-                    config.getRedirectUri(),
-                    config.getScopes(),
-                    config.isInvalid());
+            // Log configuration state after discovery has run (inside the filter constructor).
+            // Contains the clientId: printed only when the provider opts into sensitive logging.
+            if (config.isLogSensitiveInfo()) {
+                LOGGER.debug(
+                        "Provider '{}' config after discovery: authorizationUri={}, accessTokenUri={}, "
+                                + "discoveryUrl={}, clientId={}, redirectUri={}, scopes={}, "
+                                + "isInvalid={}",
+                        providerName,
+                        config.getAuthorizationUri(),
+                        config.getAccessTokenUri(),
+                        config.getDiscoveryUrl(),
+                        config.getClientId(),
+                        config.getRedirectUri(),
+                        config.getScopes(),
+                        config.isInvalid());
+            }
 
             if (config.isInvalid()) {
                 LOGGER.error(

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/CompositeOpenIdConnectFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/CompositeOpenIdConnectFilter.java
@@ -157,7 +157,7 @@ public class CompositeOpenIdConnectFilter extends GenericFilterBean
                             tokenServices, restTemplate, config, cache, validator, jwksKeyProvider);
 
             // Log configuration state after discovery has run (inside the filter constructor)
-            LOGGER.info(
+            LOGGER.debug(
                     "Provider '{}' config after discovery: authorizationUri={}, accessTokenUri={}, "
                             + "discoveryUrl={}, clientId={}, redirectUri={}, scopes={}, "
                             + "isInvalid={}",

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectConfiguration.java
@@ -27,6 +27,7 @@
  */
 package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
 
+import it.geosolutions.geostore.services.rest.security.oauth2.JWTHelper;
 import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
 import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Utils;
 import java.nio.charset.StandardCharsets;
@@ -44,6 +45,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
 
 public class OpenIdConnectConfiguration extends OAuth2Configuration {
 
@@ -292,8 +294,9 @@ public class OpenIdConnectConfiguration extends OAuth2Configuration {
      * Build the OIDC RP-Initiated Logout endpoint. Uses standard parameters: id_token_hint,
      * post_logout_redirect_uri, and client_id.
      *
-     * @param token the refresh token (unused for OIDC logout, kept for API compat).
-     * @param accessToken the access token (fallback if no ID token is available).
+     * @param token the token handed down by the logout flow: the cached ID token when the logout is
+     *     session-based, the refresh token otherwise.
+     * @param accessToken the access token (never used as id_token_hint).
      * @param configuration the OAuth2Configuration.
      * @return the logout endpoint, or null if no logoutUri is configured.
      */
@@ -305,11 +308,15 @@ public class OpenIdConnectConfiguration extends OAuth2Configuration {
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 
-        // id_token_hint: the ID token JWT string (required by most OIDC providers)
-        String idToken = OAuth2Utils.getIdToken();
-        if (idToken == null) idToken = accessToken;
+        String idToken = resolveIdTokenHint(token);
         if (idToken != null) {
             params.put("id_token_hint", Collections.singletonList(idToken));
+        } else {
+            LOGGER.warn(
+                    "No ID token available for RP-initiated logout; calling '{}' without "
+                            + "id_token_hint. The provider may require interactive confirmation "
+                            + "and keep the SSO session alive.",
+                    uri);
         }
 
         // client_id: some providers require it alongside id_token_hint
@@ -327,5 +334,41 @@ public class OpenIdConnectConfiguration extends OAuth2Configuration {
         HttpEntity<MultiValueMap<String, String>> requestEntity =
                 new HttpEntity<>(null, new HttpHeaders());
         return new Endpoint(HttpMethod.GET, appendParameters(params, uri), requestEntity);
+    }
+
+    /**
+     * Picks the ID token for the {@code id_token_hint} parameter. Tries, in order: the token passed
+     * down by the logout flow (the ID token cached at login, when the logout is session-based), the
+     * thread-local stashed during the token exchange, and the {@code id_token} request attribute
+     * set for authenticated requests. Never falls back to the access token: an invalid hint is
+     * rejected outright by the provider (leaving the SSO session alive), while a missing one may
+     * still be accepted.
+     */
+    private String resolveIdTokenHint(String token) {
+        if (isIdToken(token)) return token;
+        if (RequestContextHolder.getRequestAttributes() == null) return null;
+        String idToken = OAuth2Utils.getIdToken();
+        if (idToken == null) {
+            idToken = OAuth2Utils.getRequestAttribute(OAuth2Utils.ID_TOKEN_PARAM);
+        }
+        return idToken;
+    }
+
+    /**
+     * Detects whether a token is an OIDC ID token: a JWT whose payload {@code typ} claim is {@code
+     * ID} (Keycloak convention) or, lacking a {@code typ} claim, one carrying a {@code nonce}
+     * claim. Access tokens ({@code typ=Bearer}), refresh tokens ({@code typ=Refresh}) and opaque
+     * strings are rejected.
+     */
+    static boolean isIdToken(String token) {
+        if (token == null || token.chars().filter(c -> c == '.').count() != 2) return false;
+        try {
+            JWTHelper helper = new JWTHelper(token);
+            String typ = helper.getClaim("typ", String.class);
+            if (typ != null) return "ID".equalsIgnoreCase(typ);
+            return helper.getClaim("nonce", String.class) != null;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2ConfigurationMappingsTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2ConfigurationMappingsTest.java
@@ -1,0 +1,113 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link OAuth2Configuration#parseMappings(String)}, in particular the backslash escaping
+ * needed for IdP role/group names that contain the {@code :} separator (e.g. Keycloak
+ * permission-style roles like {@code landscape:read}).
+ */
+public class OAuth2ConfigurationMappingsTest {
+
+    @Test
+    void parsesSimpleMappings() {
+        Map<String, String> map = OAuth2Configuration.parseMappings("admin:ADMIN,user:USER");
+        assertEquals(2, map.size());
+        assertEquals("ADMIN", map.get("ADMIN"));
+        assertEquals("USER", map.get("USER"));
+    }
+
+    @Test
+    void keysAreCaseInsensitive() {
+        Map<String, String> map = OAuth2Configuration.parseMappings("Manage-Users:ADMIN");
+        assertEquals("ADMIN", map.get("MANAGE-USERS"));
+    }
+
+    @Test
+    void escapedColonInKey() {
+        Map<String, String> map =
+                OAuth2Configuration.parseMappings(
+                        "landscape\\:read:landscape_con_due_punti,manage-users:manage-users");
+        assertEquals(2, map.size());
+        assertEquals("landscape_con_due_punti", map.get("LANDSCAPE:READ"));
+        assertEquals("manage-users", map.get("MANAGE-USERS"));
+    }
+
+    @Test
+    void escapedColonInValue() {
+        Map<String, String> map =
+                OAuth2Configuration.parseMappings("active-product\\:read:active-product\\:read");
+        assertEquals(1, map.size());
+        assertEquals("active-product:read", map.get("ACTIVE-PRODUCT:READ"));
+    }
+
+    @Test
+    void unescapedValueKeepsTrailingColons() {
+        // value is everything after the first unescaped colon
+        Map<String, String> map = OAuth2Configuration.parseMappings("key:a:b");
+        assertEquals("a:b", map.get("KEY"));
+    }
+
+    @Test
+    void escapedCommaInKey() {
+        Map<String, String> map = OAuth2Configuration.parseMappings("a\\,b:VALUE,c:D");
+        assertEquals(2, map.size());
+        assertEquals("VALUE", map.get("A,B"));
+        assertEquals("D", map.get("C"));
+    }
+
+    @Test
+    void malformedPairsAreSkipped() {
+        Map<String, String> map = OAuth2Configuration.parseMappings("noseparator,ok:GOOD");
+        assertEquals(1, map.size());
+        assertEquals("GOOD", map.get("OK"));
+    }
+
+    @Test
+    void nullAndEmptyReturnNull() {
+        assertNull(OAuth2Configuration.parseMappings(null));
+        assertNull(OAuth2Configuration.parseMappings("  "));
+        assertNull(OAuth2Configuration.parseMappings("nopairs"));
+    }
+
+    @Test
+    void mappingsRoundTripThroughSetters() {
+        OAuth2Configuration config = new OAuth2Configuration();
+        config.setRoleMappings("manage-users:ADMIN");
+        config.setGroupMappings(
+                "manage-users:manage-users,landscape\\:read:landscape_con_due_punti,default-roles-portal:infragri");
+        assertEquals("ADMIN", config.getRoleMappings().get("MANAGE-USERS"));
+        assertEquals("landscape_con_due_punti", config.getGroupMappings().get("LANDSCAPE:READ"));
+        assertEquals("infragri", config.getGroupMappings().get("DEFAULT-ROLES-PORTAL"));
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceTest.java
@@ -248,9 +248,11 @@ public class OAuth2SessionServiceTest {
             sessionService.removeSession();
 
             assertEquals(HttpStatus.OK_200, response.getStatus());
-            // Note: without a revokeEndpoint, clearSession() is not called so
-            // SecurityContextHolder is not cleared. The cache entry for the
-            // sessionId passed to doLogout IS removed, though.
+            // Local state is cleared even without a revokeEndpoint: the shared client
+            // context must not retain tokens across sessions.
+            assertNull(
+                    SecurityContextHolder.getContext().getAuthentication(),
+                    "SecurityContext should be cleared");
             assertNull(cache.get(ACCESS_TOKEN), "cache entry should still be removed locally");
         }
     }

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/KeycloakLifecycleTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/KeycloakLifecycleTest.java
@@ -95,6 +95,11 @@ public class KeycloakLifecycleTest {
 
     @BeforeEach
     void setUp() {
+        // Defensive: a previous test class on this thread may have left an authentication
+        // in the ThreadLocal SecurityContext; the filter would then skip authentication.
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+
         String authServerUrl = keycloak.getAuthServerUrl();
         if (!authServerUrl.endsWith("/")) {
             authServerUrl += "/";

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/KeycloakLifecycleTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/KeycloakLifecycleTest.java
@@ -271,7 +271,25 @@ public class KeycloakLifecycleTest {
         assertEquals(200, response.getStatus());
         Authentication originalAuth = SecurityContextHolder.getContext().getAuthentication();
         assertNotNull(originalAuth, "Initial authentication should succeed");
-        assertNotNull(cache.get(tokens.accessToken), "Token should be in cache after auth");
+        assertNotNull(
+                cache.get(tokens.accessToken),
+                () ->
+                        "Token should be in cache after auth. Diagnostic: size="
+                                + cache.getCache().estimatedSize()
+                                + ", stats="
+                                + cache.getCache().stats()
+                                + ", keyPrefixes="
+                                + cache.getCache().asMap().keySet().stream()
+                                        .map(k -> k.substring(0, Math.min(16, k.length())))
+                                        .collect(java.util.stream.Collectors.toList())
+                                + ", bearerPrefix="
+                                + tokens.accessToken.substring(0, 16)
+                                + ", authClass="
+                                + originalAuth.getClass().getSimpleName()
+                                + ", detailsClass="
+                                + (originalAuth.getDetails() != null
+                                        ? originalAuth.getDetails().getClass().getSimpleName()
+                                        : "null"));
 
         // Perform a real token refresh against Keycloak
         RestTemplate refreshTemplate = new RestTemplate();

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectLogoutEndpointTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/OpenIdConnectLogoutEndpointTest.java
@@ -1,0 +1,173 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2.openid_connect;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import it.geosolutions.geostore.services.rest.security.oauth2.GeoStoreOAuthRestTemplate;
+import it.geosolutions.geostore.services.rest.security.oauth2.OAuth2Configuration;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Tests for the RP-Initiated Logout endpoint built by {@link OpenIdConnectConfiguration}: the
+ * id_token_hint must carry the ID token (never the access token), otherwise providers like Keycloak
+ * reject the request and keep the SSO session alive.
+ */
+public class OpenIdConnectLogoutEndpointTest {
+
+    private static final String LOGOUT_URI =
+            "https://idp.example.com/realms/test/protocol/openid-connect/logout";
+
+    private OpenIdConnectConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new OpenIdConnectConfiguration();
+        configuration.setLogoutUri(LOGOUT_URI);
+        configuration.setClientId("test-client");
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    private static String jwt(String payloadJson) {
+        Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
+        String header =
+                enc.encodeToString(
+                        "{\"alg\":\"RS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+        String payload = enc.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+        String signature = enc.encodeToString("sig".getBytes(StandardCharsets.UTF_8));
+        return header + "." + payload + "." + signature;
+    }
+
+    @Test
+    void usesPassedIdTokenAsHint() {
+        String idToken = jwt("{\"typ\":\"ID\",\"sub\":\"user\",\"sid\":\"abc\"}");
+
+        OAuth2Configuration.Endpoint endpoint =
+                configuration.buildLogoutEndpoint(idToken, "opaque-access-token", configuration);
+
+        assertNotNull(endpoint);
+        assertEquals(HttpMethod.GET, endpoint.getMethod());
+        assertTrue(endpoint.getUrl().startsWith(LOGOUT_URI));
+        assertTrue(
+                endpoint.getUrl().contains("id_token_hint=" + idToken),
+                "the ID token passed by the logout flow must be used as id_token_hint");
+        assertTrue(endpoint.getUrl().contains("client_id=test-client"));
+    }
+
+    @Test
+    void neverUsesAccessOrRefreshTokenAsHint() {
+        String refreshToken = jwt("{\"typ\":\"Refresh\",\"sub\":\"user\"}");
+
+        OAuth2Configuration.Endpoint endpoint =
+                configuration.buildLogoutEndpoint(
+                        refreshToken, "opaque-access-token", configuration);
+
+        assertNotNull(endpoint);
+        assertFalse(
+                endpoint.getUrl().contains("id_token_hint"),
+                "a refresh/access token must not be sent as id_token_hint");
+        assertTrue(endpoint.getUrl().contains("client_id=test-client"));
+    }
+
+    @Test
+    void fallsBackToThreadLocalIdToken() {
+        String idToken = jwt("{\"typ\":\"ID\",\"sub\":\"user\"}");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(GeoStoreOAuthRestTemplate.ID_TOKEN_VALUE, idToken);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        OAuth2Configuration.Endpoint endpoint =
+                configuration.buildLogoutEndpoint("opaque-refresh-token", null, configuration);
+
+        assertNotNull(endpoint);
+        assertTrue(endpoint.getUrl().contains("id_token_hint=" + idToken));
+    }
+
+    @Test
+    void fallsBackToIdTokenRequestAttribute() {
+        String idToken = jwt("{\"typ\":\"ID\",\"sub\":\"user\"}");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute("id_token", idToken);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        OAuth2Configuration.Endpoint endpoint =
+                configuration.buildLogoutEndpoint("opaque-refresh-token", null, configuration);
+
+        assertNotNull(endpoint);
+        assertTrue(endpoint.getUrl().contains("id_token_hint=" + idToken));
+    }
+
+    @Test
+    void includesPostLogoutRedirectUri() {
+        configuration.setPostLogoutRedirectUri("https://app.example.com/");
+        String idToken = jwt("{\"typ\":\"ID\",\"sub\":\"user\"}");
+
+        OAuth2Configuration.Endpoint endpoint =
+                configuration.buildLogoutEndpoint(idToken, null, configuration);
+
+        assertNotNull(endpoint);
+        assertTrue(endpoint.getUrl().contains("post_logout_redirect_uri="));
+    }
+
+    @Test
+    void returnsNullWithoutLogoutUri() {
+        configuration.setLogoutUri(null);
+        assertNull(configuration.buildLogoutEndpoint("token", "access", configuration));
+    }
+
+    @Test
+    void isIdTokenDetection() {
+        assertTrue(
+                OpenIdConnectConfiguration.isIdToken(jwt("{\"typ\":\"ID\",\"sub\":\"u\"}")),
+                "Keycloak-style ID token (typ=ID)");
+        assertTrue(
+                OpenIdConnectConfiguration.isIdToken(jwt("{\"sub\":\"u\",\"nonce\":\"n\"}")),
+                "generic ID token carrying a nonce");
+        assertFalse(
+                OpenIdConnectConfiguration.isIdToken(jwt("{\"typ\":\"Bearer\",\"sub\":\"u\"}")),
+                "access token (typ=Bearer)");
+        assertFalse(
+                OpenIdConnectConfiguration.isIdToken(jwt("{\"typ\":\"Refresh\",\"sub\":\"u\"}")),
+                "refresh token (typ=Refresh)");
+        assertFalse(OpenIdConnectConfiguration.isIdToken("opaque-token"), "opaque string");
+        assertFalse(OpenIdConnectConfiguration.isIdToken(null), "null");
+    }
+}

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
@@ -110,6 +110,12 @@ class RefreshTokenServiceTest {
         // Clear the RequestContextHolder after each test
         RequestContextHolder.resetRequestAttributes();
 
+        // The mocked SecurityContext set in setUp() lives in a ThreadLocal: without this,
+        // it leaks into whatever test class runs next on the same surefire thread (it made
+        // KeycloakLifecycleTest.testRefreshTokenFlow fail intermittently in CI: the filter
+        // saw a non-null mock Authentication and skipped authentication entirely).
+        SecurityContextHolder.clearContext();
+
         // Close static mocks if any
         // For Mockito 3.4.0 and above
         Mockito.framework().clearInlineMocks();

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -48,6 +48,9 @@
 # oidcOAuth2Config.groupsClaim=groups
 # oidcOAuth2Config.roleMappings=admin:ADMIN,user:USER
 # oidcOAuth2Config.groupMappings=
+# If an IdP role/group name contains ':' or ',', escape it with a backslash.
+# In this .properties file the backslash must be doubled (properties escaping):
+# oidcOAuth2Config.groupMappings=landscape\\:read:landscape_read,manage-users:admins
 # oidcOAuth2Config.dropUnmapped=false
 # oidcOAuth2Config.usePKCE=false
 #


### PR DESCRIPTION
These changes are related to this MapStore task
- https://github.com/geosolutions-it/support/issues/6035

## What this does

Fixes the issues observed in a production OIDC (Keycloak) integration running 2.6-SNAPSHOT, **validated end-to-end against a real Keycloak 26 instance** (full authorization-code logins, logout, token expiry — see "Live E2E" below). Companion master PR (subset): #545.

### 1. Global logout never invalidated the Keycloak SSO session
`buildLogoutEndpoint` sent the **access token** as `id_token_hint`, which Keycloak rejects. The RP-initiated logout now uses the real ID token (cached ID token → thread-local → `id_token` request attribute), never the access token, and logs a WARN when no ID token is available.

Live testing surfaced two more layers of the same bug, both fixed here:
- **The cache evicted entries exactly at access-token expiry** (`TokenAuthenticationCache` per-entry expiration), so any logout after token expiry (Keycloak default lifespan: 5 minutes) found no cached `TokenDetails` and no ID token. Entries now live at least `cacheExpirationMinutes` — safe because the filter re-validates expired tokens on every request anyway.
- **The logout request could not recover the ID token once re-authentication failed** on an expired bearer. The filter now publishes the cached token details (provider, ID token, refresh token) as request attributes on every bearer request before any re-authentication, and the logout delegate falls back to them. This also guarantees the provider-specific session delegate is always selected on logout.

### 2. OIDC login permanently broken after an idle period (until webapp restart)
The shared (singleton) Spring OAuth2 client context retained the previous session''s token: once expired, it shadowed the fresh authorization-code exchange (the production log showed userinfo 401 + "No access token found on callback request"). The context is now cleared on logout (no longer gated on `revokeEndpoint`), when a fresh authorization code arrives, and on new unauthenticated login attempts — which also closes a cross-session token reuse vector.

### 3. Sensitive info logged regardless of `logSensitiveInfo`
Token values, claim contents and config dumps were logged at INFO. They are now **double-gated**: demoted to DEBUG *and* guarded by the provider flag itself, so raising logger levels for ordinary troubleshooting never prints tokens/claims — they appear only with `logSensitiveInfo=true`. `clientSecret` is masked in `toString()`.

### 4. Escaped separators in role/group mappings
`roleMappings`/`groupMappings` support backslash-escaped `:` and `,` (e.g. `landscape\:read:mapped-name`; double the backslash in `.properties`).

### 5. Bearer cache keyed by the client-held token
Authentications are now also cached under the exact token the client presented, eliminating systematic cache misses (and re-authentication per request) when the internally resolved token value differs.

### 6. Deterministic KeycloakLifecycleTest
`testRefreshTokenFlow` failed intermittently in CI. Diagnostics added to the assertion caught the cause: `RefreshTokenServiceTest` leaked a mocked `SecurityContext` in the ThreadLocal holder, so the first method of the next test class on the same surefire thread skipped authentication. Fixed the leak and added defensive cleanup.

## Live E2E (real Keycloak 26 + GeoStore in Docker)

Scenario | Result
--- | ---
Authorization-code login, user auto-created from email | PASS
`manage-users` → ADMIN role mapping | PASS
`landscape\:read` → group mapping with colon escaping (+`dropUnmapped`) | PASS
Silent SSO re-login while session alive | PASS
**Global logout kills the Keycloak SSO session (fresh token)** | PASS (sessions 1→0)
**Global logout kills the Keycloak SSO session (expired token / idle user)** | PASS (sessions 1→0)
Login requires credentials again after logout | PASS
3 consecutive login/logout cycles | PASS
Login after access-token expiry (stale-context fix) | PASS
Second user gets USER role + mapped group only | PASS
Error surfacing on bad authorization code (with #547) | PASS — body: `Authentication with provider 'oidc' failed: The identity provider denied the token exchange: Code not valid`
No token values in logs with `logSensitiveInfo=false`; visible with `true` | PASS
