### PR TITLE
Set JDK 17 as minimum supported version.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,11 +26,11 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-m2-
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '21'
+        java-version: '17'
     - name: Build with Maven
       run: mvn -B clean install -Ph2_disk,auditing # running the test build with the h2 disk profile and auditing too.
   ## Only on push event, publish on geosolutions maven repo
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: 'adopt'
           server-id: geosolutions
           server-username: MAVEN_USERNAME

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '17'
 
       - name: Cache Maven local repository
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
         script: |
             core.setFailed('This workflow can not run on master branch')
     - uses: actions/checkout@v2
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'adopt'
         cache: maven
 
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Maven Repository
       uses: actions/setup-java@v3
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'adopt'
         server-id: geosolutions
         server-username: MAVEN_USERNAME

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <commons-io.version>2.14.0</commons-io.version>
         <json-lib.version>2.4.2-geoserver</json-lib.version>
         <hibernate-jpa-2.1-api.version>1.0.2.Final</hibernate-jpa-2.1-api.version>
-        <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
+        <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <junit.version>4.13.2</junit.version>
 
         <!-- GeoStore-specific persistence bits -->


### PR DESCRIPTION
These changes set Java 17 as the explicit baseline for the project, in line with the GeoServer ecosystem requirements.                                                                                    
                                                                                                                                                                                              
  - Downgrade jakarta.servlet-api from 6.1.0 to 6.0.0 (6.1 requires Java 21+)                                                                                                                 
  - Update all CI workflows (CI, release, integration-tests) to build on JDK 17                                                                                                               
                                                                                                                                                                                             
The compiler source/target was already set to 17; this change makes the runtime dependency and the CI environment consistent with it.   