### PR TITLE
[2.6.x] Fix OIDC session loss on token refresh despite regular client polling

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2SessionServiceDelegate.java
@@ -69,6 +69,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpMessageConverterExtractor;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -79,6 +80,10 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
     private static final Logger LOGGER = LogManager.getLogger(OAuth2SessionServiceDelegate.class);
 
     private static final long CLOCK_SKEW_ALLOWANCE_MILLIS = 5 * 60 * 1000; // 5 minutes
+
+    // Force a real IdP refresh when the refresh token itself is this close to its own
+    // (fixed) expiry: IdP refresh tokens only slide when a refresh grant is performed.
+    private static final long REFRESH_TOKEN_EXPIRY_SAFETY_WINDOW_MILLIS = 2 * 60 * 1000;
 
     protected UserService userService;
     protected final String delegateName;
@@ -115,12 +120,19 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
 
         OAuth2AccessToken currentToken = retrieveAccessToken(accessToken, null);
 
-        // Determine refreshTokenToUse
-        String refreshTokenToUse =
-                Optional.ofNullable(currentToken.getRefreshToken())
-                        .map(OAuth2RefreshToken::getValue)
-                        .filter(value -> !value.isEmpty())
-                        .orElse(refreshToken);
+        // Determine refreshTokenToUse: the freshest known refresh token. Sources in order:
+        // the cache entry of the presented access token, the client-supplied value, the
+        // request parameter, and the HttpOnly cookie (re-issued by this endpoint on every
+        // response). The shared OAuth2ClientContext is deliberately NOT consulted here: the
+        // singleton context retains the login-time token pair, and a stale refresh token
+        // pinned from there keeps "working" until its fixed IdP expiry, killing the session
+        // (~30 minutes after login with Keycloak defaults) even while the client keeps
+        // polling this endpoint.
+        String refreshTokenToUse = refreshTokenFromCache(accessToken);
+
+        if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
+            refreshTokenToUse = refreshToken;
+        }
 
         if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
             refreshTokenToUse = getParameterValue(REFRESH_TOKEN_PARAM, request);
@@ -133,7 +145,8 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         SessionToken sessionToken = null;
         OAuth2Configuration configuration = configuration();
 
-        if (configuration != null && shouldSkipRefresh(currentToken, configuration)) {
+        if (configuration != null
+                && shouldSkipRefresh(currentToken, refreshTokenToUse, configuration)) {
             LOGGER.debug("Token still has sufficient validity; skipping IDP refresh.");
             warningMessage = "Token still valid; refresh skipped.";
         } else if (refreshTokenToUse == null || refreshTokenToUse.isEmpty()) {
@@ -253,6 +266,58 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         }
     }
 
