### PR TITLE
[2.6.x] Surface the real OIDC failure cause on the login callback response

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -88,6 +88,7 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.RemoteTokenServices;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -558,6 +559,12 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         // 6) Nothing worked
         LOGGER.warn(
                 "Principal could not be resolved from security principal, introspection, or JWT claims.");
+        setAuthErrorIfAbsent(
+                req,
+                "Could not resolve the user identity from the identity provider response: "
+                        + "no username found in the security principal, the userinfo/introspection "
+                        + "response, or the token claims. Check the principalKey/uniqueUsername "
+                        + "configuration for the provider.");
         return null;
     }
 
@@ -607,24 +614,58 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         String errorDetail;
         if (e instanceof BadCredentialsException) {
             if (e.getCause() instanceof OAuth2AccessDeniedException) {
-                errorDetail = "OAuth2 access denied: " + e.getCause().getMessage();
+                errorDetail =
+                        "The identity provider denied the token exchange: "
+                                + deepestMessage(e.getCause());
                 LOGGER.warn(
                         "OAuth2 access denied by provider: {}",
                         e.getCause().getMessage(),
                         e.getCause());
             } else {
-                errorDetail = "Bad credentials: " + e.getMessage();
+                errorDetail = "Bad credentials: " + deepestMessage(e);
                 LOGGER.warn("OAuth2 bad credentials: {}", e.getMessage(), e);
             }
         } else if (e instanceof ResourceAccessException) {
-            errorDetail = "OAuth2 provider unreachable: " + e.getMessage();
+            errorDetail = "The identity provider is unreachable: " + e.getMessage();
             LOGGER.error("Could not reach OAuth2 provider: {}", e.getMessage(), e);
+        } else if (e instanceof HttpStatusCodeException) {
+            errorDetail =
+                    "The identity provider rejected the token validation request with status "
+                            + ((HttpStatusCodeException) e).getRawStatusCode()
+                            + ": the access token may be expired or revoked, or the "
+                            + "userinfo/introspection endpoint may be misconfigured.";
+            LOGGER.warn("OAuth2 token validation rejected by provider: {}", e.getMessage(), e);
         } else {
-            errorDetail = "Authentication error: " + e.getMessage();
+            errorDetail = "Authentication error: " + deepestMessage(e);
             LOGGER.warn("OAuth2 authentication error: {}", e.getMessage(), e);
         }
 
         req.setAttribute(RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY, errorDetail);
+    }
+
+    /** Walks the cause chain and returns the most specific (deepest) non-null message. */
+    private static String deepestMessage(Throwable t) {
+        String message = t.getMessage();
+        Throwable current = t;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+            if (current.getMessage() != null) message = current.getMessage();
+        }
+        return message != null ? message : t.getClass().getSimpleName();
+    }
+
+    /**
+     * Records the reason of an authentication failure so that downstream handlers (the login
+     * callback, the REST entry point) can report the actual cause to the client instead of a
+     * generic failure. The first recorded reason wins: later, more generic ones do not overwrite
+     * it.
+     */
+    private void setAuthErrorIfAbsent(HttpServletRequest request, String message) {
+        if (request != null
+                && request.getAttribute(RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY)
+                        == null) {
+            request.setAttribute(RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY, message);
+        }
     }
 
     private void handleUserRedirection(HttpServletRequest req, HttpServletResponse resp)
@@ -703,6 +744,13 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
         User user = retrieveUserWithAuthorities(username, request, response);
         if (user == null) {
             LOGGER.error("User retrieval failed for username: {}", username);
+            setAuthErrorIfAbsent(
+                    request,
+                    "User '"
+                            + username
+                            + "' was authenticated by the identity provider but could not be "
+                            + "found or created in GeoStore (check autoCreateUser and the "
+                            + "server logs).");
             return null;
         }
         // Mark the user as trusted (externally authenticated via OAuth2/OIDC).

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginService.java
@@ -7,6 +7,7 @@ import static org.springframework.security.oauth2.common.OAuth2AccessToken.BEARE
 import it.geosolutions.geostore.services.rest.IdPLoginService;
 import it.geosolutions.geostore.services.rest.model.SessionToken;
 import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
+import it.geosolutions.geostore.services.rest.security.RestAuthenticationEntryPoint;
 import it.geosolutions.geostore.services.rest.utils.GeoStoreContext;
 import java.io.IOException;
 import java.net.URI;
@@ -122,12 +123,30 @@ public abstract class Oauth2LoginService implements IdPLoginService {
                                                 + e.getMessage());
             }
         } else {
-            LOGGER.error("No access token found on callback request: {}", response.getStatus());
-            result =
-                    Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                            .entity("No access token found.");
+            String errorDetail = authenticationErrorDetail();
+            String message =
+                    "Authentication with provider '"
+                            + provider
+                            + "' failed: "
+                            + (errorDetail != null
+                                    ? errorDetail
+                                    : "no access token was returned by the identity provider.");
+            LOGGER.error("{} (callback response status: {})", message, response.getStatus());
+            result = Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message);
         }
         return result;
