### PR TITLE
Fixed pagination and ordering in SQL searches.

### DIFF
--- a/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/BaseDAO.java
+++ b/src/core/persistence/src/main/java/it/geosolutions/geostore/core/dao/impl/BaseDAO.java
@@ -100,22 +100,31 @@ public class BaseDAO<T, ID extends Serializable> extends GenericDAOImpl<T, ID> {
     private Search createNormalizedSearchForSql(ISearch search) {
         Search sqlSearch = new Search(search.getSearchClass());
 
-        List<Filter> sqlFilters =
-                search.getFilters().stream()
-                        .map(
-                                f -> {
-                                    if (hasLikeToStringOperator(f)) {
-                                        return new Filter(
-                                                f.getProperty(),
-                                                f.getValue().toString().replaceAll("[*]", "%"),
-                                                f.getOperator());
-                                    }
-                                    return f;
-                                })
-                        .toList();
+        sqlSearch.setFilters(calculateFilters(search));
+        sqlSearch.setSorts(search.getSorts());
 
-        sqlSearch.setFilters(sqlFilters);
+        int maxResults = search.getMaxResults();
+        if (maxResults > 0) {
+            sqlSearch.setPage(search.getPage());
+            sqlSearch.setMaxResults(maxResults);
+        }
+
         return sqlSearch;
+    }
+
+    private List<Filter> calculateFilters(ISearch search) {
+        return search.getFilters().stream()
+                .map(
+                        f -> {
+                            if (hasLikeToStringOperator(f)) {
+                                return new Filter(
+                                        f.getProperty(),
+                                        f.getValue().toString().replaceAll("[*]", "%"),
+                                        f.getOperator());
+                            }
+                            return f;
+                        })
+                .toList();
     }
 
     private boolean hasLikeToStringOperator(Filter f) {

--- a/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
+++ b/src/modules/rest/extjs/src/test/java/it/geosolutions/geostore/services/rest/impl/RESTExtJsServiceImplTest.java
@@ -2707,6 +2707,50 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
     }
 
     @Test
+    public void testGetUsersListWithNameLikeAndPagination() throws Exception {
+        final String prefix = "paginated_user_";
+
+        long adminId = restCreateUser("admin", Role.ADMIN, null, "admin");
+        SecurityContext adminSecurityContext = new SimpleSecurityContext(adminId);
+
+        restCreateUser(prefix + "E", Role.USER, null, "p0");
+        restCreateUser(prefix + "C", Role.USER, null, "p0");
+        restCreateUser(prefix + "A", Role.USER, null, "p0");
+        restCreateUser(prefix + "D", Role.USER, null, "p0");
+        restCreateUser(prefix + "B", Role.USER, null, "p0");
+
+        {
+            ExtUserList response =
+                    restExtJsService.getUsersList(
+                            adminSecurityContext, "*" + prefix + "*", 0, 2, true);
+            assertEquals(5, response.getCount());
+            List<User> users = response.getList();
+            assertEquals(2, users.size());
+            assertEquals(prefix + "A", users.get(0).getName());
+            assertEquals(prefix + "B", users.get(1).getName());
+        }
+        {
+            ExtUserList response =
+                    restExtJsService.getUsersList(
+                            adminSecurityContext, "*" + prefix + "*", 2, 2, true);
+            assertEquals(5, response.getCount());
+            List<User> users = response.getList();
+            assertEquals(2, users.size());
+            assertEquals(prefix + "C", users.get(0).getName());
+            assertEquals(prefix + "D", users.get(1).getName());
+        }
+        {
+            ExtUserList response =
+                    restExtJsService.getUsersList(
+                            adminSecurityContext, "*" + prefix + "*", 4, 2, true);
+            assertEquals(5, response.getCount());
+            List<User> users = response.getList();
+            assertEquals(1, users.size());
+            assertEquals(prefix + "E", users.get(0).getName());
+        }
+    }
+
+    @Test
     public void testGetGroupsListWithNameLike() throws Exception {
         final String groupAName = "groupA";
         final String groupBName = "gruppoB";
@@ -2737,6 +2781,50 @@ public class RESTExtJsServiceImplTest extends ServiceTestBase {
             assertEquals(1, userGroups.size());
             UserGroup userGroup = userGroups.get(0);
             assertEquals(groupAName, userGroup.getGroupName());
+        }
+    }
+
+    @Test
+    public void testGetGroupsListWithNameLikeAndPagination() throws Exception {
+        final String prefix = "paggroup";
+
+        createGroup(prefix + "E");
+        createGroup(prefix + "C");
+        createGroup(prefix + "A");
+        createGroup(prefix + "D");
+        createGroup(prefix + "B");
+
+        long adminId = restCreateUser("admin", Role.ADMIN, null, "admin");
+        SecurityContext adminSecurityContext = new SimpleSecurityContext(adminId);
+
+        {
+            ExtGroupList response =
+                    restExtJsService.getGroupsList(
+                            adminSecurityContext, "*" + prefix + "*", 0, 2, true);
+            assertEquals(5, response.getCount());
+            List<UserGroup> groups = response.getList();
+            assertEquals(2, groups.size());
+            assertEquals(prefix + "A", groups.get(0).getGroupName());
+            assertEquals(prefix + "B", groups.get(1).getGroupName());
+        }
+        {
+            ExtGroupList response =
+                    restExtJsService.getGroupsList(
+                            adminSecurityContext, "*" + prefix + "*", 2, 2, true);
+            assertEquals(5, response.getCount());
+            List<UserGroup> groups = response.getList();
+            assertEquals(2, groups.size());
+            assertEquals(prefix + "C", groups.get(0).getGroupName());
+            assertEquals(prefix + "D", groups.get(1).getGroupName());
+        }
+        {
+            ExtGroupList response =
+                    restExtJsService.getGroupsList(
+                            adminSecurityContext, "*" + prefix + "*", 4, 2, true);
+            assertEquals(5, response.getCount());
+            List<UserGroup> groups = response.getList();
+            assertEquals(1, groups.size());
+            assertEquals(prefix + "E", groups.get(0).getGroupName());
         }
     }
 


### PR DESCRIPTION
These changes fixes the pagination regression for extJS user and userGroup retrieval endpoints.

Fixes #530 .