### PR TITLE
config: add ssh-key support with wagon-ssh-external plugin

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,12 @@ jobs:
     concurrency: ci-${{ github.ref }}
     steps:
       - uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.GS_MAVEN_GEOSTORE_KEY }}
+      - name: Trust Maven Host
+        run: ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
@@ -48,14 +54,9 @@ jobs:
           distribution: 'adopt'
           server-id: geosolutions
           server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+
       - name: Publish package
         run: |
-          # Setup SSH keys for SFTP
-          mkdir -p ~/.ssh
-          # add geo-solutions.it to known hosts to avoid prompts
-          ssh-keyscan -H maven.geo-solutions.it >> ~/.ssh/known_hosts
           mvn clean install deploy -Ppostgres # published version includes only the postgres drivers. Auditing module is not added to the published version.
         env:
-          MAVEN_USERNAME: ${{ secrets.GS_MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.GS_MAVEN_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.GS_MAVEN_GEOSTORE_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
         <fmt-maven-plugin.version>2.9.1</fmt-maven-plugin.version>
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
-        <wagon-ssh.version>3.5.3</wagon-ssh.version>
+        <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <coveralls-maven-plugin.version>4.1.0</coveralls-maven-plugin.version>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
@@ -185,13 +185,13 @@
         <repository>
             <uniqueVersion>false</uniqueVersion>
             <id>geosolutions</id>
-            <url>sftp://maven.geo-solutions.it/</url>
+            <url>scpexe://maven.geo-solutions.it/</url>
         </repository>
         <!-- use the following if you ARE using a snapshot version. -->
         <snapshotRepository>
             <uniqueVersion>false</uniqueVersion>
             <id>geosolutions</id>
-            <url>sftp://maven.geo-solutions.it/</url>
+            <url>scpexe://maven.geo-solutions.it/</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -353,8 +353,8 @@
         <extensions>
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-ssh</artifactId>
-                <version>${wagon-ssh.version}</version>
+                <artifactId>wagon-ssh-external</artifactId>
+                <version>${wagon-ssh-external.version}</version>
             </extension>
         </extensions>
 

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -43,13 +43,13 @@
         <repository>
             <uniqueVersion>false</uniqueVersion>
             <id>geosolutions</id>
-            <url>sftp://maven.geo-solutions.it/</url>
+            <url>scpexe://maven.geo-solutions.it/</url>
         </repository>
         <!-- use the following if you ARE using a snapshot version. -->
         <snapshotRepository>
             <uniqueVersion>false</uniqueVersion>
             <id>geosolutions</id>
-            <url>sftp://maven.geo-solutions.it/</url>
+            <url>scpexe://maven.geo-solutions.it/</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
## Description
Adds support for ssh-key based auth to publish artifacts to maven.geo-solutions.it.

Following secrets are already created and assigned to the repository.

- [x] GS_MAVEN_GEOSTORE_USERNAME
- [x] GS_MAVEN_GEOSTORE_KEY

## Rollback
Rollback would include reverting the PR, that should enable existing `user/password based` workflow. As a precaution existing secrets are left intact and to be deleted only when ssh-key based workflow is working.

Old secrets (Intact)
```
GS_MAVEN_USERNAME
GS_MAVEN_PASSWORD
```