+    }
+
+    /**
+     * Returns the authentication failure reason recorded by the OAuth2 filter on the current
+     * request (see {@link RestAuthenticationEntryPoint#OAUTH2_AUTH_ERROR_KEY}), or null if the
+     * filter did not record one.
+     */
+    protected String authenticationErrorDetail() {
+        HttpServletRequest request = OAuth2Utils.getRequest();
+        if (request == null) return null;
+        Object detail = request.getAttribute(RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY);
+        return detail instanceof String ? (String) detail : null;
     }
 
     @Override

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginServiceCallbackTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/Oauth2LoginServiceCallbackTest.java
@@ -1,0 +1,124 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import it.geosolutions.geostore.services.rest.security.IdPConfiguration;
+import it.geosolutions.geostore.services.rest.security.RestAuthenticationEntryPoint;
+import it.geosolutions.geostore.services.rest.security.oauth2.openid_connect.OpenIdConnectConfiguration;
+import it.geosolutions.geostore.services.rest.utils.GeoStoreContext;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Tests that the OIDC callback surfaces the real authentication failure cause (recorded by the
+ * OAuth2 filter in the {@link RestAuthenticationEntryPoint#OAUTH2_AUTH_ERROR_KEY} request
+ * attribute) instead of a generic "no access token found" message.
+ */
+public class Oauth2LoginServiceCallbackTest {
+
+    private Oauth2LoginService loginService;
+    private OpenIdConnectConfiguration configuration;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        loginService = new Oauth2LoginService() {};
+        configuration = new OpenIdConnectConfiguration();
+        configuration.setEnabled(true);
+        configuration.setInternalRedirectUri("http://localhost:8081/");
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, response));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    private Response callbackWithoutToken() {
+        try (MockedStatic<GeoStoreContext> ctx = Mockito.mockStatic(GeoStoreContext.class)) {
+            ctx.when(() -> GeoStoreContext.bean("oidcOAuth2Config", IdPConfiguration.class))
+                    .thenReturn(configuration);
+            return loginService.buildCallbackResponse(response, null, null, "oidc");
+        }
+    }
+
+    @Test
+    void surfacesRecordedFailureCause() {
+        request.setAttribute(
+                RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY,
+                "The identity provider rejected the token validation request with status 401");
+
+        Response result = callbackWithoutToken();
+
+        assertEquals(500, result.getStatus());
+        String body = String.valueOf(result.getEntity());
+        assertTrue(body.contains("provider 'oidc'"), "body should name the provider: " + body);
+        assertTrue(
+                body.contains("rejected the token validation request with status 401"),
+                "body should contain the recorded cause: " + body);
+    }
+
+    @Test
+    void fallsBackToGenericMessageWhenNoCauseRecorded() {
+        Response result = callbackWithoutToken();
+
+        assertEquals(500, result.getStatus());
+        String body = String.valueOf(result.getEntity());
+        assertTrue(
+                body.contains("no access token was returned by the identity provider"),
+                "body should contain the generic message: " + body);
+    }
+
+    @Test
+    void successfulCallbackStillRedirects() {
+        try (MockedStatic<GeoStoreContext> ctx = Mockito.mockStatic(GeoStoreContext.class)) {
+            ctx.when(() -> GeoStoreContext.bean("oidcOAuth2Config", IdPConfiguration.class))
+                    .thenReturn(configuration);
+            ctx.when(() -> GeoStoreContext.bean(TokenStorage.class))
+                    .thenReturn(new InMemoryTokenStorage());
+
+            Response result =
+                    loginService.buildCallbackResponse(response, "the-access-token", null, "oidc");
+
+            assertEquals(302, result.getStatus());
+        }
+    }
+}


### PR DESCRIPTION
These changes are related to this MapStore task
- https://github.com/geosolutions-it/support/issues/6035

## What this does

When the OIDC login fails, the callback returned a bare HTTP 500 with `No access token found.` regardless of what actually went wrong, leaving users (and whoever reads their screenshot) without a clue. This PR surfaces the actual failure cause in the callback response body.

The OAuth2 filter already records a sanitized failure reason in the `oauth2.AuthError` request attribute (used by `RestAuthenticationEntryPoint` for 401 JSON responses); this PR completes the loop:

- the **login callback** now reads it and returns `Authentication with provider ''<p>'' failed: <cause>`;
- the filter records a reason on the **previously silent failure paths** too: unresolvable principal (with a `principalKey`/`uniqueUsername` hint) and user retrieval/creation failure (with an `autoCreateUser` hint);
- `handleOAuthException` reports the **deepest cause message** (e.g. the `invalid_grant` detail instead of the generic wrapper text) and gains a dedicated branch for **HTTP status errors from the provider** (e.g. the 401 returned by the userinfo endpoint when the access token is expired — the exact case observed in production);
- the first recorded reason wins, so the most specific error is the one surfaced.

Messages are sanitized by construction: no tokens, stack traces, or internals reach the browser.

Example: instead of `No access token found.` the browser now shows
`Authentication with provider 'oidc' failed: The identity provider rejected the token validation request with status 401: the access token may be expired or revoked, or the userinfo/introspection endpoint may be misconfigured.`

## Testing

New `Oauth2LoginServiceCallbackTest` (3 tests): recorded cause surfaced, generic fallback when nothing recorded, successful callback still redirects with 302. Existing filter/session suites green.

## Note on master

No companion master PR is possible for this change: the Spring 7 migration (#534) removed the whole OIDC login flow (`Oauth2LoginService`, the OAuth2 filters — no `IdPLoginService` implementation remains), so there is no code path producing this error there. `RestAuthenticationEntryPoint` (the consuming side) survives on master; the producing side should be part of the future Spring 7 OIDC reimplementation.