### PR TITLE
Restore sample-user initialization on fresh installs

### DIFF
--- a/src/web/app/src/main/resources/applicationContext.xml
+++ b/src/web/app/src/main/resources/applicationContext.xml
@@ -18,8 +18,8 @@
 
     <bean id="geostoreInitializer" class="it.geosolutions.geostore.init.GeoStoreInit" lazy-init="false">
         <!-- Site specific initialization. Please specify a path in the ovr file-->
-        <property name="userListInitFile"><null/></property>
-<!--        <property name="userListInitFile" value="classpath:sample_users.xml"/>-->
+        <!--<property name="userListInitFile"><null/></property>-->
+        <property name="userListInitFile" value="classpath:sample_users.xml"/>
         <!-- Site specific initialization. Please specify a path in the ovr file-->
         <property name="categoryListInitFile" value="classpath:sample_categories.xml" />
 


### PR DESCRIPTION
## What this does

Restores the admin bootstrap on fresh installs.

The Spring 7 upgrade (#529) flipped `userListInitFile` from `classpath:sample_users.xml` to `<null/>` in the webapp `applicationContext.xml` - apparently a local testing toggle that slipped into the commit: categories and groups initialization stayed enabled, and the change is not mentioned in the PR or commit message. Since then a fresh install (default in-memory H2) creates the sample categories and groups but never the sample users, so **nobody can authenticate at all**: `GET /rest/users/user/details` with `admin/admin` returns 401 `{"error":"unauthorized","message":"User not found. Please check your credentials"}`. The 2.6.x branch initializes `admin/admin` correctly.

## Verification (live)

Built the WAR from this branch and deployed it as ROOT on Tomcat 10.1 + JDK 17 with a fresh in-memory H2:
- startup log now shows `GeoStoreInit ... Initializing users from .../sample_users.xml`
- `GET /rest/users/user/details` with `admin/admin` returns **200**: `{"User":{"enabled":true,...,"name":"admin","role":"ADMIN"}}`