+    /** Reads the refresh token cached alongside the given access token, if any. */
+    private String refreshTokenFromCache(String accessToken) {
+        TokenAuthenticationCache cache = cache();
+        Authentication authentication = cache != null ? cache.get(accessToken) : null;
+        TokenDetails details = OAuth2Utils.getTokenDetails(authentication);
+        if (details != null
+                && details.getAccessToken() != null
+                && details.getAccessToken().getRefreshToken() != null) {
+            return details.getAccessToken().getRefreshToken().getValue();
+        }
+        return null;
+    }
+
+    /**
+     * Whether the refresh token (when it is a JWT carrying an {@code exp} claim, as Keycloak's are)
+     * is within the safety window of its own expiry. Opaque refresh tokens carry no expiry
+     * information and keep the legacy behavior.
+     */
+    private boolean isRefreshTokenNearExpiry(String refreshToken) {
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return false;
+        }
+        Date expiration = getExpirationDateQuietly(refreshToken);
+        if (expiration == null) {
+            return false;
+        }
+        long remaining = expiration.getTime() - System.currentTimeMillis();
+        return remaining <= REFRESH_TOKEN_EXPIRY_SAFETY_WINDOW_MILLIS;
+    }
+
+    /**
+     * Like {@link #getExpirationDateFromToken(String)} but silent: meant for tokens that may
+     * legitimately be opaque (non-JWT), where a parse failure is expected and must not log.
+     */
+    private Date getExpirationDateQuietly(String token) {
+        try {
+            Jwt decodedToken = JwtHelper.decode(token);
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, Object> claims = mapper.readValue(decodedToken.getClaims(), Map.class);
+            Object exp = claims.get("exp");
+            if (exp instanceof Number) {
+                return new Date(((Number) exp).longValue() * 1000);
+            }
+            if (exp instanceof String) {
+                return new Date(Long.parseLong((String) exp) * 1000);
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     private Date getIssuedAtFromToken(String token) {
         try {
             Jwt decodedToken = JwtHelper.decode(token);
@@ -282,8 +347,21 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         }
     }
 
-    boolean shouldSkipRefresh(OAuth2AccessToken token, OAuth2Configuration config) {
+    protected boolean shouldSkipRefresh(
+            OAuth2AccessToken token, String refreshToken, OAuth2Configuration config) {
         if (!config.isSkipRefreshIfTokenValid()) {
+            return false;
+        }
+
+        // Never skip when the refresh token itself is close to its own expiry: IdP refresh
+        // tokens (e.g. Keycloak refresh_expires_in / session idle, 30 minutes by default)
+        // only slide when a refresh grant is actually performed. Skipping past that window
+        // leaves an unrefreshable session even though the access token still looks healthy,
+        // and the session dies at the first real refresh attempt.
+        if (isRefreshTokenNearExpiry(refreshToken)) {
+            LOGGER.info(
+                    "Refresh token close to its expiry; performing a real IdP refresh "
+                            + "even though the access token is still valid.");
             return false;
         }
 
@@ -404,6 +482,14 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
                 break;
             } catch (RestClientException ex) {
                 LOGGER.error("Attempt {}: Error refreshing token: {}", attempt, ex.getMessage());
+                if (ex instanceof HttpStatusCodeException) {
+                    // Surface the IdP error payload (e.g. invalid_grant vs invalid_client):
+                    // it pinpoints whether the refresh token expired or the client
+                    // credentials are wrong, which is otherwise invisible at this level.
+                    LOGGER.warn(
+                            "Token refresh rejected by the identity provider: {}",
+                            ((HttpStatusCodeException) ex).getResponseBodyAsString());
+                }
                 if (attempt == maxRetries) {
                     errorMessage = "Max retries reached. Unable to refresh token.";
                     LOGGER.error(errorMessage);
@@ -449,22 +535,41 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
     public void handleRefreshFailure(
             String accessToken, String refreshToken, OAuth2Configuration configuration) {
         LOGGER.info(
-                "Unable to refresh token after max retries. Clearing session and redirecting to login.");
+                "Unable to refresh token after max retries. Clearing the session and reporting "
+                        + "the failure to the client.");
         HttpServletResponse response = getResponse();
         if (response != null) {
             clearRefreshTokenCookie(response);
         }
         doLogout(null);
 
-        try {
-            if (configuration != null && configuration.getProvider() != null) {
-                String redirectUrl =
-                        "../../openid/" + configuration.getProvider().toLowerCase() + "/login";
-                getResponse().sendRedirect(redirectUrl);
+        // This endpoint is invoked via XHR: never redirect. The 302 to the login page cannot
+        // be followed by the client (observed live as a 302 -> 404 chain through the
+        // front-end proxy that wiped the session). Report a clean 401 with the login URL so
+        // the client can start a new authorization flow itself.
+        HttpServletResponse failureResponse = getResponse();
+        if (failureResponse != null && !failureResponse.isCommitted()) {
+            try {
+                String loginUrl = null;
+                if (configuration != null && configuration.getProvider() != null) {
+                    loginUrl =
+                            "../../openid/" + configuration.getProvider().toLowerCase() + "/login";
+                }
+                failureResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                failureResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                StringBuilder body =
+                        new StringBuilder(
+                                "{\"error\":\"session_expired\","
+                                        + "\"message\":\"Token refresh failed; a new login is required.\"");
+                if (loginUrl != null) {
+                    body.append(",\"loginUrl\":\"").append(loginUrl).append("\"");
+                }
+                body.append("}");
+                failureResponse.getWriter().write(body.toString());
+                failureResponse.getWriter().flush();
+            } catch (IOException e) {
+                LOGGER.error("Error while writing the refresh-failure response: ", e);
             }
-        } catch (IOException e) {
-            LOGGER.error("Error while sending redirect to login service: ", e);
-            throw new RuntimeException("Failed to redirect to login", e);
         }
     }
 
@@ -544,7 +649,18 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
             OAuth2RestTemplate oAuth2RestTemplate = restTemplate();
             if (oAuth2RestTemplate != null) {
                 OAuth2ClientContext context = oAuth2RestTemplate.getOAuth2ClientContext();
-                if (context != null) result = context.getAccessToken();
+                if (context != null) {
+                    OAuth2AccessToken contextToken = context.getAccessToken();
+                    // Use the shared context only when it actually holds the token presented
+                    // by the client: the context is a singleton and may retain a previous
+                    // (stale) token, whose expiry and refresh token would then be evaluated
+                    // in place of the real one.
+                    if (contextToken != null
+                            && accessToken != null
+                            && accessToken.equals(contextToken.getValue())) {
+                        result = contextToken;
+                    }
+                }
             }
         }
         if (result == null) {
@@ -762,7 +878,11 @@ public abstract class OAuth2SessionServiceDelegate implements SessionServiceDele
         if (allCookies != null)
             for (Cookie toDelete : allCookies) {
                 if (deleteCookie(toDelete)) {
-                    toDelete.setMaxAge(-1);
+                    // Max-Age must be 0 (-1 means "session cookie" and would RE-INSTATE the
+                    // cookie with its current value: observed live as a logout response
+                    // carrying both the clearing Set-Cookie and a full refresh_token one).
+                    toDelete.setValue("");
+                    toDelete.setMaxAge(0);
                     toDelete.setPath("/");
                     toDelete.setComment("EXPIRING COOKIE at " + System.currentTimeMillis());
                     if (toDelete.getName().equalsIgnoreCase(REFRESH_TOKEN_PARAM)) {

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/openid_connect/RefreshTokenServiceTest.java
@@ -15,6 +15,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -27,6 +28,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.resource.UserRedirectRequiredException;
 import org.springframework.security.oauth2.common.*;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
@@ -211,7 +213,7 @@ class RefreshTokenServiceTest {
                 "Refresh token should not be in JSON response body");
         Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
         assertNotNull(refreshCookie, "Refresh token cookie should be set");
-        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertEquals("invalidRefreshToken", refreshCookie.getValue());
         assertTrue(refreshCookie.isHttpOnly(), "Cookie should be HttpOnly");
         assertNotNull(sessionToken.getWarning(), "Warning message should be set");
         assertTrue(
@@ -248,7 +250,7 @@ class RefreshTokenServiceTest {
                 "Refresh token should not be in JSON response body");
         Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
         assertNotNull(refreshCookie, "Refresh token cookie should be set");
-        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertEquals("providedRefreshToken", refreshCookie.getValue());
         assertNotNull(sessionToken.getWarning(), "Warning message should be set");
         assertTrue(
                 sessionToken.getWarning().contains("Using existing access token."),
@@ -291,7 +293,7 @@ class RefreshTokenServiceTest {
                 "Refresh token should not be in JSON response body");
         Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
         assertNotNull(refreshCookie, "Refresh token cookie should be set");
-        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertEquals("providedRefreshToken", refreshCookie.getValue());
         assertNotNull(sessionToken.getWarning(), "Warning message should be set");
         assertTrue(
                 sessionToken.getWarning().contains("Using existing access token."),
@@ -322,7 +324,7 @@ class RefreshTokenServiceTest {
                 "Refresh token should not be in JSON response body");
         Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
         assertNotNull(refreshCookie, "Refresh token cookie should be set");
-        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertEquals("providedRefreshToken", refreshCookie.getValue());
         // Verify that no exchange was attempted
         verify(restTemplate, never())
                 .exchange(
@@ -378,7 +380,7 @@ class RefreshTokenServiceTest {
                 "Refresh token should not be in JSON response body");
         Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
         assertNotNull(refreshCookie, "Refresh token cookie should be set");
-        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertEquals("providedRefreshToken", refreshCookie.getValue());
     }
 
     @Test
@@ -410,7 +412,7 @@ class RefreshTokenServiceTest {
                 "Refresh token should not be in JSON response body");
         Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
         assertNotNull(refreshCookie, "Refresh token cookie should be set");
-        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertEquals("providedRefreshToken", refreshCookie.getValue());
     }
 
     @Test
@@ -526,7 +528,7 @@ class RefreshTokenServiceTest {
                 "Refresh token should not be in JSON response body");
         Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
         assertNotNull(refreshCookie, "Refresh token cookie should be set");
-        assertEquals("existingRefreshToken", refreshCookie.getValue());
+        assertEquals("providedRefreshToken", refreshCookie.getValue());
         assertNotNull(sessionToken.getWarning(), "Warning message should be set");
         assertTrue(
                 sessionToken
@@ -856,6 +858,138 @@ class RefreshTokenServiceTest {
                 + ".";
     }
 
+    @Test
+    void testRefreshFailureRespondsWith401InsteadOfRedirect() throws Exception {
+        // The access token is already expired and the IdP rejects the refresh: the XHR
+        // client must receive a clean 401 (observed live: the old 302 to the login page
+        // turned into a 302 -> 404 chain through the front-end proxy and wiped the session).
+        String refreshToken = "expiredRefreshToken";
+        String accessToken = "providedAccessToken";
+
+        mockOAuth2AccessToken.setExpiration(new Date(System.currentTimeMillis() - 600 * 1000));
+        when(configuration.getProvider()).thenReturn("oidc");
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessToken.class)))
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        SessionToken sessionToken = serviceDelegate.refresh(refreshToken, accessToken);
+
+        assertNull(sessionToken, "A failed refresh of an expired session returns no token");
+        assertEquals(401, mockResponse.getStatus(), "The client must receive a 401");
+        assertNull(mockResponse.getRedirectedUrl(), "The refresh endpoint must never redirect");
+        String content = mockResponse.getContentAsString();
+        assertTrue(content.contains("session_expired"), "The error code is reported: " + content);
+        assertTrue(
+                content.contains("/openid/oidc/login"),
+                "The login URL is reported so the client can start a new flow: " + content);
+        Cookie refreshCookie = getRefreshTokenCookie(mockResponse);
+        assertNotNull(refreshCookie, "The refresh token cookie is cleared");
+        assertEquals(0, refreshCookie.getMaxAge());
+    }
+
+    @Test
+    void testShouldSkipRefreshFalseWhenRefreshTokenNearExpiry() {
+        when(configuration.isSkipRefreshIfTokenValid()).thenReturn(true);
+        long nowSeconds = System.currentTimeMillis() / 1000;
+
+        // Access token still fresh for one hour: the legacy logic alone would skip.
+        DefaultOAuth2AccessToken freshToken = new DefaultOAuth2AccessToken("opaque-at");
+        freshToken.setExpiration(new Date((nowSeconds + 3600) * 1000));
+
+        // Refresh token (JWT, as Keycloak's) expiring within the safety window: refresh
+        // tokens only slide when actually used, so the skip must be bypassed.
+        String nearExpiryRt = urlSafeJwt("{\"exp\":" + (nowSeconds + 60) + "}");
+        assertFalse(
+                serviceDelegate.callShouldSkipRefresh(freshToken, nearExpiryRt, configuration),
+                "A refresh token close to its own expiry must force a real IdP refresh");
+
+        // A long-lived refresh token keeps the legacy skip behavior.
+        String longLivedRt = urlSafeJwt("{\"exp\":" + (nowSeconds + 1800) + "}");
+        assertTrue(
+                serviceDelegate.callShouldSkipRefresh(freshToken, longLivedRt, configuration),
+                "A healthy refresh token keeps the skip in place");
+
+        // An opaque (non-JWT) refresh token carries no expiry info: legacy behavior.
+        assertTrue(
+                serviceDelegate.callShouldSkipRefresh(
+                        freshToken, "opaque-refresh-token", configuration),
+                "Opaque refresh tokens keep the legacy skip behavior");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testRefreshUsesCachedRefreshTokenNotStaleInjectedOne() {
+        // The cache entry for the presented access token carries the CURRENT refresh token:
+        // it must win over any other server-side leftover (the stale singleton client
+        // context used to be preferred, pinning a dead token until the session collapsed).
+        String accessToken = "providedAccessToken";
+
+        DefaultOAuth2AccessToken cachedToken = new DefaultOAuth2AccessToken(accessToken);
+        cachedToken.setRefreshToken(new DefaultOAuth2RefreshToken("cachedRt"));
+        cachedToken.setExpiration(new Date(System.currentTimeMillis() - 1000)); // force refresh
+        TokenDetails cachedDetails = new TokenDetails(cachedToken, null, "oidcOAuth2Config");
+        Authentication cachedAuth = mock(Authentication.class);
+        when(cachedAuth.getDetails()).thenReturn(cachedDetails);
+        when(authenticationCache.get(accessToken)).thenReturn(cachedAuth);
+        serviceDelegate.currentAccessToken = cachedToken;
+
+        DefaultOAuth2AccessToken newAccessToken = new DefaultOAuth2AccessToken("newAccessToken");
+        newAccessToken.setRefreshToken(new DefaultOAuth2RefreshToken("rotatedRt"));
+        newAccessToken.setExpiration(new Date(System.currentTimeMillis() + 7200 * 1000));
+        when(restTemplate.exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        any(HttpEntity.class),
+                        eq(OAuth2AccessToken.class)))
+                .thenReturn(new ResponseEntity<>(newAccessToken, HttpStatus.OK));
+
+        SessionToken sessionToken = serviceDelegate.refresh("staleClientProvidedRt", accessToken);
+
+        assertNotNull(sessionToken);
+        ArgumentCaptor<HttpEntity> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate)
+                .exchange(
+                        anyString(),
+                        eq(HttpMethod.POST),
+                        entityCaptor.capture(),
+                        eq(OAuth2AccessToken.class));
+        MultiValueMap<String, String> body =
+                (MultiValueMap<String, String>) entityCaptor.getValue().getBody();
+        assertEquals(
+                "cachedRt",
+                body.getFirst("refresh_token"),
+                "The refresh grant must use the cached (freshest) refresh token");
+    }
+
+    @Test
+    void testClearCookiesExpiresRefreshTokenCookie() {
+        // Max-Age 0 actually deletes the cookie: the previous -1 ("session cookie")
+        // RE-INSTATED the refresh token on the logout response (observed live as a logout
+        // carrying both the clearing Set-Cookie and a full refresh_token one).
+        mockRequest.setCookies(
+                new Cookie("refresh_token", "leftoverRt"), new Cookie("JSESSIONID", "xyz"));
+
+        serviceDelegate.callClearCookies(mockRequest, mockResponse);
+
+        Cookie cleared = getRefreshTokenCookie(mockResponse);
+        assertNotNull(cleared, "The refresh token cookie must be re-emitted for deletion");
+        assertEquals(0, cleared.getMaxAge(), "Max-Age must be 0 (deletion), not -1 (session)");
+        assertEquals("", cleared.getValue(), "The cookie value must be blanked");
+    }
+
+    private String urlSafeJwt(String payloadJson) {
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        return encoder.encodeToString(
+                        "{\"alg\":\"HS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8))
+                + "."
+                + encoder.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8))
+                + "."
+                + encoder.encodeToString("sig".getBytes(StandardCharsets.UTF_8));
+    }
+
     private Cookie getRefreshTokenCookie(MockHttpServletResponse response) {
         Cookie[] cookies = response.getCookies();
         Cookie result = null;
@@ -883,6 +1017,16 @@ class RefreshTokenServiceTest {
 
         public void setRefreshRestTemplate(RestTemplate refreshRestTemplate) {
             this.refreshRestTemplate = refreshRestTemplate;
+        }
+
+        // Bridges for protected superclass members living in a different package.
+        boolean callShouldSkipRefresh(
+                OAuth2AccessToken token, String refreshToken, OAuth2Configuration config) {
+            return shouldSkipRefresh(token, refreshToken, config);
+        }
+
+        void callClearCookies(HttpServletRequest request, HttpServletResponse response) {
+            clearCookies(request, response);
         }
 
         public void setConfiguration(OAuth2Configuration configuration) {


### PR DESCRIPTION
These changes are related to this MapStore task
- https://github.com/geosolutions-it/support/issues/6035

## Problem

Live testing of an OIDC deployment (MapStore polling `/session/refreshToken` every 30 seconds against Keycloak) showed the session dying "after a while" even though every poll returned HTTP 200. The network capture of the fatal request told the story:

- the refresh XHR was answered with a **302** to `../../openid/{provider}/login`, which the client cannot follow (observed live as a 302 → 404 chain through the front-end proxy) — MapStore's `.catch` then wiped the session;
- the logout response carried **two `Set-Cookie: refresh_token` headers**: the clearing one (`Max-Age=0`) followed by a full re-instatement of the token (`setMaxAge(-1)` means *session cookie*, not deletion).

Upstream of that, two structural issues made the refresh grant itself fail in the first place, verified against a live Keycloak 26:

1. **Refresh-token starvation.** `skipRefreshIfTokenValid` (default `true`) answers most polls locally without contacting the IdP. But IdP refresh tokens only *slide* when a refresh grant is actually performed (Keycloak: `refresh_expires_in=1800`, fixed per-token expiry). With access-token lifespans above ~37 minutes (0.8 fraction × lifespan > 30-minute idle), the refresh token is already dead at the first real refresh → `invalid_grant` → session collapse at access-token expiry, with 200s every 30 seconds until then.
2. **Stale refresh-token pinning.** The refresh token was resolved preferring the token object found in the shared singleton `OAuth2ClientContext` — which retains the *login-time* pair. On any cache miss the chain re-used the original refresh token (its expiry is fixed at login+30 min) instead of the fresher one in the HttpOnly cookie, killing the session ~30 minutes after login regardless of polling (multi-tab usage is a typical trigger).

## Fixes (`OAuth2SessionServiceDelegate`)

- **`handleRefreshFailure` never redirects**: the endpoint is XHR-only, so it now responds **401 with a JSON body** (`{"error":"session_expired","message":...,"loginUrl":...}`), letting the client run an orderly logout/re-login.
- **Refresh-token resolution uses the freshest sources only**: cache entry of the presented access token → client-supplied value → request parameter → HttpOnly cookie. The singleton `OAuth2ClientContext` is no longer consulted, and `retrieveAccessToken` trusts it only when it holds exactly the token presented by the client.
- **`shouldSkipRefresh` is refresh-token-aware**: when the refresh token in hand is a JWT within two minutes of its own expiry, a real IdP refresh is forced regardless of access-token freshness — the session keeps sliding. Opaque refresh tokens keep the previous behavior.
- **`clearCookies` actually deletes**: blank value + `Max-Age=0` (was `-1`).
- The IdP's 4xx response body (`invalid_grant` vs `invalid_client`) is now logged at WARN, making the next refresh-failure triage a one-log-line affair.

## Testing

- `RefreshTokenServiceTest`: 4 new tests (401+JSON+cleared cookie on failure; refresh-token-near-expiry bypassing the skip; cached-token priority over stale server-side leftovers; cookie deletion semantics) — 21/21 green. The handful of existing assertions that pinned the old stale-source ordering are updated to the new (intended) expectation.
- Full `rest/impl` suite: **267 tests, 0 failures**.
- Keycloak 26 mechanics validated live (dual client-auth accepted; `refresh_expires_in` sliding semantics; rotation behavior).

These behavioral fixes should also be absorbed into the Spring Security 7 forward-port (#543), which shares the skip logic and a milder variant of the failure handling.
