### PR TITLE
[2.6.x] Add defaultGroups: groups always assigned on IdP login

### DIFF
--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
@@ -21,6 +21,8 @@ public abstract class IdPConfiguration implements BeanNameAware {
 
     protected Role authenticatedDefaultRole;
 
+    protected String authenticatedDefaultGroup;
+
     /**
      * @return true if the filter to which this configuration object refers is enabled. False
      *     otherwise.
@@ -112,5 +114,20 @@ public abstract class IdPConfiguration implements BeanNameAware {
     public void setAuthenticatedDefaultRole(String authenticatedDefaultRole) {
         if (StringUtils.isNotBlank(authenticatedDefaultRole))
             this.authenticatedDefaultRole = Role.valueOf(authenticatedDefaultRole);
+    }
+
+    /**
+     * Optional group assigned when no group could be derived from the IdP claims (the groups claim
+     * is missing, or every value was dropped by groupMappings/dropUnmapped). Created on the fly
+     * when it does not exist. Blank or unset disables the fallback.
+     *
+     * @return the fallback group name, or null when not configured.
+     */
+    public String getAuthenticatedDefaultGroup() {
+        return authenticatedDefaultGroup;
+    }
+
+    public void setAuthenticatedDefaultGroup(String authenticatedDefaultGroup) {
+        this.authenticatedDefaultGroup = authenticatedDefaultGroup;
     }
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/IdPConfiguration.java
@@ -1,6 +1,9 @@
 package it.geosolutions.geostore.services.rest.security;
 
 import it.geosolutions.geostore.core.model.enums.Role;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.BeanNameAware;
 
@@ -21,7 +24,7 @@ public abstract class IdPConfiguration implements BeanNameAware {
 
     protected Role authenticatedDefaultRole;
 
-    protected String authenticatedDefaultGroup;
+    protected List<String> defaultGroups = Collections.emptyList();
 
     /**
      * @return true if the filter to which this configuration object refers is enabled. False
@@ -117,17 +120,29 @@ public abstract class IdPConfiguration implements BeanNameAware {
     }
 
     /**
-     * Optional group assigned when no group could be derived from the IdP claims (the groups claim
-     * is missing, or every value was dropped by groupMappings/dropUnmapped). Created on the fly
-     * when it does not exist. Blank or unset disables the fallback.
+     * Optional groups always assigned to the authenticated user, in addition to the ones derived
+     * from the IdP claims. They are not subject to groupMappings/dropUnmapped and are created on
+     * the fly when they do not exist.
      *
-     * @return the fallback group name, or null when not configured.
+     * @return the configured default group names; never null, empty when not configured.
      */
-    public String getAuthenticatedDefaultGroup() {
-        return authenticatedDefaultGroup;
+    public List<String> getDefaultGroups() {
+        return defaultGroups;
     }
 
-    public void setAuthenticatedDefaultGroup(String authenticatedDefaultGroup) {
-        this.authenticatedDefaultGroup = authenticatedDefaultGroup;
+    /** @param defaultGroups comma-separated list of group names; blank entries are discarded. */
+    public void setDefaultGroups(String defaultGroups) {
+        if (StringUtils.isBlank(defaultGroups)) {
+            this.defaultGroups = Collections.emptyList();
+            return;
+        }
+        List<String> parsed = new ArrayList<>();
+        for (String name : defaultGroups.split(",")) {
+            String trimmed = name.trim();
+            if (!trimmed.isEmpty()) {
+                parsed.add(trimmed);
+            }
+        }
+        this.defaultGroups = parsed;
     }
 }

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -1042,16 +1042,21 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             oidcGroups = mapped;
         }
 
-        // Optional fallback: when nothing could be derived from the claims (claim missing, or
-        // every value dropped by the mappings), assign the configured default group. It flows
-        // through the normal reconciliation, so it is created on the fly, tagged with this
-        // provider as sourceService, and removed again on a later login carrying real groups.
-        String defaultGroup = configuration.getAuthenticatedDefaultGroup();
-        if (oidcGroups.isEmpty() && StringUtils.isNotBlank(defaultGroup)) {
-            oidcGroups = Collections.singletonList(defaultGroup.trim());
+        // Always-assigned default groups: appended to the claim-derived ones, not subject to
+        // groupMappings/dropUnmapped. They flow through the normal reconciliation, so they are
+        // created on the fly when missing, tagged with this provider as sourceService, and
+        // assigned through the user-group service like any claim-derived group.
+        List<String> defaultGroups = configuration.getDefaultGroups();
+        if (defaultGroups != null && !defaultGroups.isEmpty()) {
+            List<String> withDefaults = new java.util.ArrayList<>(oidcGroups);
+            for (String defaultGroup : defaultGroups) {
+                if (!withDefaults.contains(defaultGroup)) {
+                    withDefaults.add(defaultGroup);
+                }
+            }
+            oidcGroups = withDefaults;
             LOGGER.info(
-                    "No groups resolved from claims; assigning authenticatedDefaultGroup '{}'",
-                    defaultGroup.trim());
+                    "Adding configured defaultGroups {} to the groups to assign.", defaultGroups);
         }
 
         debugSensitive(

--- a/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
+++ b/src/modules/rest/impl/src/main/java/it/geosolutions/geostore/services/rest/security/oauth2/OAuth2GeoStoreAuthenticationFilter.java
@@ -1042,6 +1042,18 @@ public abstract class OAuth2GeoStoreAuthenticationFilter
             oidcGroups = mapped;
         }
 
+        // Optional fallback: when nothing could be derived from the claims (claim missing, or
+        // every value dropped by the mappings), assign the configured default group. It flows
+        // through the normal reconciliation, so it is created on the fly, tagged with this
+        // provider as sourceService, and removed again on a later login carrying real groups.
+        String defaultGroup = configuration.getAuthenticatedDefaultGroup();
+        if (oidcGroups.isEmpty() && StringUtils.isNotBlank(defaultGroup)) {
+            oidcGroups = Collections.singletonList(defaultGroup.trim());
+            LOGGER.info(
+                    "No groups resolved from claims; assigning authenticatedDefaultGroup '{}'",
+                    defaultGroup.trim());
+        }
+
         debugSensitive(
                 "Final groups to reconcile: {} (user.role={}, user.id={})",
                 oidcGroups,

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
@@ -339,6 +339,20 @@ public class OpenIdIntegrationTest {
         assertTrue(
                 names.contains("base-users"),
                 "All configured defaultGroups are assigned: " + names);
+
+        // Creation-if-missing applies to EVERY entry of the list, with the provider tag.
+        DummyUserGroupService svc = (DummyUserGroupService) filter.getUserGroupService();
+        for (String name : Arrays.asList("infragri", "base-users")) {
+            UserGroup created = svc.get(name);
+            assertNotNull(created, "Each default group must be created when missing: " + name);
+            String src =
+                    created.getAttributes().stream()
+                            .filter(a -> "sourceService".equals(a.getName()))
+                            .findFirst()
+                            .orElseThrow()
+                            .getValue();
+            assertEquals(configuration.getProvider(), src, "Provider tag on created group " + name);
+        }
     }
 
     @Test

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
@@ -31,6 +31,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -283,10 +284,10 @@ public class OpenIdIntegrationTest {
 
     @Test
     public void testDefaultGroupAssignedWhenNoGroupsResolved() throws Exception {
-        // The token of CODE carries no groups claim at all: the configured fallback group is
-        // assigned, created on the fly and tagged with the provider as sourceService.
+        // The token of CODE carries no groups claim at all: the configured default group is
+        // still assigned, created on the fly and tagged with the provider as sourceService.
         configuration.setGroupsClaim("groups");
-        configuration.setAuthenticatedDefaultGroup("infragri");
+        configuration.setDefaultGroups("infragri");
         MockHttpServletRequest request = createRequest("oidc/login");
         request.setParameter("authorization_code", CODE);
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -315,10 +316,36 @@ public class OpenIdIntegrationTest {
     }
 
     @Test
-    public void testDefaultGroupNotAssignedWhenGroupsResolved() throws Exception {
-        // Groups resolved from the claims win: the fallback group must not be added.
+    public void testDefaultGroupsMultipleAssigned() throws Exception {
+        // The property is a comma-separated list: every entry is assigned.
         configuration.setGroupsClaim("groups");
-        configuration.setAuthenticatedDefaultGroup("infragri");
+        configuration.setDefaultGroups("infragri, base-users");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("authorization_code", CODE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.restTemplate
+                .getOAuth2ClientContext()
+                .getAccessTokenRequest()
+                .setAuthorizationCode(CODE);
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(
+                names.contains("infragri"), "All configured defaultGroups are assigned: " + names);
+        assertTrue(
+                names.contains("base-users"),
+                "All configured defaultGroups are assigned: " + names);
+    }
+
+    @Test
+    public void testDefaultGroupsAssignedAlongsideMappedGroups() throws Exception {
+        // defaultGroups are ALWAYS added, alongside the claim-derived groups.
+        configuration.setGroupsClaim("groups");
+        configuration.setDefaultGroups("infragri");
         MockHttpServletRequest request = createRequest("oidc/login");
         request.setParameter("authorization_code", CODE_GROUPS_RECON);
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -335,19 +362,19 @@ public class OpenIdIntegrationTest {
                 user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
         assertTrue(names.contains("A"));
         assertTrue(names.contains("B"));
-        assertFalse(
+        assertTrue(
                 names.contains("infragri"),
-                "Fallback group must not be assigned when claims resolve groups");
+                "defaultGroups must be assigned in addition to the claim-derived groups");
     }
 
     @Test
     public void testDefaultGroupAssignedWhenAllGroupsDropped() throws Exception {
         // Every claim value is dropped by groupMappings+dropUnmapped (the typical Keycloak
-        // permission-roles setup): the fallback group keeps the user from ending up groupless.
+        // permission-roles setup): the default groups keep the user from ending up groupless.
         configuration.setGroupsClaim("groups");
         configuration.setGroupMappings("not-a-real-group:whatever");
         configuration.setDropUnmapped(true);
-        configuration.setAuthenticatedDefaultGroup("infragri");
+        configuration.setDefaultGroups("infragri");
         MockHttpServletRequest request = createRequest("oidc/login");
         request.setParameter("authorization_code", CODE_GROUPS_RECON);
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -365,6 +392,46 @@ public class OpenIdIntegrationTest {
         assertTrue(names.contains("infragri"), "Fallback group should be assigned, got " + names);
         assertFalse(names.contains("A"), "Dropped claim groups must not be assigned");
         assertFalse(names.contains("B"), "Dropped claim groups must not be assigned");
+    }
+
+    @Test
+    public void testDefaultGroupAssignedWhenGroupCreationFails() throws Exception {
+        // Claim groups resolve but their creation is rejected (e.g. reserved or invalid
+        // names): the default groups are assigned independently of the claim-derived ones.
+        configuration.setGroupsClaim("groups");
+        configuration.setDefaultGroups("infragri");
+        DummyUserGroupService rejectingSvc =
+                new DummyUserGroupService() {
+                    @Override
+                    public long insert(UserGroup g) throws BadRequestServiceEx {
+                        if (!"infragri".equals(g.getGroupName())) {
+                            throw new BadRequestServiceEx(
+                                    "group name not allowed: " + g.getGroupName());
+                        }
+                        return super.insert(g);
+                    }
+                };
+        filter.setUserGroupService(rejectingSvc);
+
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("authorization_code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.restTemplate
+                .getOAuth2ClientContext()
+                .getAccessTokenRequest()
+                .setAuthorizationCode(CODE_GROUPS_RECON);
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(names.contains("infragri"), "Fallback group should be assigned, got " + names);
+        assertNotNull(
+                rejectingSvc.get("infragri"), "Fallback group should be created when missing");
+        assertNull(rejectingSvc.get("A"), "Rejected claim group must not be created");
+        assertNull(rejectingSvc.get("B"), "Rejected claim group must not be created");
     }
 
     @Test
@@ -759,7 +826,7 @@ public class OpenIdIntegrationTest {
         private long nextId = 1;
 
         @Override
-        public long insert(UserGroup g) {
+        public long insert(UserGroup g) throws BadRequestServiceEx {
             if (g.getId() == null) g.setId(nextId++);
             if (g.getAttributes() == null) g.setAttributes(new ArrayList<>());
             byId.put(g.getId(), g);

--- a/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
+++ b/src/modules/rest/impl/src/test/java/it/geosolutions/geostore/services/rest/security/oauth2/OpenIdIntegrationTest.java
@@ -282,6 +282,92 @@ public class OpenIdIntegrationTest {
     }
 
     @Test
+    public void testDefaultGroupAssignedWhenNoGroupsResolved() throws Exception {
+        // The token of CODE carries no groups claim at all: the configured fallback group is
+        // assigned, created on the fly and tagged with the provider as sourceService.
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultGroup("infragri");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("authorization_code", CODE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.restTemplate
+                .getOAuth2ClientContext()
+                .getAccessTokenRequest()
+                .setAuthorizationCode(CODE);
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(names.contains("infragri"), "Fallback group should be assigned, got " + names);
+
+        UserGroup created = ((DummyUserGroupService) filter.getUserGroupService()).get("infragri");
+        assertNotNull(created, "Fallback group should be created when missing");
+        String src =
+                created.getAttributes().stream()
+                        .filter(a -> "sourceService".equals(a.getName()))
+                        .findFirst()
+                        .orElseThrow()
+                        .getValue();
+        assertEquals(configuration.getProvider(), src);
+    }
+
+    @Test
+    public void testDefaultGroupNotAssignedWhenGroupsResolved() throws Exception {
+        // Groups resolved from the claims win: the fallback group must not be added.
+        configuration.setGroupsClaim("groups");
+        configuration.setAuthenticatedDefaultGroup("infragri");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("authorization_code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.restTemplate
+                .getOAuth2ClientContext()
+                .getAccessTokenRequest()
+                .setAuthorizationCode(CODE_GROUPS_RECON);
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(names.contains("A"));
+        assertTrue(names.contains("B"));
+        assertFalse(
+                names.contains("infragri"),
+                "Fallback group must not be assigned when claims resolve groups");
+    }
+
+    @Test
+    public void testDefaultGroupAssignedWhenAllGroupsDropped() throws Exception {
+        // Every claim value is dropped by groupMappings+dropUnmapped (the typical Keycloak
+        // permission-roles setup): the fallback group keeps the user from ending up groupless.
+        configuration.setGroupsClaim("groups");
+        configuration.setGroupMappings("not-a-real-group:whatever");
+        configuration.setDropUnmapped(true);
+        configuration.setAuthenticatedDefaultGroup("infragri");
+        MockHttpServletRequest request = createRequest("oidc/login");
+        request.setParameter("authorization_code", CODE_GROUPS_RECON);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+        filter.restTemplate
+                .getOAuth2ClientContext()
+                .getAccessTokenRequest()
+                .setAuthorizationCode(CODE_GROUPS_RECON);
+        filter.doFilter(request, response, chain);
+        assertEquals(200, response.getStatus());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        User user = (User) authentication.getPrincipal();
+        Set<String> names =
+                user.getGroups().stream().map(UserGroup::getGroupName).collect(Collectors.toSet());
+        assertTrue(names.contains("infragri"), "Fallback group should be assigned, got " + names);
+        assertFalse(names.contains("A"), "Dropped claim groups must not be assigned");
+        assertFalse(names.contains("B"), "Dropped claim groups must not be assigned");
+    }
+
+    @Test
     public void testRoleFromToken_adminPromotion() throws Exception {
         configuration.setRolesClaim("roles");
         MockHttpServletRequest request = createRequest("oidc/login");

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -52,9 +52,10 @@
 # In this .properties file the backslash must be doubled (properties escaping):
 # oidcOAuth2Config.groupMappings=landscape\\:read:landscape_read,manage-users:admins
 # oidcOAuth2Config.dropUnmapped=false
-# Optional fallback group when NO group could be derived from the claims (claim missing,
-# or every value dropped by groupMappings/dropUnmapped). Created on the fly when missing.
-# oidcOAuth2Config.authenticatedDefaultGroup=
+# Optional comma-separated groups ALWAYS assigned to the authenticated user, in addition
+# to the claim-derived ones (not subject to groupMappings/dropUnmapped). Created on the
+# fly when missing.
+# oidcOAuth2Config.defaultGroups=
 # oidcOAuth2Config.usePKCE=false
 #
 # Access type for authorization (set to "offline" for refresh token support, e.g. Google)

--- a/src/web/app/src/main/resources/geostore-ovr.properties
+++ b/src/web/app/src/main/resources/geostore-ovr.properties
@@ -52,6 +52,9 @@
 # In this .properties file the backslash must be doubled (properties escaping):
 # oidcOAuth2Config.groupMappings=landscape\\:read:landscape_read,manage-users:admins
 # oidcOAuth2Config.dropUnmapped=false
+# Optional fallback group when NO group could be derived from the claims (claim missing,
+# or every value dropped by groupMappings/dropUnmapped). Created on the fly when missing.
+# oidcOAuth2Config.authenticatedDefaultGroup=
 # oidcOAuth2Config.usePKCE=false
 #
 # Access type for authorization (set to "offline" for refresh token support, e.g. Google)


### PR DESCRIPTION
These changes are related to this MapStore task
- https://github.com/geosolutions-it/support/issues/6035

## What

New **optional** IdP configuration property (comma-separated list, so adding a second group later needs no code change):

```properties
oidcOAuth2Config.defaultGroups=<name>[,<name>...]
```

When set, every listed group is **always assigned** to the authenticated user, **in addition to** the groups derived from the IdP claims. Unset or blank keeps the previous behavior exactly.

## How

The configured names are appended to the post-mapping claim-derived list (they are **not** subject to `groupMappings`/`dropUnmapped`; duplicates collapse) and flow through the existing remote-group reconciliation, so they inherit its semantics for free:

- **created on the fly** when they do not exist;
- tagged with the provider as `sourceService`;
- **assigned through `UserGroupService.assignUserGroup`** (and persisted with the user), like any claim-derived group.

Because the defaults always travel with the reconcile set, the user keeps them even when every claim group fails to materialize (e.g. rejected names) or when the groups claim is missing entirely.

## Why

Typical Keycloak setups map permission-style realm roles (`landscape:read`, `manage-users`, …) through `groupMappings` with `dropUnmapped=true`. Users matching none of the mappings previously ended up with **no group at all**; `defaultGroups` guarantees a baseline group (or groups) for every authenticated user without loosening the mappings.

## Testing

`OpenIdIntegrationTest` (+5): defaults assigned **alongside** mapped groups; assigned when the claim is missing (auto-created with the `sourceService` tag); multiple comma-separated entries; defaults survive `dropUnmapped`; defaults survive claim-group creation failures. Full `rest/impl` suite green. Property documented in `geostore-ovr.properties`.

The same feature lands on the Spring Security 7 line via #543.
