### PR TITLE
Surface the real OIDC failure cause on the login callback response

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/IdPLoginRestImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/IdPLoginRestImpl.java
@@ -88,10 +88,10 @@ public class IdPLoginRestImpl implements IdPLoginRest {
             LOGGER.error("No login service registered for callback provider '{}'", provider);
             throw new NotFoundWebEx("No login service for provider: " + provider);
         }
-        Response response =
+        return surfaceAuthError(
                 service.doInternalRedirect(
-                        OAuth2Utils.getRequest(), OAuth2Utils.getResponse(), provider);
-        return surfaceAuthError(response, provider);
+                        OAuth2Utils.getRequest(), OAuth2Utils.getResponse(), provider),
+                provider);
     }
 
     /**

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/IdPLoginRestImpl.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/IdPLoginRestImpl.java
@@ -32,6 +32,7 @@ import it.geosolutions.geostore.services.rest.IdPLoginRest;
 import it.geosolutions.geostore.services.rest.IdPLoginService;
 import it.geosolutions.geostore.services.rest.exception.NotFoundWebEx;
 import it.geosolutions.geostore.services.rest.model.SessionToken;
+import it.geosolutions.geostore.services.rest.security.RestAuthenticationEntryPoint;
 import it.geosolutions.geostore.services.rest.utils.GeoStoreContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -87,8 +88,36 @@ public class IdPLoginRestImpl implements IdPLoginRest {
             LOGGER.error("No login service registered for callback provider '{}'", provider);
             throw new NotFoundWebEx("No login service for provider: " + provider);
         }
-        return service.doInternalRedirect(
-                OAuth2Utils.getRequest(), OAuth2Utils.getResponse(), provider);
+        Response response =
+                service.doInternalRedirect(
+                        OAuth2Utils.getRequest(), OAuth2Utils.getResponse(), provider);
+        return surfaceAuthError(response, provider);
+    }
+
+    /**
+     * If the callback failed and the security layer recorded the actual failure reason in the
+     * {@link RestAuthenticationEntryPoint#OAUTH2_AUTH_ERROR_KEY} request attribute, return a
+     * response carrying that reason instead of a generic message, so the client sees the real cause
+     * (e.g. token exchange rejected, userinfo 401, unresolvable principal) instead of "No access
+     * token found.".
+     */
+    private Response surfaceAuthError(Response response, String provider) {
+        if (response == null || response.getStatus() < 400) return response;
+        HttpServletRequest request = OAuth2Utils.getRequest();
+        if (request == null) return response;
+        Object detail = request.getAttribute(RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY);
+        if (!(detail instanceof String)) return response;
+
+        Object entity = response.getEntity();
+        boolean genericEntity =
+                entity == null
+                        || String.valueOf(entity).trim().isEmpty()
+                        || "No access token found.".equals(String.valueOf(entity).trim());
+        if (!genericEntity) return response;
+
+        String message = "Authentication with provider '" + provider + "' failed: " + detail;
+        LOGGER.error("{} (callback response status: {})", message, response.getStatus());
+        return Response.status(response.getStatus()).entity(message).build();
     }
 
     @Override

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/IdPLoginRestCallbackTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/IdPLoginRestCallbackTest.java
@@ -1,0 +1,122 @@
+/* ====================================================================
+ *
+ * Copyright (C) 2025 GeoSolutions S.A.S.
+ * http://www.geo-solutions.it
+ *
+ * GPLv3 + Classpath exception
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by developers
+ * of GeoSolutions.  For more information on GeoSolutions, please see
+ * <http://www.geo-solutions.it/>.
+ *
+ */
+package it.geosolutions.geostore.services.rest.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import it.geosolutions.geostore.services.rest.IdPLoginService;
+import it.geosolutions.geostore.services.rest.security.RestAuthenticationEntryPoint;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Tests that the OIDC callback endpoint surfaces the real authentication failure cause (recorded by
+ * the security layer in the {@link RestAuthenticationEntryPoint#OAUTH2_AUTH_ERROR_KEY} request
+ * attribute) instead of a generic "No access token found." message.
+ */
+public class IdPLoginRestCallbackTest {
+
+    private IdPLoginRestImpl loginRest;
+    private IdPLoginService loginService;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        loginRest = new IdPLoginRestImpl();
+        loginService = mock(IdPLoginService.class);
+        loginRest.registerService("oidc", loginService);
+        request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(request, new MockHttpServletResponse()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    private void serviceReturns(Response response) {
+        when(loginService.doInternalRedirect(any(), any(), eq("oidc"))).thenReturn(response);
+    }
+
+    @Test
+    void surfacesRecordedFailureCauseOnGenericFailure() {
+        request.setAttribute(
+                RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY,
+                "The identity provider rejected the token exchange: invalid_grant");
+        serviceReturns(Response.status(500).entity("No access token found.").build());
+
+        Response result = loginRest.callback("oidc");
+
+        assertEquals(500, result.getStatus());
+        String body = String.valueOf(result.getEntity());
+        assertTrue(body.contains("provider 'oidc'"), "body should name the provider: " + body);
+        assertTrue(body.contains("invalid_grant"), "body should contain the cause: " + body);
+    }
+
+    @Test
+    void keepsSpecificEntityFromLoginService() {
+        request.setAttribute(RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY, "recorded cause");
+        serviceReturns(Response.status(500).entity("a specific failure explanation").build());
+
+        Response result = loginRest.callback("oidc");
+
+        assertEquals("a specific failure explanation", result.getEntity());
+    }
+
+    @Test
+    void leavesFailureUntouchedWhenNoCauseRecorded() {
+        serviceReturns(Response.status(500).entity("No access token found.").build());
+
+        Response result = loginRest.callback("oidc");
+
+        assertEquals(500, result.getStatus());
+        assertEquals("No access token found.", result.getEntity());
+    }
+
+    @Test
+    void successfulCallbackPassesThrough() {
+        request.setAttribute(
+                RestAuthenticationEntryPoint.OAUTH2_AUTH_ERROR_KEY, "stale error from a sub-call");
+        serviceReturns(Response.status(302).build());
+
+        Response result = loginRest.callback("oidc");
+
+        assertEquals(302, result.getStatus());
+    }
+}


### PR DESCRIPTION
These changes are related to this MapStore task
- https://github.com/geosolutions-it/support/issues/6035

This PR forward-ports the changes from #547 to the master branch.

## What this does

Companion of the 2.6.x PR #547, adapted to what survives on master after the Spring 7 migration (#534 removed the legacy OIDC login flow).

The callback endpoint (`IdPLoginRestImpl.callback`) now surfaces the actual authentication failure reason to the client: when a login service returns a failure with a generic body ("No access token found." or empty), the endpoint replaces it with the cause recorded by the security layer in the `oauth2.AuthError` request attribute - the same contract `RestAuthenticationEntryPoint` already uses for 401 JSON responses. Examples: token exchange rejected (`invalid_grant`), userinfo endpoint 401, unresolvable principal.

Rules:
- a **specific** entity provided by the login service is preserved (no double-wrapping);
- successful responses pass through untouched;
- nothing sensitive is exposed - only the sanitized reason recorded by the security layer.

On master nothing records the attribute yet (the producer side went away with the legacy OIDC layer); this keeps the error-surfacing contract alive at the endpoint level so the upcoming Spring 7 OIDC reimplementation - and any downstream `IdPLoginService` registration - gets it for free. The full producer-side implementation for the active OIDC code is in #547 (2.6.x).

## Testing

New `IdPLoginRestCallbackTest` (4 tests): cause surfaced on generic failure, specific service entity preserved, untouched failure without recorded cause, successful 302 pass-through.